### PR TITLE
Stabilize embeds and load dynamic macro calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
           <li><a href="#bonds">Bonds</a></li>
           <li><a href="#currencies">Currencies</a></li>
           <li><a href="#commodities">Commodities</a></li>
+          <li><a href="#timeline">Macro Timeline</a></li>
         </ul>
       </nav>
     </header>
@@ -44,9 +45,9 @@
     <main id="main-content">
       <section class="intro">
         <p>
-          A lightweight personal market observatory featuring live embeds from
-          TradingView and FRED. Tap any card to launch the full interactive
-          chart in a new tab.
+          A lightweight personal market observatory featuring interactive TradingView charts and FRED data embeds.
+          Zoom, pan, and study each chart without leaving the dashboard, then dive into the macro timeline for upcoming
+          catalysts.
         </p>
       </section>
 
@@ -56,110 +57,89 @@
           <p>Major equity benchmarks across the U.S. and Asia.</p>
         </div>
         <div class="cards-grid">
-          <a
-            class="card"
-            href="https://www.tradingview.com/symbols/SP-SPX/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <article class="card">
             <div class="card-header">
-              <h3>S&amp;P 500</h3>
-              <p>Large-cap U.S. equities snapshot.</p>
+              <h3>S&amp;P 500 (SPY)</h3>
+              <p>ETF proxy tracking the benchmark U.S. equities index.</p>
             </div>
             <div class="card-body">
-              <div class="tradingview-widget-container">
-                <div class="tradingview-widget-container__widget"></div>
-                <script
-                  type="text/javascript"
-                  src="https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js"
-                  async
-                >
-{
-  "symbol": "SP:SPX",
-  "width": "100%",
-  "height": "240",
-  "locale": "en",
-  "dateRange": "12M",
-  "colorTheme": "light",
-  "trendLineColor": "#009688",
-  "underLineColor": "rgba(0, 150, 136, 0.25)",
-  "isTransparent": false,
-  "autosize": true
-}
-                </script>
+              <div class="tradingview-widget-container card-chart">
+                <div
+                  id="tv-spx"
+                  class="chart-container"
+                  data-tv-symbol="AMEX:SPY"
+                  data-tv-range="12M"
+                  aria-label="Interactive price chart for the SPDR S&amp;P 500 ETF"
+                ></div>
               </div>
             </div>
-          </a>
+            <div class="card-footer">
+              <a
+                class="card-link"
+                href="https://www.tradingview.com/symbols/AMEX-SPY/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open on TradingView
+              </a>
+            </div>
+          </article>
 
-          <a
-            class="card"
-            href="https://www.tradingview.com/symbols/NASDAQ-IXIC/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <article class="card">
             <div class="card-header">
               <h3>NASDAQ</h3>
               <p>Growth and tech-heavy U.S. composite.</p>
             </div>
             <div class="card-body">
-              <div class="tradingview-widget-container">
-                <div class="tradingview-widget-container__widget"></div>
-                <script
-                  type="text/javascript"
-                  src="https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js"
-                  async
-                >
-{
-  "symbol": "NASDAQ:IXIC",
-  "width": "100%",
-  "height": "240",
-  "locale": "en",
-  "dateRange": "12M",
-  "colorTheme": "light",
-  "trendLineColor": "#009688",
-  "underLineColor": "rgba(0, 150, 136, 0.25)",
-  "isTransparent": false,
-  "autosize": true
-}
-                </script>
+              <div class="tradingview-widget-container card-chart">
+                <div
+                  id="tv-nasdaq"
+                  class="chart-container"
+                  data-tv-symbol="NASDAQ:IXIC"
+                  data-tv-range="12M"
+                  aria-label="Interactive price chart for the NASDAQ Composite"
+                ></div>
               </div>
             </div>
-          </a>
+            <div class="card-footer">
+              <a
+                class="card-link"
+                href="https://www.tradingview.com/symbols/NASDAQ-IXIC/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open on TradingView
+              </a>
+            </div>
+          </article>
 
-          <a
-            class="card"
-            href="https://www.tradingview.com/symbols/TWSE-TAIEX/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <article class="card">
             <div class="card-header">
               <h3>Taiwan Weighted Index</h3>
               <p>Semiconductor-led performance barometer.</p>
             </div>
             <div class="card-body">
-              <div class="tradingview-widget-container">
-                <div class="tradingview-widget-container__widget"></div>
-                <script
-                  type="text/javascript"
-                  src="https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js"
-                  async
-                >
-{
-  "symbol": "TWSE:TAIEX",
-  "width": "100%",
-  "height": "240",
-  "locale": "en",
-  "dateRange": "12M",
-  "colorTheme": "light",
-  "trendLineColor": "#009688",
-  "underLineColor": "rgba(0, 150, 136, 0.25)",
-  "isTransparent": false,
-  "autosize": true
-}
-                </script>
+              <div class="tradingview-widget-container card-chart">
+                <div
+                  id="tv-taiex"
+                  class="chart-container"
+                  data-tv-symbol="TWSE:TAIEX"
+                  data-tv-range="12M"
+                  aria-label="Interactive price chart for the Taiwan Weighted Index"
+                ></div>
               </div>
             </div>
-          </a>
+            <div class="card-footer">
+              <a
+                class="card-link"
+                href="https://www.tradingview.com/symbols/TWSE-TAIEX/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open on TradingView
+              </a>
+            </div>
+          </article>
         </div>
       </section>
 
@@ -169,12 +149,7 @@
           <p>FRED 10-year constant maturity treasury rate.</p>
         </div>
         <div class="cards-grid single">
-          <a
-            class="card"
-            href="https://fred.stlouisfed.org/series/DGS10"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <article class="card">
             <div class="card-header">
               <h3>US Treasury 10Y</h3>
               <p>Macro benchmark for global discount rates.</p>
@@ -187,10 +162,21 @@
                   scrolling="no"
                   frameborder="0"
                   loading="lazy"
+                  referrerpolicy="no-referrer-when-downgrade"
                 ></iframe>
               </div>
             </div>
-          </a>
+            <div class="card-footer">
+              <a
+                class="card-link"
+                href="https://fred.stlouisfed.org/series/DGS10"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View full series on FRED
+              </a>
+            </div>
+          </article>
         </div>
       </section>
 
@@ -200,75 +186,61 @@
           <p>Dollar strength vs. broad basket and the Japanese yen.</p>
         </div>
         <div class="cards-grid">
-          <a
-            class="card"
-            href="https://www.tradingview.com/symbols/TVC-DXY/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <article class="card">
             <div class="card-header">
               <h3>US Dollar Index (DXY)</h3>
               <p>Measures USD against a major currency basket.</p>
             </div>
             <div class="card-body">
-              <div class="tradingview-widget-container">
-                <div class="tradingview-widget-container__widget"></div>
-                <script
-                  type="text/javascript"
-                  src="https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js"
-                  async
-                >
-{
-  "symbol": "TVC:DXY",
-  "width": "100%",
-  "height": "240",
-  "locale": "en",
-  "dateRange": "12M",
-  "colorTheme": "light",
-  "trendLineColor": "#003366",
-  "underLineColor": "rgba(0, 51, 102, 0.25)",
-  "isTransparent": false,
-  "autosize": true
-}
-                </script>
+              <div class="tradingview-widget-container card-chart">
+                <div
+                  id="tv-dxy"
+                  class="chart-container"
+                  data-tv-symbol="TVC:DXY"
+                  data-tv-range="12M"
+                  aria-label="Interactive price chart for the US Dollar Index"
+                ></div>
               </div>
             </div>
-          </a>
+            <div class="card-footer">
+              <a
+                class="card-link"
+                href="https://www.tradingview.com/symbols/TVC-DXY/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open on TradingView
+              </a>
+            </div>
+          </article>
 
-          <a
-            class="card"
-            href="https://www.tradingview.com/symbols/FX-USDJPY/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <article class="card">
             <div class="card-header">
               <h3>USD / JPY</h3>
               <p>Key rate for global carry and risk sentiment.</p>
             </div>
             <div class="card-body">
-              <div class="tradingview-widget-container">
-                <div class="tradingview-widget-container__widget"></div>
-                <script
-                  type="text/javascript"
-                  src="https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js"
-                  async
-                >
-{
-  "symbol": "FX:USDJPY",
-  "width": "100%",
-  "height": "240",
-  "locale": "en",
-  "dateRange": "12M",
-  "colorTheme": "light",
-  "trendLineColor": "#003366",
-  "underLineColor": "rgba(0, 51, 102, 0.25)",
-  "isTransparent": false,
-  "autosize": true
-}
-                </script>
+              <div class="tradingview-widget-container card-chart">
+                <div
+                  id="tv-usdjpy"
+                  class="chart-container"
+                  data-tv-symbol="FX:USDJPY"
+                  data-tv-range="12M"
+                  aria-label="Interactive price chart for the USD/JPY exchange rate"
+                ></div>
               </div>
             </div>
-          </a>
+            <div class="card-footer">
+              <a
+                class="card-link"
+                href="https://www.tradingview.com/symbols/FX-USDJPY/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open on TradingView
+              </a>
+            </div>
+          </article>
         </div>
       </section>
 
@@ -278,113 +250,391 @@
           <p>Energy and precious metals benchmarks.</p>
         </div>
         <div class="cards-grid">
-          <a
-            class="card"
-            href="https://www.tradingview.com/symbols/TVC-USOIL/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <article class="card">
             <div class="card-header">
               <h3>WTI Crude Oil</h3>
               <p>Gauge for global growth and inflation pressures.</p>
             </div>
             <div class="card-body">
-              <div class="tradingview-widget-container">
-                <div class="tradingview-widget-container__widget"></div>
-                <script
-                  type="text/javascript"
-                  src="https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js"
-                  async
-                >
-{
-  "symbol": "TVC:USOIL",
-  "width": "100%",
-  "height": "240",
-  "locale": "en",
-  "dateRange": "12M",
-  "colorTheme": "light",
-  "trendLineColor": "#009688",
-  "underLineColor": "rgba(0, 150, 136, 0.25)",
-  "isTransparent": false,
-  "autosize": true
-}
-                </script>
+              <div class="tradingview-widget-container card-chart">
+                <div
+                  id="tv-usoil"
+                  class="chart-container"
+                  data-tv-symbol="TVC:USOIL"
+                  data-tv-range="12M"
+                  aria-label="Interactive price chart for WTI crude oil"
+                ></div>
               </div>
             </div>
-          </a>
+            <div class="card-footer">
+              <a
+                class="card-link"
+                href="https://www.tradingview.com/symbols/TVC-USOIL/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open on TradingView
+              </a>
+            </div>
+          </article>
 
-          <a
-            class="card"
-            href="https://www.tradingview.com/symbols/TVC-GOLD/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <article class="card">
             <div class="card-header">
               <h3>Gold</h3>
               <p>Store of value and macro hedge signal.</p>
             </div>
             <div class="card-body">
-              <div class="tradingview-widget-container">
-                <div class="tradingview-widget-container__widget"></div>
-                <script
-                  type="text/javascript"
-                  src="https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js"
-                  async
-                >
-{
-  "symbol": "TVC:GOLD",
-  "width": "100%",
-  "height": "240",
-  "locale": "en",
-  "dateRange": "12M",
-  "colorTheme": "light",
-  "trendLineColor": "#003366",
-  "underLineColor": "rgba(0, 51, 102, 0.25)",
-  "isTransparent": false,
-  "autosize": true
-}
-                </script>
+              <div class="tradingview-widget-container card-chart">
+                <div
+                  id="tv-gold"
+                  class="chart-container"
+                  data-tv-symbol="TVC:GOLD"
+                  data-tv-range="12M"
+                  aria-label="Interactive price chart for gold"
+                ></div>
               </div>
             </div>
-          </a>
+            <div class="card-footer">
+              <a
+                class="card-link"
+                href="https://www.tradingview.com/symbols/TVC-GOLD/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open on TradingView
+              </a>
+            </div>
+          </article>
         </div>
+      </section>
+
+      <section id="timeline" class="dashboard-section timeline-section">
+        <div class="section-header">
+          <h2>Global Macro Timeline</h2>
+          <p>Upcoming policy decisions and economic events that move markets.</p>
+        </div>
+        <ol class="timeline" aria-label="Upcoming macroeconomic events"></ol>
       </section>
     </main>
 
     <footer class="site-footer">
       <p>
-        Data and charts are provided by their respective platforms. This
-        dashboard is for informational purposes only.
+        Data and charts are provided by their respective platforms. This dashboard is for informational purposes only.
       </p>
     </footer>
 
+    <script src="https://s3.tradingview.com/tv.js" id="tradingview-widget-script" defer></script>
     <script>
-      const menuToggle = document.querySelector(".menu-toggle");
-      const nav = document.querySelector(".nav-links");
-      const navLinks = nav.querySelectorAll("a");
+      document.addEventListener("DOMContentLoaded", () => {
+        const menuToggle = document.querySelector(".menu-toggle");
+        const nav = document.querySelector(".nav-links");
+        const navLinks = nav ? nav.querySelectorAll("a") : [];
 
-      const closeMenu = () => {
-        nav.classList.remove("open");
-        menuToggle.setAttribute("aria-expanded", "false");
-      };
+        const closeMenu = () => {
+          if (!nav || !menuToggle) {
+            return;
+          }
 
-      menuToggle.addEventListener("click", () => {
-        const isOpen = nav.classList.toggle("open");
-        menuToggle.setAttribute("aria-expanded", String(isOpen));
-      });
+          nav.classList.remove("open");
+          menuToggle.setAttribute("aria-expanded", "false");
+        };
 
-      navLinks.forEach((link) => {
-        link.addEventListener("click", () => {
-          if (window.matchMedia("(max-width: 720px)").matches) {
+        if (menuToggle && nav) {
+          menuToggle.addEventListener("click", () => {
+            const isOpen = nav.classList.toggle("open");
+            menuToggle.setAttribute("aria-expanded", String(isOpen));
+          });
+        }
+
+        navLinks.forEach((link) => {
+          link.addEventListener("click", () => {
+            if (window.matchMedia("(max-width: 720px)").matches) {
+              closeMenu();
+            }
+          });
+        });
+
+        window.addEventListener("keydown", (event) => {
+          if (event.key === "Escape") {
             closeMenu();
           }
         });
-      });
 
-      window.addEventListener("keydown", (event) => {
-        if (event.key === "Escape") {
-          closeMenu();
+        const tradingViewContainers = document.querySelectorAll(".chart-container[data-tv-symbol]");
+
+        const initializeTradingViewCharts = () => {
+          if (!window.TradingView || !tradingViewContainers.length) {
+            return;
+          }
+
+          tradingViewContainers.forEach((container) => {
+            const symbol = container.dataset.tvSymbol;
+            if (!symbol || !container.id) {
+              return;
+            }
+
+            new window.TradingView.widget({
+              autosize: true,
+              symbol,
+              interval: container.dataset.tvInterval || "D",
+              timezone: container.dataset.tvTimezone || "Etc/UTC",
+              theme: "light",
+              style: "1",
+              locale: "en",
+              toolbar_bg: "#f1f3f6",
+              enable_publishing: false,
+              allow_symbol_change: false,
+              hide_side_toolbar: true,
+              withdateranges: true,
+              range: container.dataset.tvRange || "12M",
+              support_host: "https://www.tradingview.com",
+              container_id: container.id,
+            });
+          });
+        };
+
+        const showTradingViewFallback = () => {
+          tradingViewContainers.forEach((container) => {
+            container.classList.add("chart-unavailable");
+            container.innerHTML =
+              '<p class="chart-fallback">TradingView charts are unavailable right now. Please refresh the page.</p>';
+          });
+        };
+
+        if (window.TradingView && typeof window.TradingView.widget === "function") {
+          initializeTradingViewCharts();
+        } else if (tradingViewContainers.length) {
+          const tradingViewScript = document.getElementById("tradingview-widget-script");
+
+          if (tradingViewScript) {
+            tradingViewScript.addEventListener("load", () => {
+              if (window.TradingView && typeof window.TradingView.widget === "function") {
+                initializeTradingViewCharts();
+              } else {
+                showTradingViewFallback();
+              }
+            });
+
+            tradingViewScript.addEventListener("error", showTradingViewFallback, {
+              once: true,
+            });
+          } else {
+            showTradingViewFallback();
+          }
         }
+
+        const timelineList = document.querySelector(".timeline");
+        const timelineSection = document.querySelector(".timeline-section");
+
+        const renderTimelineStatus = (message, type = "status") => {
+          if (!timelineList) {
+            return;
+          }
+
+          timelineList.innerHTML = "";
+          const statusItem = document.createElement("li");
+          statusItem.className = `timeline-${type}`;
+          statusItem.textContent = message;
+          timelineList.appendChild(statusItem);
+        };
+
+        const formatDisplayDate = (date) =>
+          date.toLocaleString(undefined, {
+            month: "short",
+            day: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+          });
+
+        const normaliseTime = (value) => {
+          if (!value) {
+            return "00:00:00";
+          }
+
+          if (/^\d{2}:\d{2}$/.test(value)) {
+            return `${value}:00`;
+          }
+
+          return value;
+        };
+
+        const parseEventDate = (event) => {
+          if (!event || !event.date) {
+            return null;
+          }
+
+          const [datePart, timePart] = event.date.split(" ");
+          const baseDate = datePart || event.date;
+          const time = event.time ? normaliseTime(event.time) : normaliseTime(timePart);
+
+          const isoCandidate = `${baseDate}T${time || "00:00:00"}`;
+
+          const utcCandidate = Date.parse(`${isoCandidate}Z`);
+          if (!Number.isNaN(utcCandidate)) {
+            return new Date(utcCandidate);
+          }
+
+          const localCandidate = Date.parse(isoCandidate);
+          if (!Number.isNaN(localCandidate)) {
+            return new Date(localCandidate);
+          }
+
+          return null;
+        };
+
+        const buildTimelineItem = (event) => {
+          const item = document.createElement("li");
+
+          const eventDate = parseEventDate(event);
+          const dateElement = document.createElement("div");
+          dateElement.className = "timeline-date";
+          if (eventDate) {
+            dateElement.textContent = formatDisplayDate(eventDate);
+          } else {
+            dateElement.textContent = event.date || "Upcoming";
+          }
+
+          const content = document.createElement("div");
+          content.className = "timeline-content";
+
+          const title = document.createElement("h3");
+          title.textContent = event.event || event.title || "Economic release";
+
+          const details = document.createElement("p");
+          const info = [];
+          if (event.country) {
+            info.push(event.country);
+          }
+          if (event.importance) {
+            info.push(event.importance);
+          }
+          if (event.category && !event.importance) {
+            info.push(event.category);
+          }
+          if (event.consensus != null) {
+            info.push(`Forecast: ${event.consensus}`);
+          }
+          if (event.actual != null) {
+            info.push(`Actual: ${event.actual}`);
+          }
+          if (event.previous != null) {
+            info.push(`Previous: ${event.previous}`);
+          }
+
+          if (info.length) {
+            details.textContent = info.join(" • ");
+          } else if (event.description) {
+            details.textContent = event.description;
+          } else {
+            details.textContent = "Upcoming economic data";
+          }
+
+          content.append(title, details);
+
+          const tagValue = event.importance || event.category || "";
+          if (tagValue) {
+            const tag = document.createElement("span");
+            tag.className = "event-tag";
+            tag.textContent = tagValue;
+            content.appendChild(tag);
+          }
+
+          item.append(dateElement, content);
+          return { item, eventDate };
+        };
+
+        const fallbackEvents = [
+          {
+            date: new Date().toISOString(),
+            title: "FOMC press conference",
+            description: "Federal Reserve chair provides color on the latest policy decision.",
+            category: "Monetary Policy",
+          },
+          {
+            date: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+            title: "US Nonfarm Payrolls",
+            description: "Employment data that often swings risk sentiment and USD crosses.",
+            category: "Labor Market",
+          },
+          {
+            date: new Date(Date.now() + 4 * 24 * 60 * 60 * 1000).toISOString(),
+            title: "Eurozone CPI Flash",
+            description: "Inflation snapshot guiding ECB expectations.",
+            category: "Inflation",
+          },
+        ];
+
+        const loadEconomicCalendar = async () => {
+          if (!timelineList) {
+            return;
+          }
+
+          renderTimelineStatus("Loading upcoming releases…");
+
+          const now = new Date();
+          const formatDateParam = (date) => date.toISOString().split("T")[0];
+          const start = formatDateParam(now);
+          const end = formatDateParam(new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000));
+          const calendarEndpoint =
+            "https://financialmodelingprep.com/api/v3/economic_calendar" +
+            `?from=${start}&to=${end}&apikey=demo`;
+
+          try {
+            const response = await fetch(calendarEndpoint);
+            if (!response.ok) {
+              throw new Error(`Request failed with status ${response.status}`);
+            }
+
+            const payload = await response.json();
+            if (!Array.isArray(payload) || payload.length === 0) {
+              throw new Error("No upcoming events");
+            }
+
+            const upcoming = payload
+              .map((event) => {
+                const { item, eventDate } = buildTimelineItem(event);
+                return { item, eventDate };
+              })
+              .filter(({ eventDate }) => eventDate && eventDate.getTime() >= now.getTime())
+              .sort((a, b) => a.eventDate - b.eventDate)
+              .slice(0, 10);
+
+            timelineList.innerHTML = "";
+
+            if (!upcoming.length) {
+              renderTimelineStatus("No upcoming releases in the next few days.");
+              return;
+            }
+
+            const fragment = document.createDocumentFragment();
+            upcoming.forEach(({ item }) => fragment.appendChild(item));
+            timelineList.appendChild(fragment);
+
+            if (timelineSection) {
+              timelineSection.setAttribute(
+                "data-calendar-source",
+                "financialmodelingprep.com/api/v3/economic_calendar"
+              );
+            }
+          } catch (error) {
+            renderTimelineStatus(
+              "Unable to load live economic releases right now. Please try again later.",
+              "error"
+            );
+            if (timelineSection) {
+              timelineSection.setAttribute("data-calendar-error", String(error));
+            }
+
+            const fragment = document.createDocumentFragment();
+            fallbackEvents.forEach((event) => {
+              const { item } = buildTimelineItem(event);
+              fragment.appendChild(item);
+            });
+            timelineList.appendChild(fragment);
+          }
+        };
+
+        loadEconomicCalendar();
       });
     </script>
   </body>

--- a/style.css
+++ b/style.css
@@ -182,16 +182,39 @@ main {
 .card-body {
   flex: 1;
   display: flex;
-  align-items: center;
+  align-items: stretch;
 }
 
 .tradingview-widget-container,
-.tradingview-widget-container__widget,
 .iframe-wrapper {
   width: 100%;
 }
 
-.tradingview-widget-container__widget,
+.card-chart {
+  min-height: 0;
+}
+
+.chart-container {
+  width: 100%;
+  height: 320px;
+}
+
+.chart-container.chart-unavailable {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  border-radius: 12px;
+  background: rgba(0, 51, 102, 0.06);
+}
+
+.chart-fallback {
+  margin: 0;
+  text-align: center;
+  color: rgba(51, 51, 51, 0.65);
+  font-size: 0.95rem;
+}
+
 .iframe-wrapper {
   min-height: 220px;
 }
@@ -203,11 +226,130 @@ main {
   border-radius: 12px;
 }
 
+.card-footer {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.card-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--accent-navy);
+  text-decoration: none;
+}
+
+.card-link::after {
+  content: "↗";
+  font-size: 0.85rem;
+  transform: translateY(-1px);
+}
+
+.card-link:hover,
+.card-link:focus-visible {
+  color: var(--accent-teal);
+}
+
 .site-footer {
   padding: 2rem 5vw 3rem;
   text-align: center;
   color: rgba(51, 51, 51, 0.6);
   font-size: 0.9rem;
+}
+
+.timeline {
+  position: relative;
+  list-style: none;
+  margin: 2rem 0 0;
+  padding: 0;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 14px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(0, 150, 136, 0.2), rgba(0, 51, 102, 0.35));
+}
+
+.timeline li {
+  position: relative;
+  margin: 0 0 1.75rem;
+  padding-left: 2.5rem;
+}
+
+.timeline li:last-child {
+  margin-bottom: 0;
+}
+
+.timeline-status,
+.timeline-error {
+  list-style: none;
+  margin: 0;
+  padding: 1.25rem 1.5rem 1.25rem 3rem;
+  border-radius: 14px;
+  background: rgba(0, 150, 136, 0.08);
+  font-weight: 600;
+  color: var(--accent-navy);
+}
+
+.timeline-error {
+  background: rgba(220, 53, 69, 0.12);
+  color: #b71c1c;
+}
+
+.timeline li::before {
+  content: "";
+  position: absolute;
+  left: 8px;
+  top: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--card-color);
+  border: 2px solid var(--accent-teal);
+  box-shadow: 0 0 0 4px rgba(0, 150, 136, 0.12);
+}
+
+.timeline-status::before,
+.timeline-error::before {
+  display: none;
+}
+
+.timeline-date {
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent-navy);
+}
+
+.timeline-content h3 {
+  margin: 0.35rem 0 0.3rem;
+  font-size: 1.05rem;
+}
+
+.timeline-content p {
+  margin: 0;
+  color: rgba(51, 51, 51, 0.75);
+  font-size: 0.95rem;
+}
+
+.event-tag {
+  display: inline-flex;
+  margin-top: 0.6rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: rgba(0, 51, 102, 0.08);
+  color: var(--accent-navy);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -273,6 +415,10 @@ main {
 
   .cards-grid {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .chart-container {
+    height: 280px;
   }
 
   .iframe-wrapper iframe {


### PR DESCRIPTION
## Summary
- defer TradingView initialization until the widget script is ready and show a clearer fallback when the library fails to load
- replace the static macro timeline with live data from the Financial Modeling Prep economic calendar API and retain curated events as a backup
- style timeline status and error states so loading and outage messaging fits the dashboard visuals

## Testing
- python3 -m compileall serve.py

------
https://chatgpt.com/codex/tasks/task_e_68ce1c7268d4832298beed1c3735d5e6