### PR TITLE
feat: Chord diagram + Economic Cycle Locator (Pring-Stovall rotation clock)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@ __pycache__/
 *.pyc
 *.pyo
 .env
+
+# Next.js
+node_modules/
+.next/
+out/
+
+# TypeScript
+tsconfig.tsbuildinfo

--- a/index.html
+++ b/index.html
@@ -409,6 +409,17 @@
 
   <section class="panel">
     <div class="panel-header">
+      <h2>📍 景氣循環定位器</h2>
+      <span class="panel-hint">基於 Pring-Stovall 板塊輪動理論 ─ 各板塊典型強勢週期位置，白色箭頭為當前流向估算位置</span>
+    </div>
+    <div class="cycle-clock-wrap">
+      <canvas id="cycleClockCanvas"></canvas>
+      <div class="cycle-clock-info" id="cycleClockInfo"><div style="color:#8b949e">載入中…</div></div>
+    </div>
+  </section>
+
+  <section class="panel">
+    <div class="panel-header">
       <h2>重大市場事件時間軸</h2>
       <span class="panel-hint">點選事件卡查看詳情與受影響板塊</span>
     </div>
@@ -1942,109 +1953,97 @@ function renderChipCharts() {
 
 function renderNetworkGraph(data) {
   const canvas = document.getElementById("networkCanvas");
-  canvas.width  = canvas.parentElement.clientWidth  || 700;
-  canvas.height = canvas.parentElement.clientHeight || 420;
-  const W = canvas.width, H = canvas.height;
+  const W = canvas.width  = canvas.parentElement.clientWidth  || 720;
+  const H = canvas.height = Math.min(W * 0.76, 520);
   const ctx = canvas.getContext("2d");
-  const n = data.sectors.length;
+  ctx.clearRect(0, 0, W, H);
 
-  if (state.networkRunning) { state.networkRunning = false; }
-  // Initialise nodes in a circle
-  const nodes = data.sectors.map((sec, i) => {
-    const angle = (2 * Math.PI * i) / n;
-    return {
-      id: sec, i,
-      x: W / 2 + (W * 0.35) * Math.cos(angle),
-      y: H / 2 + (H * 0.35) * Math.sin(angle),
-      vx: 0, vy: 0,
-      r: Math.max(18, Math.sqrt(data.mcaps[i] || 1) * 2.2),
-      color: SECTOR_COLORS[sec] || "#58a6ff",
-      label: sec,
-    };
+  if (!data || !data.sectors || !data.rotation_matrix) return;
+
+  const cx = W / 2, cy = H / 2;
+  const R  = Math.min(W, H) * 0.34;   // outer arc radius
+  const ri = R * 0.76;                 // inner arc (chord endpoints)
+  const rl = R + 30;                   // label radius
+  const n  = data.sectors.length;
+  const GAP  = 0.026;
+  const span = (2 * Math.PI - GAP * n) / n;
+
+  const arcs = data.sectors.map((sec, i) => {
+    const a0 = -Math.PI / 2 + i * (span + GAP);
+    const a1 = a0 + span;
+    return { sec, i, a0, a1, mid: (a0 + a1) / 2 };
   });
 
-  // Build edges from rotation matrix (|corr| > 0.25)
-  const edges = [];
+  // ── Chords (drawn under arcs) ────────────────────────────────
   for (let i = 0; i < n; i++) {
     for (let j = i + 1; j < n; j++) {
-      const c = data.rotation_matrix[i][j];
-      if (Math.abs(c) > 0.25) edges.push({ i, j, c });
-    }
-  }
-
-  const K_REPEL = 8000, K_ATTRACT = 0.04, DAMPING = 0.82, DT = 0.9;
-  let frame = 0;
-  state.networkRunning = true;
-
-  function tick() {
-    if (!state.networkRunning) return;
-    frame++;
-
-    // Forces
-    for (let a = 0; a < n; a++) {
-      let fx = 0, fy = 0;
-      // Centre gravity
-      fx += (W / 2 - nodes[a].x) * 0.004;
-      fy += (H / 2 - nodes[a].y) * 0.004;
-      // Repulsion
-      for (let b = 0; b < n; b++) {
-        if (a === b) continue;
-        const dx = nodes[a].x - nodes[b].x, dy = nodes[a].y - nodes[b].y;
-        const dist2 = dx * dx + dy * dy + 1;
-        const f = K_REPEL / dist2;
-        fx += f * dx / Math.sqrt(dist2);
-        fy += f * dy / Math.sqrt(dist2);
-      }
-      // Attraction along edges
-      edges.forEach(e => {
-        if (e.i !== a && e.j !== a) return;
-        const b = e.i === a ? e.j : e.i;
-        const dx = nodes[b].x - nodes[a].x, dy = nodes[b].y - nodes[a].y;
-        const str = Math.abs(e.c) * K_ATTRACT;
-        fx += dx * str; fy += dy * str;
-      });
-
-      nodes[a].vx = (nodes[a].vx + fx * DT) * DAMPING;
-      nodes[a].vy = (nodes[a].vy + fy * DT) * DAMPING;
-    }
-    nodes.forEach(nd => {
-      nd.x = Math.max(nd.r + 2, Math.min(W - nd.r - 2, nd.x + nd.vx));
-      nd.y = Math.max(nd.r + 2, Math.min(H - nd.r - 2, nd.y + nd.vy));
-    });
-
-    // Draw
-    ctx.clearRect(0, 0, W, H);
-    edges.forEach(e => {
+      const c   = ((data.rotation_matrix[i] || [])[j]) ?? 0;
+      const abs = Math.abs(c);
+      if (abs < 0.2) continue;
+      const x1 = cx + ri * Math.cos(arcs[i].mid);
+      const y1 = cy + ri * Math.sin(arcs[i].mid);
+      const x2 = cx + ri * Math.cos(arcs[j].mid);
+      const y2 = cy + ri * Math.sin(arcs[j].mid);
+      const pull = 0.22;
       ctx.save();
-      ctx.globalAlpha = Math.min(0.8, Math.abs(e.c));
-      ctx.strokeStyle = e.c > 0 ? "#4a90e2" : "#e67e22";
-      ctx.lineWidth = Math.abs(e.c) * 3;
+      ctx.globalAlpha = 0.07 + abs * 0.52;
+      ctx.strokeStyle = c > 0 ? "#4a9eff" : "#f97316";
+      ctx.lineWidth   = 1 + abs * 5.5;
+      ctx.lineCap     = "round";
       ctx.beginPath();
-      ctx.moveTo(nodes[e.i].x, nodes[e.i].y);
-      ctx.lineTo(nodes[e.j].x, nodes[e.j].y);
+      ctx.moveTo(x1, y1);
+      ctx.bezierCurveTo(
+        x1 + (cx - x1) * pull, y1 + (cy - y1) * pull,
+        x2 + (cx - x2) * pull, y2 + (cy - y2) * pull,
+        x2, y2
+      );
       ctx.stroke();
       ctx.restore();
-    });
-    nodes.forEach(nd => {
-      ctx.beginPath();
-      ctx.arc(nd.x, nd.y, nd.r, 0, Math.PI * 2);
-      ctx.fillStyle = nd.color + "cc";
-      ctx.fill();
-      ctx.strokeStyle = nd.color;
-      ctx.lineWidth = 1.5;
-      ctx.stroke();
-      ctx.fillStyle = "#fff";
-      ctx.font = `bold ${Math.max(9, Math.min(12, nd.r * 0.55))}px Inter,sans-serif`;
-      ctx.textAlign = "center";
-      ctx.textBaseline = "middle";
-      const short = nd.label.length > 8 ? nd.label.slice(0, 7) + "…" : nd.label;
-      ctx.fillText(short, nd.x, nd.y);
-    });
-
-    if (frame < 180) requestAnimationFrame(tick);
-    else state.networkRunning = false;
+    }
   }
-  requestAnimationFrame(tick);
+
+  // ── Sector arcs ──────────────────────────────────────────────
+  arcs.forEach(arc => {
+    const color = SECTOR_COLORS[arc.sec] || "#58a6ff";
+    const eps   = 0.007;
+    ctx.beginPath();
+    ctx.arc(cx, cy, R,  arc.a0 + eps, arc.a1 - eps);
+    ctx.arc(cx, cy, ri, arc.a1 - eps, arc.a0 + eps, true);
+    ctx.closePath();
+    ctx.fillStyle   = color + "d8";
+    ctx.fill();
+    ctx.strokeStyle = "#0d1117";
+    ctx.lineWidth   = 0.8;
+    ctx.stroke();
+
+    // Label
+    const cos = Math.cos(arc.mid), sin = Math.sin(arc.mid);
+    const lx = cx + rl * cos, ly = cy + rl * sin;
+    ctx.font         = "bold 10px Inter, sans-serif";
+    ctx.fillStyle    = "#c9d1d9";
+    ctx.textAlign    = Math.abs(cos) < 0.18 ? "center" : cos > 0 ? "left" : "right";
+    ctx.textBaseline = Math.abs(sin) < 0.18 ? "middle" : sin > 0 ? "top" : "bottom";
+    const lbl = arc.sec.length > 12 ? arc.sec.slice(0, 11) + "…" : arc.sec;
+    ctx.fillText(lbl, lx, ly);
+  });
+
+  // ── Center label ─────────────────────────────────────────────
+  ctx.fillStyle = "#8b949e"; ctx.font = "11px Inter, sans-serif";
+  ctx.textAlign = "center";  ctx.textBaseline = "middle";
+  ctx.fillText("板塊相關性", cx, cy - 8);
+  ctx.fillText("Chord Diagram", cx, cy + 8);
+
+  // ── Legend ───────────────────────────────────────────────────
+  [["#4a9eff", "正相關 (+)"], ["#f97316", "負相關 (−)"]].forEach(([col, txt], k) => {
+    ctx.fillStyle = col;
+    ctx.beginPath();
+    if (ctx.roundRect) ctx.roundRect(14, H - 40 + k * 17, 14, 5, 2);
+    else ctx.rect(14, H - 40 + k * 17, 14, 5);
+    ctx.fill();
+    ctx.fillStyle = "#8b949e"; ctx.font = "10px Inter";
+    ctx.textAlign = "left"; ctx.textBaseline = "middle";
+    ctx.fillText(txt, 32, H - 37 + k * 17);
+  });
 }
 
 // Chip period buttons
@@ -2198,15 +2197,199 @@ function renderRotationFlow(data) {
 // ═══════════════════════════════════════════════════════════════
 
 async function renderCycleTab() {
-  if (!state.eventsData) {
-    try { state.eventsData = await apiFetch("/api/events"); } catch { return; }
-  }
-  if (!state.cycleData) {
-    try { state.cycleData = await apiFetch("/api/cycle"); } catch { return; }
-  }
+  const fetches = [];
+  if (!state.eventsData)     fetches.push(apiFetch("/api/events").then(d => { state.eventsData = d; }));
+  if (!state.cycleData)      fetches.push(apiFetch("/api/cycle").then(d => { state.cycleData = d; }));
+  if (!state.flowMatrixData) fetches.push(apiFetch("/api/flow-matrix?period=1m").then(d => { state.flowMatrixData = d; }));
+  try { await Promise.all(fetches); } catch { return; }
+  renderCycleClock();
   renderEventTimeline();
   renderCycleHeatmap();
   renderPercentileRanks();
+}
+
+// ═══════════════════════════════════════════════════════════════
+//  12a.  ECONOMIC CYCLE LOCATOR (Pring-Stovall Rotation Clock)
+// ═══════════════════════════════════════════════════════════════
+
+// clockDeg: 0 = 12 o'clock, 90 = 3 o'clock, going clockwise
+const CYCLE_CLOCK_POS = {
+  "Technology":    { deg: 350 }, "Industrials":  { deg: 328 },
+  "Broad Market":  { deg: 314 }, "International":{ deg: 302 },
+  "Crypto":        { deg: 288 }, "Consumer":     { deg: 272 },
+  "Financials":    { deg: 252 }, "Real Estate":  { deg: 208 },
+  "Bonds":         { deg: 186 }, "Utilities":    { deg: 158 },
+  "Healthcare":    { deg: 122 }, "Energy":       { deg: 72 },
+  "Commodities":   { deg: 54 },  "Materials":    { deg: 38 },
+};
+
+const CLOCK_PHASES = [
+  { start: 298, end:  58, label: "擴張期",    eng: "Expansion",      bg: "#071e12", fg: "#4ade80",  note: "成長股 / 科技主導" },
+  { start:  58, end: 138, label: "後期擴張",  eng: "Late Expansion", bg: "#1e1007", fg: "#fb923c",  note: "原物料 / 能源領漲" },
+  { start: 138, end: 228, label: "收縮衰退",  eng: "Contraction",    bg: "#1e0709", fg: "#f87171",  note: "防禦性板塊優先" },
+  { start: 228, end: 298, label: "復甦期",    eng: "Recovery",       bg: "#07101e", fg: "#60a5fa",  note: "金融 / 早期循環領先" },
+];
+
+function renderCycleClock() {
+  const canvas = document.getElementById("cycleClockCanvas");
+  if (!canvas) return;
+  const size = Math.min(canvas.parentElement.clientWidth * 0.62 || 480, 500);
+  canvas.width = canvas.height = size;
+  const W = size, ctx = canvas.getContext("2d");
+  ctx.clearRect(0, 0, W, W);
+
+  const cx = W / 2, cy = W / 2;
+  const oR = W * 0.43;   // outer phase ring
+  const iR = W * 0.21;   // inner hole radius
+  const sR = W * 0.34;   // sector dot orbit
+  const lR = W * 0.415;  // sector label orbit
+
+  // clock degrees → canvas radians (0 = 12 o'clock)
+  const toA = d => (d - 90) * Math.PI / 180;
+
+  // ── Phase arc segments ──────────────────────────────────────
+  CLOCK_PHASES.forEach(p => {
+    const a0 = toA(p.start), sweep = (p.end - p.start + 360) % 360 * Math.PI / 180;
+    ctx.beginPath();
+    ctx.arc(cx, cy, oR, a0, a0 + sweep);
+    ctx.arc(cx, cy, iR, a0 + sweep, a0, true);
+    ctx.closePath();
+    ctx.fillStyle = p.bg;
+    ctx.fill();
+    ctx.strokeStyle = "#0d1117";
+    ctx.lineWidth   = 0.6;
+    ctx.stroke();
+  });
+
+  // ── Phase labels (curved inside each arc) ───────────────────
+  CLOCK_PHASES.forEach(p => {
+    const midDeg = p.start + ((p.end - p.start + 360) % 360) / 2;
+    const a = toA(midDeg);
+    const lr = (oR + iR) / 2;
+    ctx.save();
+    ctx.translate(cx + lr * Math.cos(a), cy + lr * Math.sin(a));
+    let rot = a + Math.PI / 2;
+    if (Math.cos(a) < 0) rot += Math.PI;
+    ctx.rotate(rot);
+    ctx.textAlign    = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillStyle = p.fg;
+    ctx.font = `bold ${Math.round(W * 0.034)}px Inter, sans-serif`;
+    ctx.fillText(p.label, 0, -W * 0.015);
+    ctx.fillStyle = p.fg + "aa";
+    ctx.font = `${Math.round(W * 0.022)}px Inter, sans-serif`;
+    ctx.fillText(p.eng, 0, W * 0.015);
+    ctx.restore();
+  });
+
+  // ── Outer ring ticks (12 hour marks) ────────────────────────
+  for (let h = 0; h < 12; h++) {
+    const a = toA(h * 30);
+    const r0 = oR * 0.965, r1 = oR;
+    ctx.beginPath();
+    ctx.moveTo(cx + r0 * Math.cos(a), cy + r0 * Math.sin(a));
+    ctx.lineTo(cx + r1 * Math.cos(a), cy + r1 * Math.sin(a));
+    ctx.strokeStyle = "#21262d"; ctx.lineWidth = 1; ctx.stroke();
+  }
+
+  // ── Inner hole ───────────────────────────────────────────────
+  ctx.beginPath();
+  ctx.arc(cx, cy, iR, 0, Math.PI * 2);
+  ctx.fillStyle = "#0d1117"; ctx.fill();
+
+  // ── Flow score map for emphasis ─────────────────────────────
+  const flowMap = {};
+  if (state.flowMatrixData) {
+    state.flowMatrixData.sectors.forEach((s, i) => {
+      flowMap[s] = state.flowMatrixData.flow_scores[i] || 0;
+    });
+  }
+
+  // ── Compute current angle (weighted avg of sector positions) ─
+  let sumX = 0, sumY = 0;
+  Object.entries(CYCLE_CLOCK_POS).forEach(([sec, pos]) => {
+    const score = Math.max(0, (flowMap[sec] || 0) + 3);
+    const a = toA(pos.deg);
+    sumX += Math.cos(a) * score;
+    sumY += Math.sin(a) * score;
+  });
+  const currentAngle = Math.atan2(sumY, sumX);
+
+  // ── Sector dots + labels ─────────────────────────────────────
+  Object.entries(CYCLE_CLOCK_POS).forEach(([sec, pos]) => {
+    const a  = toA(pos.deg);
+    const sx = cx + sR * Math.cos(a), sy = cy + sR * Math.sin(a);
+    const score = flowMap[sec] || 0;
+    const color = SECTOR_COLORS[sec] || "#58a6ff";
+    const r = 4.5 + Math.max(0, score) * 0.6;
+
+    if (score > 1.5) {
+      ctx.save();
+      ctx.shadowColor = color; ctx.shadowBlur = 14;
+      ctx.beginPath(); ctx.arc(sx, sy, r + 3, 0, Math.PI * 2);
+      ctx.fillStyle = color + "33"; ctx.fill();
+      ctx.restore();
+    }
+
+    ctx.beginPath(); ctx.arc(sx, sy, r, 0, Math.PI * 2);
+    ctx.fillStyle = color; ctx.fill();
+    ctx.strokeStyle = "#0d1117"; ctx.lineWidth = 1; ctx.stroke();
+
+    const cos = Math.cos(a), sin = Math.sin(a);
+    const tx = cx + lR * cos, ty = cy + lR * sin;
+    ctx.font         = `${Math.round(W * 0.026)}px Inter, sans-serif`;
+    ctx.fillStyle    = score > 0.5 ? "#e6edf3" : "#8b949e";
+    ctx.textAlign    = Math.abs(cos) < 0.2 ? "center" : cos > 0 ? "left" : "right";
+    ctx.textBaseline = Math.abs(sin) < 0.2 ? "middle" : sin > 0 ? "top" : "bottom";
+    ctx.fillText(sec.length > 10 ? sec.slice(0, 9) + "…" : sec, tx, ty);
+  });
+
+  // ── Current-position needle ──────────────────────────────────
+  const nLen = iR * 0.82;
+  const nx = cx + nLen * Math.cos(currentAngle);
+  const ny = cy + nLen * Math.sin(currentAngle);
+
+  ctx.save();
+  ctx.shadowColor = "#ffffff"; ctx.shadowBlur = 10;
+  ctx.strokeStyle = "#ffffff"; ctx.lineWidth = 2.5; ctx.lineCap = "round";
+  ctx.beginPath(); ctx.moveTo(cx, cy); ctx.lineTo(nx, ny); ctx.stroke();
+  const aH = 0.48;
+  ctx.fillStyle = "#ffffff";
+  ctx.beginPath();
+  ctx.moveTo(nx, ny);
+  ctx.lineTo(nx - 9 * Math.cos(currentAngle - aH), ny - 9 * Math.sin(currentAngle - aH));
+  ctx.lineTo(nx - 9 * Math.cos(currentAngle + aH), ny - 9 * Math.sin(currentAngle + aH));
+  ctx.closePath(); ctx.fill();
+  ctx.restore();
+
+  ctx.beginPath(); ctx.arc(cx, cy, 4.5, 0, Math.PI * 2);
+  ctx.fillStyle = "#ffffff"; ctx.fill();
+
+  // ── Info panel ───────────────────────────────────────────────
+  const curDeg = ((currentAngle * 180 / Math.PI) + 90 + 360) % 360;
+  const phase  = CLOCK_PHASES.find(p => {
+    const e = p.end < p.start ? p.end + 360 : p.end;
+    const d = curDeg < p.start && e > 360 ? curDeg + 360 : curDeg;
+    return d >= p.start && d < e;
+  }) || CLOCK_PHASES[0];
+
+  const info = document.getElementById("cycleClockInfo");
+  if (info) {
+    info.innerHTML = `
+      <div class="cc-subtitle">當前估算階段</div>
+      <div class="cc-phase" style="color:${phase.fg}">${phase.label}</div>
+      <div class="cc-note">${phase.note}</div>
+      <hr class="cc-divider">
+      <div class="cc-legend-title">輪動邏輯</div>
+      ${CLOCK_PHASES.map(p => `
+        <div class="cc-row">
+          <span class="cc-dot" style="background:${p.fg}"></span>
+          <span style="color:${p.fg};font-weight:600">${p.label}</span>
+          <span class="cc-row-note">${p.note}</span>
+        </div>
+      `).join("")}
+    `;
+  }
 }
 
 const EVENT_COLORS = { fed: "#4a90e2", macro: "#27ae60", earnings: "#f7931a", geopolitical: "#e74c3c" };

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6205 @@
+{
+  "name": "fund-flow-dashboard",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fund-flow-dashboard",
+      "version": "0.1.0",
+      "dependencies": {
+        "chart.js": "^4.4.7",
+        "next": "15.1.0",
+        "react": "^19.0.0",
+        "react-chartjs-2": "^5.2.0",
+        "react-dom": "^19.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "autoprefixer": "^10.0.1",
+        "eslint": "^9",
+        "eslint-config-next": "15.1.0",
+        "postcss": "^8",
+        "tailwindcss": "^3.4.17",
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.1.0.tgz",
+      "integrity": "sha512-UcCO481cROsqJuszPPXJnb7GGuLq617ve4xuAyyNG4VSSocJNtMU5Fsx+Lp6mlN8c7W58aZLc5y6D/2xNmaK+w==",
+      "license": "MIT"
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.1.0.tgz",
+      "integrity": "sha512-+jPT0h+nelBT6HC9ZCHGc7DgGVy04cv4shYdAe6tKlEbjQUtwU3LzQhzbDHQyY2m6g39m6B0kOFVuLGBrxxbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.1.0.tgz",
+      "integrity": "sha512-ZU8d7xxpX14uIaFC3nsr4L++5ZS/AkWDm1PzPO6gD9xWhFkOj2hzSbSIxoncsnlJXB1CbLOfGVN4Zk9tg83PUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.1.0.tgz",
+      "integrity": "sha512-DQ3RiUoW2XC9FcSM4ffpfndq1EsLV0fj0/UY33i7eklW5akPUCo6OX2qkcLXZ3jyPdo4sf2flwAED3AAq3Om2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.1.0.tgz",
+      "integrity": "sha512-M+vhTovRS2F//LMx9KtxbkWk627l5Q7AqXWWWrfIzNIaUFiz2/NkOFkxCFyNyGACi5YbA8aekzCLtbDyfF/v5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.1.0.tgz",
+      "integrity": "sha512-Qn6vOuwaTCx3pNwygpSGtdIu0TfS1KiaYLYXLH5zq1scoTXdwYfdZtwvJTpB1WrLgiQE2Ne2kt8MZok3HlFqmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.1.0.tgz",
+      "integrity": "sha512-yeNh9ofMqzOZ5yTOk+2rwncBzucc6a1lyqtg8xZv0rH5znyjxHOWsoUtSq4cUTeeBIiXXX51QOOe+VoCjdXJRw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.1.0.tgz",
+      "integrity": "sha512-t9IfNkHQs/uKgPoyEtU912MG6a1j7Had37cSUyLTKx9MnUpjj+ZDKw9OyqTI9OwIIv0wmkr1pkZy+3T5pxhJPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.1.0.tgz",
+      "integrity": "sha512-WEAoHyG14t5sTavZa1c6BnOIEukll9iqFRTavqRVPfYmfegOAd5MaZfXgOGG6kGo1RduyGdTHD4+YZQSdsNZXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.1.0.tgz",
+      "integrity": "sha512-J1YdKuJv9xcixzXR24Dv+4SaDKc2jj31IVUEMdO5xJivMTXuE6MAdIi4qPjSymHuFG8O5wbfWKnhJUcHHpj5CA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rushstack/eslint-patch": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
+      "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/type-utils": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.3",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.3",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.355",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.355.tgz",
+      "integrity": "sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.1.0.tgz",
+      "integrity": "sha512-gADO+nKVseGso3DtOrYX9H7TxB/MuX7AUYhMlvQMqLYvUWu4HrOQuU7cC1HW74tHIqkAvXdwgAz3TCbczzSEXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "15.1.0",
+        "@rushstack/eslint-patch": "^1.10.3",
+        "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.37.0",
+        "eslint-plugin-react-hooks": "^5.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/next": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.1.0.tgz",
+      "integrity": "sha512-QKhzt6Y8rgLNlj30izdMbxAwjHMFANnLwDwZ+WQh5sMhyt4lEBqDK9QpvWHtIM4rINKPoJ8aiRZKg5ULSybVHw==",
+      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "15.1.0",
+        "@swc/counter": "0.1.3",
+        "@swc/helpers": "0.5.15",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.1.0",
+        "@next/swc-darwin-x64": "15.1.0",
+        "@next/swc-linux-arm64-gnu": "15.1.0",
+        "@next/swc-linux-arm64-musl": "15.1.0",
+        "@next/swc-linux-x64-gnu": "15.1.0",
+        "@next/swc-linux-x64-musl": "15.1.0",
+        "@next/swc-win32-arm64-msvc": "15.1.0",
+        "@next/swc-win32-x64-msvc": "15.1.0",
+        "sharp": "^0.33.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-import/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.1.tgz",
+      "integrity": "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "fund-flow-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "15.1.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "chart.js": "^4.4.7",
+    "react-chartjs-2": "^5.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "15.1.0",
+    "tailwindcss": "^3.4.17",
+    "postcss": "^8",
+    "autoprefixer": "^10.0.1",
+    "typescript": "^5"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,8 @@
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+
+export default config;

--- a/src/app/api/backtest/route.ts
+++ b/src/app/api/backtest/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { ETF_UNIVERSE, runBacktest } from '@/lib/data-engine';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const rawWeights = searchParams.get('weights') ?? 'SPY:1';
+  const period = searchParams.get('period') ?? '1y';
+
+  const weights: Record<string, number> = {};
+  for (const part of rawWeights.split(',')) {
+    if (part.includes(':')) {
+      const colonIdx = part.indexOf(':');
+      const sym = part.slice(0, colonIdx).trim().toUpperCase();
+      const w = parseFloat(part.slice(colonIdx + 1));
+      if (sym in ETF_UNIVERSE && !isNaN(w)) {
+        weights[sym] = w / 100;
+      }
+    }
+  }
+
+  if (Object.keys(weights).length === 0) {
+    return NextResponse.json({ error: 'no valid weights' }, { status: 400 });
+  }
+
+  const total = Object.values(weights).reduce((sum, w) => sum + w, 0);
+  const normalised: Record<string, number> = {};
+  for (const [sym, w] of Object.entries(weights)) {
+    normalised[sym] = w / total;
+  }
+
+  return NextResponse.json(runBacktest(normalised, period));
+}

--- a/src/app/api/chips/route.ts
+++ b/src/app/api/chips/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { getChipsData } from '@/lib/data-engine';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const period = searchParams.get('period') ?? '1m';
+  return NextResponse.json(getChipsData(period));
+}

--- a/src/app/api/cycle/route.ts
+++ b/src/app/api/cycle/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { getCycleData } from '@/lib/data-engine';
+
+export async function GET() {
+  return NextResponse.json(getCycleData());
+}

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { MOCK_EVENTS } from '@/lib/data-engine';
+
+export async function GET() {
+  return NextResponse.json(MOCK_EVENTS);
+}

--- a/src/app/api/flow-matrix/route.ts
+++ b/src/app/api/flow-matrix/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { getFlowMatrix } from '@/lib/data-engine';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const period = searchParams.get('period') ?? '1m';
+  return NextResponse.json(getFlowMatrix(period));
+}

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { ETF_UNIVERSE, PERIOD_DAYS, generateSeries } from '@/lib/data-engine';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const symbol = (searchParams.get('symbol') ?? 'SPY').toUpperCase();
+  const period = searchParams.get('period') ?? '1y';
+
+  if (!(symbol in ETF_UNIVERSE)) {
+    return NextResponse.json({ error: 'unknown symbol' }, { status: 400 });
+  }
+
+  const days = PERIOD_DAYS[period as keyof typeof PERIOD_DAYS] ?? 380;
+  const series = generateSeries(symbol, days);
+  return NextResponse.json({ symbol, period, series });
+}

--- a/src/app/api/macro/route.ts
+++ b/src/app/api/macro/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { getMacroData } from '@/lib/data-engine';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const period = searchParams.get('period') ?? '1d';
+  return NextResponse.json(getMacroData(period));
+}

--- a/src/app/api/quotes/route.ts
+++ b/src/app/api/quotes/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { getAllQuotes } from '@/lib/data-engine';
+
+export async function GET() {
+  return NextResponse.json(getAllQuotes());
+}

--- a/src/app/api/sectors/route.ts
+++ b/src/app/api/sectors/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { ETF_UNIVERSE, getAllQuotes, Quote } from '@/lib/data-engine';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const period = searchParams.get('period') ?? '1d';
+  const key = `change_${period}` as keyof Quote;
+
+  const sectors: Record<string, {
+    sector: string;
+    change: number;
+    mcap: number;
+    etfs: { symbol: string; change: number }[];
+  }> = {};
+
+  for (const q of getAllQuotes()) {
+    const sec = q.sector as string;
+    if (!(sec in sectors)) {
+      sectors[sec] = { sector: sec, change: 0, mcap: 0, etfs: [] };
+    }
+    sectors[sec].etfs.push({ symbol: q.symbol as string, change: (q[key] as number) ?? 0 });
+    sectors[sec].mcap += q.mcap as number;
+  }
+
+  for (const data of Object.values(sectors)) {
+    const totalM = data.etfs.reduce((sum, e) => {
+      return sum + ((ETF_UNIVERSE as Record<string, { mcap: number }>)[e.symbol]?.mcap ?? 0);
+    }, 0);
+    data.change = totalM
+      ? Math.round(
+          (data.etfs.reduce((sum, e) => {
+            return sum + e.change * ((ETF_UNIVERSE as Record<string, { mcap: number }>)[e.symbol]?.mcap ?? 0);
+          }, 0) /
+            totalM) *
+            100
+        ) / 100
+      : 0;
+  }
+
+  return NextResponse.json(Object.values(sectors));
+}

--- a/src/app/api/strategy-backtest/route.ts
+++ b/src/app/api/strategy-backtest/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { runStrategyBacktest } from '@/lib/data-engine';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const period = searchParams.get('period') ?? '1y';
+  const topN = parseInt(searchParams.get('top_n') ?? '3', 10);
+  return NextResponse.json(runStrategyBacktest(period, topN));
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,1025 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* ── Reset & Variables ─────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg:        #0d1117;
+  --surface:   #161b22;
+  --surface2:  #1c2333;
+  --border:    #30363d;
+  --text:      #e6edf3;
+  --text-muted:#8b949e;
+  --accent:    #58a6ff;
+  --accent2:   #388bfd;
+  --pos:       #3fb950;
+  --neg:       #f85149;
+  --radius:    10px;
+  --radius-sm: 6px;
+  --shadow:    0 4px 16px rgba(0,0,0,0.4);
+}
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.5;
+  min-height: 100vh;
+}
+
+/* ── Top Bar ────────────────────────────────────────────────────── */
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.65rem 1.25rem;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  flex-wrap: wrap;
+}
+
+.topbar-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-right: auto;
+}
+.brand-icon { font-size: 1.3rem; }
+.brand-name {
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--text);
+  white-space: nowrap;
+}
+.brand-sub {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.topbar-period {
+  display: flex;
+  gap: 4px;
+  background: var(--bg);
+  border-radius: 8px;
+  padding: 3px;
+  border: 1px solid var(--border);
+}
+
+.period-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  font-weight: 500;
+  padding: 4px 9px;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  font-family: inherit;
+}
+.period-btn:hover { background: var(--surface2); color: var(--text); }
+.period-btn.active {
+  background: var(--accent2);
+  color: #fff;
+}
+
+.topbar-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.data-badge {
+  font-size: 0.7rem;
+  background: #2d333b;
+  color: #ffc107;
+  padding: 3px 8px;
+  border-radius: 20px;
+  border: 1px solid #4a3f1a;
+}
+.update-time {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+/* ── Tab Navigation ─────────────────────────────────────────────── */
+.tab-nav {
+  display: flex;
+  gap: 0;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 0 1rem;
+  overflow-x: auto;
+}
+
+.tab-btn {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 0.7rem 1.1rem;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+  font-family: inherit;
+}
+.tab-btn:hover { color: var(--text); }
+.tab-btn.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ── Tab Panels ─────────────────────────────────────────────────── */
+.tab-panel {
+  display: none;
+  padding: 1.25rem;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+.tab-panel.active { display: block; }
+
+/* ── Stat Cards Row ─────────────────────────────────────────────── */
+.stat-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.stat-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem 1.1rem;
+  transition: border-color 0.2s;
+}
+.stat-card:hover { border-color: var(--accent2); }
+
+.stat-label {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.4rem;
+}
+.stat-symbol {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 0.25rem;
+}
+.stat-change {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.2rem;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+}
+.stat-sector {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+/* ── Panels ─────────────────────────────────────────────────────── */
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.panel-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+.panel-header h2 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+}
+.panel-hint {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+/* ── Heatmap ────────────────────────────────────────────────────── */
+.heatmap-wrap {
+  width: 100%;
+  overflow: hidden;
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+}
+.heatmap-wrap canvas { display: block; }
+
+.heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+.legend-bar {
+  flex: 1;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(to right,
+    #a01010, #c83030, #1a1a1a, #1a4a1a, #0a8a0a);
+}
+.legend-label { white-space: nowrap; }
+
+/* ── Chart Wrappers ─────────────────────────────────────────────── */
+.chart-wrap { position: relative; }
+.chart-wrap.medium { height: 260px; }
+.chart-wrap.tall   { height: 360px; }
+
+/* ── ETF Table ──────────────────────────────────────────────────── */
+.table-wrap {
+  overflow-x: auto;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+
+.etf-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+}
+.etf-table th {
+  background: var(--surface2);
+  color: var(--text-muted);
+  font-weight: 500;
+  padding: 0.55rem 0.9rem;
+  text-align: left;
+  white-space: nowrap;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.etf-table td {
+  padding: 0.5rem 0.9rem;
+  border-top: 1px solid var(--border);
+  color: var(--text);
+}
+.etf-table tr:hover td { background: var(--surface2); }
+.name-cell {
+  color: var(--text-muted);
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mono { font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace; font-size: 0.82rem; }
+
+.icon-btn {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: color 0.15s, border-color 0.15s;
+}
+.icon-btn:hover { color: var(--text); border-color: var(--accent2); }
+
+/* ── Symbol Picker ──────────────────────────────────────────────── */
+.symbol-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-bottom: 1rem;
+}
+
+.sym-btn {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+}
+.sym-btn:hover {
+  border-color: var(--sc);
+  color: var(--text);
+}
+.sym-btn.active {
+  background: var(--sc, var(--accent));
+  border-color: var(--sc, var(--accent));
+  color: #fff;
+}
+
+/* ── Correlation Matrix ─────────────────────────────────────────── */
+.corr-wrap { overflow-x: auto; }
+
+.corr-table {
+  border-collapse: collapse;
+  font-size: 0.8rem;
+}
+.corr-table th, .corr-table td {
+  width: 60px;
+  height: 42px;
+  text-align: center;
+  border: 1px solid var(--border);
+}
+.corr-table th {
+  background: var(--surface2);
+  color: var(--text-muted);
+  font-weight: 500;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+}
+
+/* ── Backtest Builder ───────────────────────────────────────────── */
+.backtest-builder {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+  align-items: start;
+}
+
+.builder-controls { display: flex; flex-direction: column; gap: 0.4rem; }
+
+.field-label {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.bt-period-row, .template-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.bt-period-btn, .template-btn {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  font-size: 0.78rem;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.15s;
+}
+.bt-period-btn:hover, .template-btn:hover {
+  border-color: var(--accent2);
+  color: var(--text);
+}
+.bt-period-btn.active {
+  background: var(--accent2);
+  border-color: var(--accent2);
+  color: #fff;
+}
+
+.weight-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 350px;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+.weight-grid::-webkit-scrollbar { width: 4px; }
+.weight-grid::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+.weight-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 4px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--surface2);
+}
+.w-symbol {
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text);
+  width: 48px;
+  padding-left: 6px;
+}
+.w-slider {
+  flex: 1;
+  height: 4px;
+  accent-color: var(--accent2);
+  cursor: pointer;
+}
+.w-input {
+  width: 46px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-size: 0.78rem;
+  padding: 2px 5px;
+  text-align: right;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+}
+.w-input:focus { outline: none; border-color: var(--accent2); }
+.w-pct { font-size: 0.72rem; color: var(--text-muted); }
+
+.builder-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border);
+}
+
+.alloc-total {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+.alloc-warn {
+  color: #f97316;
+  font-size: 0.78rem;
+}
+.alloc-warn.hidden { display: none; }
+
+.run-btn {
+  background: var(--accent2);
+  border: none;
+  color: #fff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  padding: 8px 20px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background 0.15s;
+  font-family: inherit;
+  margin-left: auto;
+}
+.run-btn:hover:not(:disabled) { background: #1f6feb; }
+.run-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* ── Backtest Results ───────────────────────────────────────────── */
+.stats-row {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+.bt-stat {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem;
+  text-align: center;
+}
+.bt-stat-label {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  margin-bottom: 0.3rem;
+}
+.bt-stat-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+}
+
+.bt-composition { margin-top: 1.5rem; }
+
+.comp-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.comp-item {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+.comp-bar-wrap {
+  flex: 1;
+  height: 10px;
+  background: var(--bg);
+  border-radius: 5px;
+  overflow: hidden;
+}
+.comp-bar {
+  height: 100%;
+  border-radius: 5px;
+  transition: width 0.4s ease;
+}
+.comp-sym {
+  width: 40px;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text);
+  text-align: right;
+}
+.comp-pct {
+  width: 36px;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+/* ── Macro Flow Tab ─────────────────────────────────────────────── */
+.macro-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+  font-size: 0.82rem;
+}
+.bc-item {
+  color: var(--accent);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+.bc-item:hover { background: var(--surface2); }
+.bc-active { color: var(--text); font-weight: 600; cursor: default; }
+.bc-active:hover { background: transparent; }
+.bc-sep { color: var(--text-muted); }
+.bc-home { font-weight: 600; }
+
+.macro-summary {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+.macro-sum-item { display: flex; flex-direction: column; gap: 2px; }
+.macro-sum-label { font-size: 0.7rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.macro-sum-val   { font-size: 1.1rem; font-weight: 700; color: var(--text); }
+
+.macro-charts {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 1.5rem;
+  align-items: start;
+  margin-bottom: 1.5rem;
+}
+.macro-donut-wrap {
+  position: relative;
+  width: 260px;
+}
+.donut-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  pointer-events: none;
+}
+.donut-label { font-size: 0.68rem; color: var(--text-muted); text-transform: uppercase; }
+.donut-value { font-size: 1.05rem; font-weight: 700; color: var(--text); }
+.macro-bar-wrap { flex: 1; }
+
+.macro-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 0.6rem;
+}
+.macro-card {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  transition: border-color 0.2s, transform 0.15s;
+}
+.macro-card-drillable { cursor: pointer; }
+.macro-card-drillable:hover { border-color: var(--accent2); transform: translateY(-1px); }
+
+.macro-card-color { height: 3px; }
+.macro-card-body  { padding: 0.7rem; position: relative; }
+.macro-card-name  { font-size: 0.82rem; font-weight: 600; color: var(--text); margin-bottom: 0.3rem; }
+.macro-card-aum   { font-size: 1rem; font-weight: 700; color: var(--text); font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace; }
+.macro-card-pct   { font-size: 0.68rem; color: var(--text-muted); margin-bottom: 0.25rem; }
+.macro-card-change{ font-size: 0.88rem; font-weight: 600; font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace; }
+.macro-card-arrow { position: absolute; top: 0.6rem; right: 0.7rem; color: var(--accent); font-size: 1rem; }
+.macro-card-bar   { height: 4px; background: var(--bg); margin: 0 0.5rem 0.5rem; border-radius: 2px; }
+
+/* ── Strategy Comparison ─────────────────────────────────────────── */
+.strat-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border);
+}
+.strat-topn {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.topn-select {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 3px 6px;
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.82rem;
+}
+.strat-stat-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 1rem;
+}
+.strat-stat-row {
+  display: grid;
+  grid-template-columns: 110px repeat(3, 1fr);
+  gap: 4px;
+}
+.strat-header { margin-bottom: 6px; }
+.strat-col-head {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-align: center;
+  padding: 6px 4px;
+  background: var(--surface2);
+  border-radius: 4px;
+}
+.strat-row-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+}
+.strat-cell {
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-align: center;
+  padding: 6px 4px;
+  background: var(--surface2);
+  border-radius: 4px;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+}
+.strat-note {
+  margin-top: 1rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  padding: 0.75rem;
+  background: var(--surface2);
+  border-radius: var(--radius-sm);
+  border-left: 3px solid var(--accent2);
+}
+
+/* ── Hidden utility ─────────────────────────────────────────────── */
+.hidden { display: none !important; }
+
+/* ══════════════════════════════════════════════════════════════════
+   FLOW & CHIPS TAB
+══════════════════════════════════════════════════════════════════ */
+.flow-top-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+@media (max-width: 800px) { .flow-top-grid { grid-template-columns: 1fr; } }
+
+.chart-sublabel {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+.quadrant-legend {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px;
+  margin-top: 0.5rem;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+.ql { padding: 2px 6px; background: var(--surface2); border-radius: 4px; text-align: center; }
+.ql-tr, .ql-br { color: #4ade80; }
+.ql-tl, .ql-bl { color: #f87171; }
+
+/* ── Chip controls ─────────────────────────────────────────────── */
+.chip-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+.chip-select {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: var(--radius-sm);
+  padding: 5px 10px;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+.chip-select:focus { outline: none; border-color: var(--accent); }
+
+.chip-period-row, .chip-mode-row { display: flex; gap: 6px; }
+.cp-btn {
+  padding: 4px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: all 0.15s;
+}
+.cp-btn:hover { color: var(--text); border-color: var(--accent); }
+.cp-btn.active { background: var(--accent2); color: #fff; border-color: var(--accent2); }
+.cm-btn {
+  padding: 4px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: all 0.15s;
+}
+.cm-btn:hover { color: var(--text); border-color: var(--accent); }
+.cm-btn.active { background: #8e44ad; color: #fff; border-color: #8e44ad; }
+/* Network subtabs */
+.network-subtabs { display: flex; gap: 6px; margin-bottom: 0.75rem; }
+.nsb {
+  padding: 5px 16px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.82rem;
+  transition: all 0.15s;
+}
+.nsb:hover  { color: var(--text); border-color: var(--accent); }
+.nsb.active { background: var(--accent2); color: #fff; border-color: var(--accent2); }
+
+.chip-charts-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+@media (max-width: 800px) { .chip-charts-grid { grid-template-columns: 1fr; } }
+
+/* ── Network graph ─────────────────────────────────────────────── */
+.network-wrap {
+  width: 100%;
+  height: 440px;
+  background: var(--surface2);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+.network-wrap canvas { display: block; }
+
+/* ══════════════════════════════════════════════════════════════════
+   EVENTS & CYCLES TAB
+══════════════════════════════════════════════════════════════════ */
+
+/* ── Event filter chips ────────────────────────────────────────── */
+.event-filters {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+}
+.ef-btn {
+  padding: 5px 14px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: all 0.15s;
+}
+.ef-btn:hover  { color: var(--text); border-color: var(--accent); }
+.ef-btn.active { background: var(--accent2); color: #fff; border-color: var(--accent2); }
+
+/* ── Event timeline cards ──────────────────────────────────────── */
+.event-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 520px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+.ev-card {
+  display: flex;
+  border-radius: var(--radius-sm);
+  background: var(--surface2);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  transition: border-color 0.15s;
+}
+.ev-card:hover { border-color: var(--accent); }
+.ev-pos .ev-stripe { background: #3fb95066; }
+.ev-neg .ev-stripe { background: #f8514966; }
+.ev-neu .ev-stripe { background: #58a6ff33; }
+.ev-stripe { width: 4px; flex-shrink: 0; }
+.ev-body { padding: 10px 12px; flex: 1; }
+.ev-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
+}
+.ev-icon { font-size: 1rem; }
+.ev-date { font-size: 0.75rem; color: var(--text-muted); font-family: 'JetBrains Mono', monospace; }
+.ev-badge {
+  font-size: 0.68rem;
+  padding: 1px 7px;
+  border-radius: 10px;
+  color: #fff;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.ev-mag { font-size: 0.72rem; color: var(--text-muted); }
+.ev-title { font-size: 0.9rem; font-weight: 600; color: var(--text); margin-bottom: 3px; }
+.ev-detail { font-size: 0.78rem; color: var(--text-muted); margin-bottom: 6px; }
+.ev-sectors { display: flex; gap: 6px; flex-wrap: wrap; }
+.ev-sec-tag {
+  font-size: 0.7rem;
+  padding: 1px 7px;
+  border-radius: 10px;
+  border: 1px solid;
+  font-weight: 500;
+}
+
+/* ── Cycle heatmap ─────────────────────────────────────────────── */
+.cycle-heatmap-wrap {
+  overflow-x: auto;
+  background: var(--surface2);
+  border-radius: var(--radius-sm);
+  padding: 8px 4px 4px;
+}
+.cycle-heatmap-wrap canvas { display: block; }
+
+.cycle-tooltip {
+  position: fixed;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  font-size: 0.78rem;
+  pointer-events: none;
+  z-index: 9999;
+  white-space: nowrap;
+}
+
+/* ── Percentile ranks ──────────────────────────────────────────── */
+.percentile-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.perc-row {
+  display: grid;
+  grid-template-columns: 120px 1fr 48px auto;
+  align-items: center;
+  gap: 10px;
+}
+.perc-sector { font-size: 0.82rem; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.perc-bar-track {
+  height: 8px;
+  background: var(--surface2);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.perc-bar-fill { height: 100%; border-radius: 4px; transition: width 0.6s ease; }
+.perc-rank { font-size: 0.82rem; font-weight: 700; font-family: 'JetBrains Mono', monospace; text-align: right; }
+.perc-meta { display: flex; gap: 8px; font-size: 0.72rem; color: var(--text-muted); flex-wrap: wrap; }
+.perc-best  { color: #4ade80; }
+.perc-worst { color: #f87171; }
+
+/* ══════════════════════════════════════════════════════════════════
+   ETF MAPPING TABLE
+══════════════════════════════════════════════════════════════════ */
+.etfmap-controls {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+.etfmap-search {
+  width: 100%;
+  max-width: 320px;
+  padding: 7px 12px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+}
+.etfmap-search:focus { outline: none; border-color: var(--accent); }
+.etfmap-filters { display: flex; gap: 6px; flex-wrap: wrap; }
+
+.etfmap-table .sortable { cursor: pointer; user-select: none; white-space: nowrap; }
+.etfmap-table .sortable:hover { color: var(--accent); }
+.etfmap-row { cursor: pointer; transition: background 0.1s; }
+.etfmap-row:hover td { background: rgba(88,166,255,0.07); }
+
+.sym-badge {
+  display: inline-block;
+  padding: 2px 7px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  font-family: 'JetBrains Mono', monospace;
+}
+.sector-tag {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 0.7rem;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+}
+
+/* ── Loading Overlay ────────────────────────────────────────────── */
+.loader-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(13, 17, 23, 0.75);
+  backdrop-filter: blur(4px);
+  z-index: 999;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+.loader-overlay.active { display: flex; }
+
+.loader-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.loader-text { color: var(--text-muted); font-size: 0.85rem; }
+
+/* ── Scrollbar ──────────────────────────────────────────────────── */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+/* ── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .stat-row        { grid-template-columns: repeat(2, 1fr); }
+  .stats-row       { grid-template-columns: repeat(3, 1fr); }
+  .backtest-builder{ grid-template-columns: 1fr; }
+  .builder-controls{ flex-direction: row; flex-wrap: wrap; align-items: center; gap: 0.75rem; }
+  .macro-charts    { grid-template-columns: 1fr; }
+  .macro-donut-wrap{ width: 220px; margin: 0 auto; }
+  .strat-stat-row  { grid-template-columns: 80px repeat(3, 1fr); }
+}
+
+@media (max-width: 600px) {
+  .topbar       { padding: 0.5rem 0.75rem; gap: 0.5rem; }
+  .brand-sub    { display: none; }
+  .tab-panel    { padding: 0.75rem; }
+  .stat-row     { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .stats-row    { grid-template-columns: repeat(2, 1fr); }
+  .panel        { padding: 0.875rem; }
+  .chart-wrap.tall   { height: 280px; }
+  .chart-wrap.medium { height: 200px; }
+  .name-cell    { display: none; }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Fund Flow Dashboard | 全球資金流向',
+  description: 'Global capital flow analysis platform',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="zh-TW">
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" crossOrigin="anonymous" />
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" media="print" />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,139 @@
+'use client';
+import { useState, useEffect, useCallback } from 'react';
+import dynamic from 'next/dynamic';
+import TopBar from '@/components/layout/TopBar';
+import TabNav from '@/components/layout/TabNav';
+import Loader from '@/components/layout/Loader';
+import type { Quote, MacroNode, MockEvent, CycleRow, Period } from '@/types';
+
+// Dynamic imports to avoid SSR for canvas/chart components
+const MacroTab = dynamic(() => import('@/components/tabs/MacroTab'), {
+  ssr: false,
+});
+const OverviewTab = dynamic(() => import('@/components/tabs/OverviewTab'), {
+  ssr: false,
+});
+const TrendTab = dynamic(() => import('@/components/tabs/TrendTab'), {
+  ssr: false,
+});
+const BacktestTab = dynamic(() => import('@/components/tabs/BacktestTab'), {
+  ssr: false,
+});
+const FlowChipsTab = dynamic(() => import('@/components/tabs/FlowChipsTab'), {
+  ssr: false,
+});
+const CycleTab = dynamic(() => import('@/components/tabs/CycleTab'), {
+  ssr: false,
+});
+
+export default function DashboardPage() {
+  const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState('macro');
+  const [period, setPeriod] = useState<Period>('1d');
+  const [quotes, setQuotes] = useState<Quote[]>([]);
+  const [macroData, setMacroData] = useState<MacroNode | null>(null);
+  const [eventsData, setEventsData] = useState<MockEvent[] | null>(null);
+  const [cycleData, setCycleData] = useState<CycleRow[] | null>(null);
+  const [updateTime, setUpdateTime] = useState('—');
+  // Trend tab selected symbols
+  const [selected, setSelected] = useState<string[]>([
+    'QQQ',
+    'XLK',
+    'GLD',
+    'TLT',
+    'VNQ',
+    'IBIT',
+  ]);
+
+  const fetchMacro = useCallback(async (p: Period): Promise<MacroNode> => {
+    const r = await fetch(`/api/macro?period=${p}`);
+    return r.json() as Promise<MacroNode>;
+  }, []);
+
+  useEffect(() => {
+    setLoading(true);
+    Promise.all([
+      fetch('/api/quotes').then(r => r.json()) as Promise<Quote[]>,
+      fetchMacro(period),
+      fetch('/api/events').then(r => r.json()) as Promise<MockEvent[]>,
+      fetch('/api/cycle').then(r => r.json()) as Promise<CycleRow[]>,
+    ])
+      .then(([q, m, e, c]) => {
+        setQuotes(q);
+        setMacroData(m);
+        setEventsData(e);
+        setCycleData(c);
+        setUpdateTime(
+          '更新於 ' + new Date().toLocaleTimeString('zh-TW'),
+        );
+      })
+      .finally(() => setLoading(false));
+    // Run only once on mount — period is intentionally excluded
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Refresh macro when period changes (skip if quotes not loaded yet)
+  useEffect(() => {
+    if (!quotes.length) return;
+    fetchMacro(period).then(setMacroData);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [period]);
+
+  // 60s auto-refresh of quotes
+  useEffect(() => {
+    const id = setInterval(async () => {
+      const q = (await fetch('/api/quotes').then(r =>
+        r.json(),
+      )) as Quote[];
+      setQuotes(q);
+      setUpdateTime('更新於 ' + new Date().toLocaleTimeString('zh-TW'));
+    }, 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  function handleSelectSymbolForTrend(sym: string) {
+    setSelected(prev => {
+      if (prev.includes(sym)) return prev;
+      return prev.length >= 6 ? [...prev.slice(1), sym] : [...prev, sym];
+    });
+    setActiveTab('trends');
+  }
+
+  return (
+    <>
+      <TopBar
+        period={period}
+        onPeriodChange={setPeriod}
+        updateTime={updateTime}
+      />
+      <TabNav activeTab={activeTab} onTabChange={setActiveTab} />
+      <Loader show={loading} />
+      {activeTab === 'macro' && (
+        <MacroTab macroData={macroData} period={period} />
+      )}
+      {activeTab === 'overview' && (
+        <OverviewTab
+          quotes={quotes}
+          period={period}
+          onSelectSymbolForTrend={handleSelectSymbolForTrend}
+        />
+      )}
+      {activeTab === 'trends' && (
+        <TrendTab
+          quotes={quotes}
+          eventsData={eventsData}
+          period={period}
+          selected={selected}
+          onSelectedChange={setSelected}
+        />
+      )}
+      {activeTab === 'backtest' && <BacktestTab quotes={quotes} />}
+      {activeTab === 'flow' && (
+        <FlowChipsTab quotes={quotes} period={period} />
+      )}
+      {activeTab === 'cycle' && (
+        <CycleTab eventsData={eventsData} cycleData={cycleData} />
+      )}
+    </>
+  );
+}

--- a/src/components/layout/Loader.tsx
+++ b/src/components/layout/Loader.tsx
@@ -1,0 +1,9 @@
+interface Props { show: boolean }
+export default function Loader({ show }: Props) {
+  return show ? (
+    <div className="loader-overlay active">
+      <div className="loader-spinner" />
+      <div className="loader-text">載入市場數據中…</div>
+    </div>
+  ) : null;
+}

--- a/src/components/layout/TabNav.tsx
+++ b/src/components/layout/TabNav.tsx
@@ -1,0 +1,27 @@
+'use client';
+interface Props {
+  activeTab: string;
+  onTabChange: (tab: string) => void;
+}
+
+const TABS = [
+  { id: 'macro',    label: '🌐 Macro Flow' },
+  { id: 'overview', label: '📊 Overview' },
+  { id: 'trends',   label: '📈 Trend Analysis' },
+  { id: 'backtest', label: '🔬 Backtest' },
+  { id: 'flow',     label: '📡 Flow & Chips' },
+  { id: 'cycle',    label: '📅 Events & Cycles' },
+];
+
+export default function TabNav({ activeTab, onTabChange }: Props) {
+  return (
+    <nav className="tab-nav">
+      {TABS.map(t => (
+        <button key={t.id} className={`tab-btn${activeTab === t.id ? ' active' : ''}`}
+          onClick={() => onTabChange(t.id)}>
+          {t.label}
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,0 +1,34 @@
+'use client';
+import type { Period } from '@/types';
+
+const PERIODS: Period[] = ['1d', '5d', '1m', '3m', '6m', '1y', 'ytd'];
+
+interface Props {
+  period: Period;
+  onPeriodChange: (p: Period) => void;
+  updateTime: string;
+}
+
+export default function TopBar({ period, onPeriodChange, updateTime }: Props) {
+  return (
+    <header className="topbar">
+      <div className="topbar-brand">
+        <span className="brand-icon">⚡</span>
+        <span className="brand-name">Fund Flow</span>
+        <span className="brand-sub">全球資金流向分析</span>
+      </div>
+      <div className="topbar-period" id="periodBar">
+        {PERIODS.map(p => (
+          <button key={p} className={`period-btn${period === p ? ' active' : ''}`}
+            onClick={() => onPeriodChange(p)}>
+            {p.toUpperCase()}
+          </button>
+        ))}
+      </div>
+      <div className="topbar-meta">
+        <span className="data-badge">⚙ Mock Data</span>
+        <span className="update-time">{updateTime}</span>
+      </div>
+    </header>
+  );
+}

--- a/src/components/tabs/BacktestTab.tsx
+++ b/src/components/tabs/BacktestTab.tsx
@@ -1,0 +1,506 @@
+'use client';
+import { useState } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  LineElement,
+  PointElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+  Filler,
+} from 'chart.js';
+import { SECTOR_COLORS, fmtPct } from '@/lib/utils/colors';
+import { TEMPLATES } from '@/types';
+import type { Quote } from '@/types';
+
+ChartJS.register(
+  LineElement,
+  PointElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+  Filler,
+);
+
+interface IndexedPoint {
+  date: string;
+  value: number;
+}
+
+interface StatsResult {
+  total_return: number;
+  cagr: number;
+  sharpe: number;
+  max_drawdown: number;
+}
+
+interface BacktestResult {
+  portfolio: IndexedPoint[];
+  benchmark: IndexedPoint[];
+  stats: (StatsResult & { spy_return: number }) | null;
+}
+
+interface StrategyResult {
+  momentum: IndexedPoint[];
+  equal_weight: IndexedPoint[];
+  spy: IndexedPoint[];
+  theme_names: Record<string, string>;
+  stats: {
+    momentum: StatsResult | null;
+    equal_weight: StatsResult | null;
+    spy: StatsResult | null;
+  };
+}
+
+interface Props {
+  quotes: Quote[];
+}
+
+export default function BacktestTab({ quotes }: Props) {
+  // Strategy section
+  const [scPeriod, setScPeriod] = useState('1y');
+  const [topN, setTopN] = useState(3);
+  const [stratData, setStratData] = useState<StrategyResult | null>(null);
+  const [stratLoading, setStratLoading] = useState(false);
+
+  // Custom backtest section
+  const [btPeriod, setBtPeriod] = useState('1y');
+  const [weights, setWeights] = useState<Record<string, number>>(() => ({
+    ...TEMPLATES.balanced,
+  }));
+  const [btData, setBtData] = useState<BacktestResult | null>(null);
+  const [btLoading, setBtLoading] = useState(false);
+
+  const nonSpy = quotes.filter(q => q.symbol !== 'SPY');
+  const allSyms = nonSpy.map(q => q.symbol);
+
+  const getWeight = (sym: string) => weights[sym] ?? 0;
+  const allocTotal = allSyms.reduce((s, sym) => s + getWeight(sym), 0);
+
+  function setWeight(sym: string, val: number) {
+    setWeights(prev => ({ ...prev, [sym]: Math.max(0, Math.min(100, val)) }));
+  }
+
+  function applyTemplate(tpl: string) {
+    const tplW = TEMPLATES[tpl] ?? {};
+    const next: Record<string, number> = {};
+    allSyms.forEach(sym => {
+      next[sym] = tplW[sym] ?? 0;
+    });
+    setWeights(next);
+  }
+
+  async function runStrategy() {
+    setStratLoading(true);
+    setStratData(null);
+    try {
+      const r = await fetch(
+        `/api/strategy-backtest?period=${scPeriod}&top_n=${topN}`,
+      );
+      setStratData(await r.json());
+    } finally {
+      setStratLoading(false);
+    }
+  }
+
+  async function runBacktest() {
+    if (Math.round(allocTotal) !== 100) return;
+    setBtLoading(true);
+    setBtData(null);
+    const active = allSyms
+      .filter(s => getWeight(s) > 0)
+      .map(s => `${s}:${getWeight(s)}`)
+      .join(',');
+    try {
+      const r = await fetch(`/api/backtest?weights=${active}&period=${btPeriod}`);
+      setBtData(await r.json());
+    } finally {
+      setBtLoading(false);
+    }
+  }
+
+  const lineOpts: Record<string, unknown> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: 'index', intersect: false },
+    plugins: {
+      legend: { labels: { color: '#e2e8f0', font: { size: 12 } } },
+      tooltip: {
+        callbacks: {
+          label: (ctx: { dataset: { label: string }; raw: number | null }) =>
+            ` ${ctx.dataset.label}: ${ctx.raw?.toFixed(2)}`,
+        },
+      },
+    },
+    scales: {
+      x: {
+        ticks: { color: '#64748b', maxTicksLimit: 12, maxRotation: 0 },
+        grid: { color: 'rgba(255,255,255,0.04)' },
+      },
+      y: {
+        ticks: {
+          color: '#94a3b8',
+          callback: (v: unknown) => (v as number).toFixed(0),
+        },
+        grid: { color: 'rgba(255,255,255,0.06)' },
+        title: {
+          display: true,
+          text: '指數化報酬（起點=100）',
+          color: '#64748b',
+        },
+      },
+    },
+  };
+
+  const STRATS = [
+    { key: 'momentum' as const, label: `動量輪動 (Top${topN})`, color: '#4ade80' },
+    { key: 'equal_weight' as const, label: '等權重', color: '#60a5fa' },
+    { key: 'spy' as const, label: 'SPY 大盤', color: '#94a3b8' },
+  ];
+
+  const STAT_ROWS = [
+    { key: 'total_return' as const, label: '總報酬' },
+    { key: 'cagr' as const, label: '年化 CAGR' },
+    { key: 'sharpe' as const, label: 'Sharpe Ratio' },
+    { key: 'max_drawdown' as const, label: '最大回撤' },
+  ];
+
+  return (
+    <main className="tab-panel active">
+      {/* Strategy Comparison */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>策略比較</h2>
+          <span className="panel-hint">動量輪動 vs 等權重 vs SPY 大盤</span>
+        </div>
+        <div className="strat-controls">
+          <div className="bt-period-row">
+            {['1y', '3y', '5y'].map(p => (
+              <button
+                key={p}
+                className={`sc-period-btn${scPeriod === p ? ' active' : ''}`}
+                onClick={() => setScPeriod(p)}
+              >
+                {p === '1y' ? '1 年' : p === '3y' ? '3 年' : '5 年'}
+              </button>
+            ))}
+          </div>
+          <div className="strat-topn">
+            每次輪動持有前
+            <select
+              className="topn-select"
+              value={topN}
+              onChange={e => setTopN(+e.target.value)}
+            >
+              {[1, 2, 3, 5].map(n => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+            強勢主題
+          </div>
+          <button
+            className="run-btn"
+            style={{ marginLeft: 'auto' }}
+            onClick={runStrategy}
+            disabled={stratLoading}
+          >
+            {stratLoading ? '計算中…' : '▶ 執行比較'}
+          </button>
+        </div>
+
+        {stratData && (
+          <div>
+            <div className="strat-stat-grid">
+              <div className="strat-stat-row strat-header">
+                <div></div>
+                {STRATS.map(s => (
+                  <div
+                    key={s.key}
+                    className="strat-col-head"
+                    style={{ color: s.color }}
+                  >
+                    {s.label}
+                  </div>
+                ))}
+              </div>
+              {STAT_ROWS.map(m => (
+                <div key={m.key} className="strat-stat-row">
+                  <div className="strat-row-label">{m.label}</div>
+                  {STRATS.map(s => {
+                    const statsForKey = stratData.stats[s.key];
+                    const raw =
+                      statsForKey !== null && statsForKey !== undefined
+                        ? (statsForKey as unknown as Record<string, number>)[m.key] ?? 0
+                        : 0;
+                    const isDD = m.key === 'max_drawdown';
+                    const pos = isDD
+                      ? raw < 10
+                      : m.key === 'sharpe'
+                        ? raw >= 1
+                        : raw >= 0;
+                    const disp = isDD
+                      ? `-${raw.toFixed(2)}%`
+                      : m.key === 'sharpe'
+                        ? raw.toFixed(2)
+                        : fmtPct(raw);
+                    return (
+                      <div
+                        key={s.key}
+                        className="strat-cell"
+                        style={{ color: pos ? '#4ade80' : '#f87171' }}
+                      >
+                        {disp}
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+            <div className="chart-wrap tall" style={{ marginTop: '1.25rem' }}>
+              <Line
+                data={{
+                  labels: stratData.spy.map(p => p.date),
+                  datasets: STRATS.map(s => ({
+                    label: s.label,
+                    data: stratData[s.key].map(p => p.value),
+                    borderColor: s.color,
+                    backgroundColor: s.color + '18',
+                    borderWidth: s.key === 'spy' ? 1.5 : 2.5,
+                    borderDash: s.key === 'spy' ? [5, 5] : [],
+                    fill: s.key === 'momentum',
+                    pointRadius: 0,
+                    tension: 0.3,
+                    spanGaps: true,
+                  })),
+                }}
+                options={lineOpts}
+              />
+            </div>
+            <div className="strat-note">
+              <strong>動量輪動：</strong>
+              每 21 個交易日，依過去一個月報酬選出前 N
+              強板塊，等權重持有至下次調倉。
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Custom Backtest */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>自訂組合回測</h2>
+          <span className="panel-hint">
+            配置各 ETF 權重，系統計算歷史績效並與 S&P 500 比較
+          </span>
+        </div>
+        <div className="backtest-builder">
+          <div className="builder-controls">
+            <label className="field-label">回測區間</label>
+            <div className="bt-period-row">
+              {['1y', '3y', '5y'].map(p => (
+                <button
+                  key={p}
+                  className={`bt-period-btn${btPeriod === p ? ' active' : ''}`}
+                  onClick={() => setBtPeriod(p)}
+                >
+                  {p === '1y' ? '1 年' : p === '3y' ? '3 年' : '5 年'}
+                </button>
+              ))}
+            </div>
+            <label className="field-label" style={{ marginTop: '1rem' }}>
+              快速模板
+            </label>
+            <div className="template-row">
+              {['aggressive', 'balanced', 'defensive', 'crypto'].map(tpl => (
+                <button
+                  key={tpl}
+                  className="template-btn"
+                  onClick={() => applyTemplate(tpl)}
+                >
+                  {tpl === 'aggressive'
+                    ? '進攻型'
+                    : tpl === 'balanced'
+                      ? '均衡型'
+                      : tpl === 'defensive'
+                        ? '防禦型'
+                        : '加密貨幣'}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="weight-grid">
+            {allSyms.map(sym => {
+              const w = getWeight(sym);
+              const q = quotes.find(q => q.symbol === sym);
+              const color = SECTOR_COLORS[q?.sector ?? ''] ?? '#888';
+              return (
+                <div key={sym} className="weight-row">
+                  <span
+                    className="w-symbol"
+                    style={{ borderLeft: `3px solid ${color}` }}
+                  >
+                    {sym}
+                  </span>
+                  <input
+                    type="range"
+                    className="w-slider"
+                    min={0}
+                    max={100}
+                    step={5}
+                    value={w}
+                    onChange={e => setWeight(sym, +e.target.value)}
+                  />
+                  <input
+                    type="number"
+                    className="w-input"
+                    min={0}
+                    max={100}
+                    step={5}
+                    value={w}
+                    onChange={e => setWeight(sym, +e.target.value)}
+                  />
+                  <span className="w-pct">%</span>
+                </div>
+              );
+            })}
+          </div>
+          <div className="builder-actions">
+            <div className="alloc-total">
+              已配置：<span>{Math.round(allocTotal)}</span>%{' '}
+              {Math.round(allocTotal) !== 100 && (
+                <span className="alloc-warn">需配置 100%</span>
+              )}
+            </div>
+            <button
+              className="run-btn"
+              onClick={runBacktest}
+              disabled={btLoading || Math.round(allocTotal) !== 100}
+            >
+              {btLoading ? '計算中…' : '▶ 執行回測'}
+            </button>
+          </div>
+        </div>
+
+        {btData && btData.stats && (
+          <div>
+            <div className="stats-row">
+              {[
+                {
+                  label: '總報酬率',
+                  val: fmtPct(btData.stats.total_return),
+                  pos: btData.stats.total_return >= 0,
+                },
+                {
+                  label: '年化報酬 CAGR',
+                  val: fmtPct(btData.stats.cagr),
+                  pos: btData.stats.cagr >= 0,
+                },
+                {
+                  label: 'Sharpe Ratio',
+                  val: btData.stats.sharpe.toFixed(2),
+                  pos: btData.stats.sharpe >= 1,
+                },
+                {
+                  label: '最大回撤',
+                  val: `-${btData.stats.max_drawdown.toFixed(2)}%`,
+                  pos: false,
+                },
+                {
+                  label: 'SPY 報酬',
+                  val: fmtPct(btData.stats.spy_return),
+                  pos: btData.stats.spy_return >= 0,
+                },
+                {
+                  label: '超額報酬',
+                  val: fmtPct(
+                    btData.stats.total_return - btData.stats.spy_return,
+                  ),
+                  pos:
+                    btData.stats.total_return > btData.stats.spy_return,
+                },
+              ].map(s => (
+                <div key={s.label} className="bt-stat">
+                  <div className="bt-stat-label">{s.label}</div>
+                  <div
+                    className="bt-stat-value"
+                    style={{ color: s.pos ? '#4ade80' : '#f87171' }}
+                  >
+                    {s.val}
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="chart-wrap tall" style={{ marginTop: '1.5rem' }}>
+              <Line
+                data={{
+                  labels: btData.portfolio.map(p => p.date),
+                  datasets: [
+                    {
+                      label: '我的組合',
+                      data: btData.portfolio.map(p => p.value),
+                      borderColor: '#4a90e2',
+                      backgroundColor: '#4a90e222',
+                      borderWidth: 2.5,
+                      fill: true,
+                      pointRadius: 0,
+                      tension: 0.3,
+                    },
+                    {
+                      label: 'SPY (標普500)',
+                      data: btData.benchmark.map(b => b.value),
+                      borderColor: '#94a3b8',
+                      backgroundColor: 'transparent',
+                      borderWidth: 1.5,
+                      borderDash: [5, 5],
+                      pointRadius: 0,
+                      tension: 0.3,
+                    },
+                  ],
+                }}
+                options={lineOpts}
+              />
+            </div>
+            <div className="bt-composition">
+              <h3
+                style={{
+                  color: '#94a3b8',
+                  fontSize: '0.85rem',
+                  marginBottom: '0.75rem',
+                }}
+              >
+                組合配置
+              </h3>
+              <div className="comp-grid">
+                {allSyms
+                  .filter(sym => getWeight(sym) > 0)
+                  .sort((a, b) => getWeight(b) - getWeight(a))
+                  .map(sym => {
+                    const w = getWeight(sym);
+                    const q = quotes.find(q => q.symbol === sym);
+                    const col = SECTOR_COLORS[q?.sector ?? ''] ?? '#888';
+                    return (
+                      <div key={sym} className="comp-item">
+                        <div className="comp-bar-wrap">
+                          <div
+                            className="comp-bar"
+                            style={{ width: `${w}%`, background: col }}
+                          />
+                        </div>
+                        <span className="comp-sym">{sym}</span>
+                        <span className="comp-pct">{w}%</span>
+                      </div>
+                    );
+                  })}
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/components/tabs/CycleTab.tsx
+++ b/src/components/tabs/CycleTab.tsx
@@ -1,0 +1,284 @@
+'use client';
+import { useState, useEffect, useRef } from 'react';
+import { changeColor, changeTextColor, fmtPct, SECTOR_COLORS } from '@/lib/utils/colors';
+import type { MockEvent, CycleRow } from '@/types';
+
+const EVENT_COLORS: Record<string, string> = {
+  fed: '#4a90e2',
+  macro: '#27ae60',
+  earnings: '#f7931a',
+  geopolitical: '#e74c3c',
+};
+const EVENT_ICONS: Record<string, string> = {
+  fed: '🏦',
+  macro: '📊',
+  earnings: '📈',
+  geopolitical: '🌐',
+};
+
+// ── Cycle Heatmap Canvas ─────────────────────────────────────────
+interface HeatmapTooltip {
+  text: string;
+  x: number;
+  y: number;
+}
+
+function CycleHeatmapCanvas({ cycleData }: { cycleData: CycleRow[] }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [tooltip, setTooltip] = useState<HeatmapTooltip | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !cycleData.length) return;
+    const wrapper = canvas.parentElement!;
+    const allMonths = [
+      ...new Set(cycleData.flatMap(d => Object.keys(d.monthly_returns))),
+    ].sort();
+    const sectors = cycleData.map(d => d.sector);
+    const LABEL_W = 110;
+    const CELL_H = 30;
+    const CELL_W = Math.max(
+      34,
+      Math.floor((wrapper.clientWidth - LABEL_W - 16) / allMonths.length),
+    );
+    const TOP_H = 36;
+    canvas.width = LABEL_W + allMonths.length * CELL_W + 4;
+    canvas.height = TOP_H + sectors.length * CELL_H + 4;
+    canvas.style.width = canvas.width + 'px';
+    canvas.style.height = canvas.height + 'px';
+    const ctx = canvas.getContext('2d')!;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    ctx.fillStyle = '#8b949e';
+    ctx.font = '10px Inter,sans-serif';
+    ctx.textAlign = 'center';
+    allMonths.forEach((m, j) => {
+      ctx.fillText(m.slice(2), LABEL_W + j * CELL_W + CELL_W / 2, TOP_H - 8);
+    });
+
+    sectors.forEach((sec, i) => {
+      const row = cycleData[i];
+      const y = TOP_H + i * CELL_H;
+      ctx.fillStyle = '#cdd9e5';
+      ctx.font = '11px Inter,sans-serif';
+      ctx.textAlign = 'right';
+      ctx.fillText(sec, LABEL_W - 6, y + CELL_H / 2 + 4);
+      allMonths.forEach((m, j) => {
+        const val = row.monthly_returns[m];
+        const x = LABEL_W + j * CELL_W;
+        ctx.fillStyle =
+          val === undefined ? '#1c2333' : changeColor(val * 0.5, 0.85);
+        ctx.fillRect(x + 1, y + 1, CELL_W - 2, CELL_H - 2);
+        if (val !== undefined && CELL_W > 38) {
+          ctx.fillStyle = Math.abs(val) > 2 ? '#fff' : '#cdd9e5';
+          ctx.font = '9px Inter,sans-serif';
+          ctx.textAlign = 'center';
+          ctx.fillText(fmtPct(val, false), x + CELL_W / 2, y + CELL_H / 2 + 3);
+        }
+      });
+    });
+
+    canvas.onmousemove = (ev: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      const mx = ev.clientX - rect.left;
+      const my = ev.clientY - rect.top;
+      const j = Math.floor((mx - LABEL_W) / CELL_W);
+      const i = Math.floor((my - TOP_H) / CELL_H);
+      if (i < 0 || i >= sectors.length || j < 0 || j >= allMonths.length) {
+        setTooltip(null);
+        return;
+      }
+      const val = cycleData[i].monthly_returns[allMonths[j]];
+      if (val === undefined) {
+        setTooltip(null);
+        return;
+      }
+      setTooltip({
+        text: `${sectors[i]} · ${allMonths[j]} → ${fmtPct(val)}`,
+        x: ev.clientX + 12,
+        y: ev.clientY - 28,
+      });
+    };
+    canvas.onmouseleave = () => setTooltip(null);
+  }, [cycleData]);
+
+  return (
+    <div className="cycle-heatmap-wrap">
+      <canvas ref={canvasRef} />
+      {tooltip && (
+        <div
+          className="cycle-tooltip"
+          style={{ position: 'fixed', left: tooltip.x, top: tooltip.y }}
+        >
+          {tooltip.text}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main CycleTab ────────────────────────────────────────────────
+interface Props {
+  eventsData: MockEvent[] | null;
+  cycleData: CycleRow[] | null;
+}
+
+export default function CycleTab({ eventsData, cycleData }: Props) {
+  const [eventTypeFilter, setEventTypeFilter] = useState('all');
+
+  const filteredEvents = (eventsData ?? [])
+    .filter(e => eventTypeFilter === 'all' || e.type === eventTypeFilter)
+    .slice()
+    .reverse();
+
+  const sortedCycle = cycleData
+    ? [...cycleData].sort((a, b) => b.percentile_rank - a.percentile_rank)
+    : [];
+
+  return (
+    <main className="tab-panel active">
+      {/* Event Timeline */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>重大市場事件時間軸</h2>
+          <span className="panel-hint">點選事件卡查看詳情與受影響板塊</span>
+        </div>
+        <div className="event-filters">
+          {(
+            [
+              ['all', '全部'],
+              ['fed', 'Fed/央行'],
+              ['macro', '總體經濟'],
+              ['earnings', '財報/科技'],
+              ['geopolitical', '地緣政治'],
+            ] as [string, string][]
+          ).map(([t, l]) => (
+            <button
+              key={t}
+              className={`ef-btn${eventTypeFilter === t ? ' active' : ''}`}
+              onClick={() => setEventTypeFilter(t)}
+            >
+              {l}
+            </button>
+          ))}
+        </div>
+        <div className="event-timeline">
+          {filteredEvents.map((ev, idx) => (
+            <div
+              key={idx}
+              className={`ev-card ${
+                ev.magnitude > 0
+                  ? 'ev-pos'
+                  : ev.magnitude < 0
+                    ? 'ev-neg'
+                    : 'ev-neu'
+              }`}
+            >
+              <div
+                className="ev-stripe"
+                style={{ background: EVENT_COLORS[ev.type] ?? '#58a6ff' }}
+              />
+              <div className="ev-body">
+                <div className="ev-top">
+                  <span className="ev-icon">
+                    {EVENT_ICONS[ev.type] ?? '📌'}
+                  </span>
+                  <span className="ev-date">{ev.date}</span>
+                  <span
+                    className="ev-badge"
+                    style={{
+                      background: EVENT_COLORS[ev.type] ?? '#58a6ff',
+                    }}
+                  >
+                    {ev.type}
+                  </span>
+                  <span className="ev-mag">
+                    {'★'.repeat(Math.abs(ev.magnitude)) || '—'}
+                    {ev.magnitude < 0 ? ' 利空' : ' 利多'}
+                  </span>
+                </div>
+                <div className="ev-title">{ev.title}</div>
+                <div className="ev-detail">{ev.detail}</div>
+                <div className="ev-sectors">
+                  {ev.sectors.map(s => (
+                    <span
+                      key={s}
+                      className="ev-sec-tag"
+                      style={{
+                        borderColor: SECTOR_COLORS[s] ?? '#444',
+                        color: SECTOR_COLORS[s] ?? '#ccc',
+                      }}
+                    >
+                      {s}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Cycle Heatmap */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>板塊歷史月份熱力圖</h2>
+          <span className="panel-hint">
+            各板塊過去 ~25 個月漲跌幅 — 顏色越深代表漲跌越大
+          </span>
+        </div>
+        {cycleData && <CycleHeatmapCanvas cycleData={cycleData} />}
+      </section>
+
+      {/* Percentile Ranks */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>52 週百分位排名</h2>
+          <span className="panel-hint">
+            目前1年期報酬在過去 2 年歷史中的相對位置，100 = 歷史最高
+          </span>
+        </div>
+        <div className="percentile-grid">
+          {sortedCycle.map(d => {
+            const clr =
+              d.percentile_rank >= 70
+                ? '#4ade80'
+                : d.percentile_rank >= 40
+                  ? '#fbbf24'
+                  : '#f87171';
+            return (
+              <div key={d.sector} className="perc-row">
+                <div className="perc-sector" style={{ color: d.color }}>
+                  {d.sector}
+                </div>
+                <div className="perc-bar-track">
+                  <div
+                    className="perc-bar-fill"
+                    style={{ width: `${d.percentile_rank}%`, background: clr }}
+                  />
+                </div>
+                <div className="perc-rank" style={{ color: clr }}>
+                  {d.percentile_rank}%
+                </div>
+                <div className="perc-meta">
+                  <span
+                    title="1Y Return"
+                    style={{ color: changeTextColor(d.current_1y) }}
+                  >
+                    {fmtPct(d.current_1y)} 1Y
+                  </span>
+                  <span className="perc-best">
+                    ↑ {d.best_months.join('/')}
+                  </span>
+                  <span className="perc-worst">
+                    ↓ {d.worst_months.join('/')}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/tabs/FlowChipsTab.tsx
+++ b/src/components/tabs/FlowChipsTab.tsx
@@ -1,0 +1,772 @@
+'use client';
+import { useState, useEffect, useRef } from 'react';
+import { Bubble, Bar, Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  ArcElement,
+  BarElement,
+  BubbleController,
+  LineElement,
+  PointElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+  Filler,
+} from 'chart.js';
+import { SECTOR_COLORS, changeColor } from '@/lib/utils/colors';
+import type { Quote, ChipRow, FlowMatrix } from '@/types';
+
+ChartJS.register(
+  ArcElement,
+  BarElement,
+  BubbleController,
+  LineElement,
+  PointElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+  Filler,
+);
+
+interface Props {
+  quotes: Quote[];
+  period: string;
+}
+
+// ── Network Correlation Canvas ──────────────────────────────────
+interface NetworkNode {
+  id: string;
+  i: number;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  r: number;
+  color: string;
+  label: string;
+}
+
+interface NetworkEdge {
+  i: number;
+  j: number;
+  c: number;
+}
+
+function NetworkCorrCanvas({ data }: { data: FlowMatrix }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const runningRef = useRef(false);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.width = canvas.parentElement?.clientWidth || 700;
+    canvas.height = canvas.parentElement?.clientHeight || 420;
+    const W = canvas.width;
+    const H = canvas.height;
+    const ctx = canvas.getContext('2d')!;
+    const n = data.sectors.length;
+
+    runningRef.current = false;
+    const timerId = setTimeout(() => {
+      runningRef.current = true;
+      const nodes: NetworkNode[] = data.sectors.map((sec, i) => {
+        const angle = (2 * Math.PI * i) / n;
+        return {
+          id: sec,
+          i,
+          x: W / 2 + W * 0.35 * Math.cos(angle),
+          y: H / 2 + H * 0.35 * Math.sin(angle),
+          vx: 0,
+          vy: 0,
+          r: Math.max(18, Math.sqrt(data.mcaps[i] || 1) * 2.2),
+          color: SECTOR_COLORS[sec] || '#58a6ff',
+          label: sec,
+        };
+      });
+
+      const edges: NetworkEdge[] = [];
+      for (let i = 0; i < n; i++) {
+        for (let j = i + 1; j < n; j++) {
+          const c = data.rotation_matrix[i][j];
+          if (Math.abs(c) > 0.25) edges.push({ i, j, c });
+        }
+      }
+
+      const K_REPEL = 8000;
+      const K_ATTRACT = 0.04;
+      const DAMPING = 0.82;
+      const DT = 0.9;
+      let frame = 0;
+
+      function tick() {
+        if (!runningRef.current) return;
+        frame++;
+        for (let a = 0; a < n; a++) {
+          let fx = (W / 2 - nodes[a].x) * 0.004;
+          let fy = (H / 2 - nodes[a].y) * 0.004;
+          for (let b = 0; b < n; b++) {
+            if (a === b) continue;
+            const dx = nodes[a].x - nodes[b].x;
+            const dy = nodes[a].y - nodes[b].y;
+            const dist2 = dx * dx + dy * dy + 1;
+            const f = K_REPEL / dist2;
+            fx += (f * dx) / Math.sqrt(dist2);
+            fy += (f * dy) / Math.sqrt(dist2);
+          }
+          edges.forEach(e => {
+            if (e.i !== a && e.j !== a) return;
+            const b = e.i === a ? e.j : e.i;
+            const dx = nodes[b].x - nodes[a].x;
+            const dy = nodes[b].y - nodes[a].y;
+            const str = Math.abs(e.c) * K_ATTRACT;
+            fx += dx * str;
+            fy += dy * str;
+          });
+          nodes[a].vx = (nodes[a].vx + fx * DT) * DAMPING;
+          nodes[a].vy = (nodes[a].vy + fy * DT) * DAMPING;
+        }
+        nodes.forEach(nd => {
+          nd.x = Math.max(nd.r + 2, Math.min(W - nd.r - 2, nd.x + nd.vx));
+          nd.y = Math.max(nd.r + 2, Math.min(H - nd.r - 2, nd.y + nd.vy));
+        });
+        ctx.clearRect(0, 0, W, H);
+        edges.forEach(e => {
+          ctx.save();
+          ctx.globalAlpha = Math.min(0.8, Math.abs(e.c));
+          ctx.strokeStyle = e.c > 0 ? '#4a90e2' : '#e67e22';
+          ctx.lineWidth = Math.abs(e.c) * 3;
+          ctx.beginPath();
+          ctx.moveTo(nodes[e.i].x, nodes[e.i].y);
+          ctx.lineTo(nodes[e.j].x, nodes[e.j].y);
+          ctx.stroke();
+          ctx.restore();
+        });
+        nodes.forEach(nd => {
+          ctx.beginPath();
+          ctx.arc(nd.x, nd.y, nd.r, 0, Math.PI * 2);
+          ctx.fillStyle = nd.color + 'cc';
+          ctx.fill();
+          ctx.strokeStyle = nd.color;
+          ctx.lineWidth = 1.5;
+          ctx.stroke();
+          ctx.fillStyle = '#fff';
+          ctx.font = `bold ${Math.max(9, Math.min(12, nd.r * 0.55))}px Inter,sans-serif`;
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.fillText(
+            nd.label.length > 8 ? nd.label.slice(0, 7) + '…' : nd.label,
+            nd.x,
+            nd.y,
+          );
+        });
+        if (frame < 180) requestAnimationFrame(tick);
+        else runningRef.current = false;
+      }
+      requestAnimationFrame(tick);
+    }, 10);
+
+    return () => {
+      runningRef.current = false;
+      clearTimeout(timerId);
+    };
+  }, [data]);
+
+  return <canvas ref={canvasRef} style={{ width: '100%', height: '100%' }} />;
+}
+
+// ── Rotation Flow Canvas ─────────────────────────────────────────
+function RotationFlowCanvas({ data }: { data: FlowMatrix }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.width = canvas.parentElement?.clientWidth || 700;
+    canvas.height = canvas.parentElement?.clientHeight || 420;
+    const W = canvas.width;
+    const H = canvas.height;
+    const ctx = canvas.getContext('2d')!;
+    ctx.clearRect(0, 0, W, H);
+    const n = data.sectors.length;
+    const R = Math.min(W, H) * 0.38;
+
+    const nodes = data.sectors.map((sec, i) => {
+      const angle = (2 * Math.PI * i) / n - Math.PI / 2;
+      return {
+        id: sec,
+        i,
+        x: W / 2 + R * Math.cos(angle),
+        y: H / 2 + R * Math.sin(angle),
+        score: data.flow_scores[i],
+        mcap: data.mcaps[i] || 1,
+        color: SECTOR_COLORS[sec] || '#58a6ff',
+      };
+    });
+
+    const sorted = [...nodes].sort((a, b) => b.score - a.score);
+    const inflow = sorted.slice(0, 3);
+    const outflow = sorted.slice(-3);
+
+    function drawArrow(
+      x1: number,
+      y1: number,
+      x2: number,
+      y2: number,
+      color: string,
+      alpha: number,
+      width: number,
+    ) {
+      const dx = x2 - x1;
+      const dy = y2 - y1;
+      const len = Math.sqrt(dx * dx + dy * dy);
+      if (len < 1) return;
+      const nx = dx / len;
+      const ny = dy / len;
+      const nr = 22;
+      const sx = x1 + nx * nr;
+      const sy = y1 + ny * nr;
+      const ex = x2 - nx * nr;
+      const ey = y2 - ny * nr;
+      const cx2 = (sx + ex) / 2 - ny * len * 0.18;
+      const cy2 = (sy + ey) / 2 + nx * len * 0.18;
+      ctx.save();
+      ctx.globalAlpha = alpha;
+      ctx.strokeStyle = color;
+      ctx.lineWidth = width;
+      ctx.beginPath();
+      ctx.moveTo(sx, sy);
+      ctx.quadraticCurveTo(cx2, cy2, ex, ey);
+      ctx.stroke();
+      const tx = ex - nx * 8 + ny * 5;
+      const ty = ey - ny * 8 - nx * 5;
+      const tx2 = ex - nx * 8 - ny * 5;
+      const ty2 = ey - ny * 8 + nx * 5;
+      ctx.beginPath();
+      ctx.moveTo(ex, ey);
+      ctx.lineTo(tx, ty);
+      ctx.lineTo(tx2, ty2);
+      ctx.fillStyle = color;
+      ctx.fill();
+      ctx.restore();
+    }
+
+    outflow.forEach(out => {
+      inflow.forEach(inn => {
+        if (out.id === inn.id) return;
+        const str = Math.min(1, (Math.abs(out.score) + inn.score) / 20);
+        drawArrow(
+          out.x,
+          out.y,
+          inn.x,
+          inn.y,
+          '#f7931a',
+          0.25 + str * 0.45,
+          1 + str * 2.5,
+        );
+      });
+    });
+
+    nodes.forEach(nd => {
+      const r = Math.max(18, Math.sqrt(nd.mcap) * 1.8);
+      ctx.beginPath();
+      ctx.arc(nd.x, nd.y, r, 0, Math.PI * 2);
+      ctx.fillStyle = nd.color + 'cc';
+      ctx.fill();
+      ctx.strokeStyle = inflow.some(n => n.id === nd.id)
+        ? '#4ade80'
+        : outflow.some(n => n.id === nd.id)
+          ? '#f87171'
+          : nd.color;
+      ctx.lineWidth =
+        inflow.some(n => n.id === nd.id) || outflow.some(n => n.id === nd.id)
+          ? 2.5
+          : 1;
+      ctx.stroke();
+      ctx.fillStyle = '#fff';
+      const fs = Math.max(9, Math.min(11, r * 0.55));
+      ctx.font = `bold ${fs}px Inter,sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(
+        nd.id.length > 8 ? nd.id.slice(0, 7) + '…' : nd.id,
+        nd.x,
+        nd.y - 3,
+      );
+      ctx.font = `${Math.max(8, fs - 1)}px Inter,sans-serif`;
+      ctx.fillStyle = nd.score > 0 ? '#4ade80' : '#f87171';
+      ctx.fillText((nd.score > 0 ? '+' : '') + nd.score, nd.x, nd.y + 8);
+    });
+
+    ctx.globalAlpha = 1;
+    ctx.font = '11px Inter,sans-serif';
+    ctx.fillStyle = '#4ade80';
+    ctx.textAlign = 'left';
+    ctx.fillText('→ 資金流入（綠框）', 12, H - 28);
+    ctx.fillStyle = '#f87171';
+    ctx.fillText('← 資金流出（紅框）', 12, H - 12);
+  }, [data]);
+
+  return <canvas ref={canvasRef} style={{ width: '100%', height: '100%' }} />;
+}
+
+// ── Main FlowChipsTab ────────────────────────────────────────────
+export default function FlowChipsTab({ quotes, period }: Props) {
+  const [flowData, setFlowData] = useState<FlowMatrix | null>(null);
+  const [flowPeriod, setFlowPeriod] = useState<string>('');
+  const [chipsData, setChipsData] = useState<ChipRow[] | null>(null);
+  const [chipsPeriod, setChipsPeriod] = useState('1m');
+  const [chipSector, setChipSector] = useState('Technology');
+  const [chipMode, setChipMode] = useState<'us' | 'tw'>('us');
+  const [networkTab, setNetworkTab] = useState<'corr' | 'flow'>('corr');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (flowPeriod === period && flowData) return;
+    setLoading(true);
+    fetch(`/api/flow-matrix?period=${period}`)
+      .then(r => r.json())
+      .then((d: FlowMatrix) => {
+        setFlowData(d);
+        setFlowPeriod(period);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [period]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    fetch(`/api/chips?period=${chipsPeriod}`)
+      .then(r => r.json())
+      .then((d: ChipRow[]) => setChipsData(d));
+  }, [chipsPeriod]);
+
+  if (loading || !flowData) {
+    return (
+      <main className="tab-panel active">
+        <div className="panel">
+          <p style={{ color: '#64748b' }}>載入中…</p>
+        </div>
+      </main>
+    );
+  }
+
+  const n = flowData.sectors.length;
+
+  const bubbleDatasets = flowData.sectors.map((sec, i) => ({
+    label: sec,
+    data: [
+      {
+        x: n - i,
+        y: flowData.volume_ratios[i],
+        r: Math.max(6, Math.sqrt(flowData.mcaps[i] || 1) * 1.8),
+      },
+    ],
+    backgroundColor: changeColor(flowData.flow_scores[i], 0.7),
+    borderColor: changeColor(flowData.flow_scores[i], 1),
+    borderWidth: 1.5,
+  }));
+
+  const quadrantPlugin = {
+    id: 'quadrantLines',
+    afterDraw(chart: ChartJS) {
+      const c = chart as unknown as {
+        ctx: CanvasRenderingContext2D;
+        chartArea: { left: number; right: number; top: number; bottom: number };
+        scales: {
+          x: { getPixelForValue: (v: number) => number };
+          y: { getPixelForValue: (v: number) => number };
+        };
+      };
+      const { ctx, chartArea: { left, right, top, bottom }, scales: { x, y } } = c;
+      const mx = x.getPixelForValue((n + 1) / 2);
+      const my = y.getPixelForValue(1);
+      ctx.save();
+      ctx.strokeStyle = 'rgba(139,148,158,0.25)';
+      ctx.setLineDash([5, 4]);
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(mx, top);
+      ctx.lineTo(mx, bottom);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.moveTo(left, my);
+      ctx.lineTo(right, my);
+      ctx.stroke();
+      ctx.restore();
+    },
+  };
+
+  const flowSorted = flowData.sectors
+    .map((s, i) => ({ s, v: flowData.flow_scores[i] }))
+    .sort((a, b) => a.v - b.v);
+
+  const scoreBarData = {
+    labels: flowSorted.map(d => d.s),
+    datasets: [
+      {
+        data: flowSorted.map(d => d.v),
+        backgroundColor: flowSorted.map(d => changeColor(d.v, 0.75)),
+        borderColor: flowSorted.map(d => changeColor(d.v, 1)),
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  const barOpts: Record<string, unknown> = {
+    indexAxis: 'y',
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (c: { raw: number }) =>
+            ` Flow Score: ${c.raw > 0 ? '+' : ''}${c.raw}`,
+        },
+      },
+    },
+    scales: {
+      x: { ticks: { color: '#8b949e' }, grid: { color: '#21262d' } },
+      y: {
+        ticks: { color: '#cdd9e5', font: { size: 11 } },
+        grid: { color: '#21262d' },
+      },
+    },
+    animation: { duration: 300 },
+  };
+
+  // Chip charts
+  const chipRow =
+    chipsData?.find(c => c.sector === chipSector) ?? chipsData?.[0] ?? null;
+  const sectors = [
+    ...new Set((chipsData ?? []).map(c => c.sector)),
+  ].sort();
+  const isTW = chipMode === 'tw';
+  const chipLabels = isTW
+    ? ['外資', '投信', '自營商']
+    : ['機構法人', '聰明錢', '散戶'];
+  const secEtf = quotes.find(
+    q => q.sector === chipRow?.sector && q.symbol !== 'SPY',
+  );
+
+  return (
+    <main className="tab-panel active">
+      {/* Flow Direction */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>資金流向分析</h2>
+          <span className="panel-hint">
+            代理指標：動能 × 成交量異常 推估各板塊資金流向
+          </span>
+        </div>
+        <div className="flow-top-grid">
+          <div>
+            <div className="chart-sublabel">板塊輪動象限圖</div>
+            <div className="chart-wrap" style={{ height: '340px' }}>
+              <Bubble
+                data={{ datasets: bubbleDatasets }}
+                options={{
+                  responsive: true,
+                  maintainAspectRatio: false,
+                  plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                      callbacks: {
+                        label: (ctx: import('chart.js').TooltipItem<'bubble'>) => {
+                          const d = ctx.raw as { x: number; y: number; r: number };
+                          const sec = ctx.dataset.label ?? '';
+                          const score =
+                            flowData.flow_scores[
+                              flowData.sectors.indexOf(sec)
+                            ];
+                          return `${sec} | 動能排名:${d.x} | 成交量比:${d.y.toFixed(2)}x | 流向:${score > 0 ? '+' : ''}${score}`;
+                        },
+                      },
+                    },
+                  },
+                  scales: {
+                    x: {
+                      title: {
+                        display: true,
+                        text: '動能排名 →（右=資金流入）',
+                        color: '#8b949e',
+                      },
+                      ticks: { color: '#8b949e' },
+                      grid: { color: '#21262d' },
+                      min: 0,
+                      max: n + 1,
+                    },
+                    y: {
+                      title: {
+                        display: true,
+                        text: '成交量比率（vs 30日均）',
+                        color: '#8b949e',
+                      },
+                      ticks: { color: '#8b949e' },
+                      grid: { color: '#21262d' },
+                    },
+                  },
+                  animation: { duration: 400 },
+                }}
+                plugins={[quadrantPlugin as unknown as import('chart.js').Plugin]}
+              />
+            </div>
+            <div className="quadrant-legend">
+              <span className="ql ql-tr">↗ 強勢流入</span>
+              <span className="ql ql-tl">↖ 高量洗盤</span>
+              <span className="ql ql-br">↘ 整理蓄勢</span>
+              <span className="ql ql-bl">↙ 弱勢流出</span>
+            </div>
+          </div>
+          <div>
+            <div className="chart-sublabel">板塊資金流向強度</div>
+            <div className="chart-wrap" style={{ height: '340px' }}>
+              <Bar data={scoreBarData} options={barOpts} />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Institutional Chips */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>法人籌碼</h2>
+          <span className="panel-hint">
+            模擬三大法人每日淨買超，單位：百萬美元
+          </span>
+        </div>
+        <div className="chip-controls">
+          <label className="field-label">板塊：</label>
+          <select
+            className="chip-select"
+            value={chipSector}
+            onChange={e => setChipSector(e.target.value)}
+          >
+            {sectors.map(s => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+          <div className="chip-period-row">
+            {['1m', '3m', '6m'].map(p => (
+              <button
+                key={p}
+                className={`cp-btn${chipsPeriod === p ? ' active' : ''}`}
+                onClick={() => setChipsPeriod(p)}
+              >
+                {p.toUpperCase()}
+              </button>
+            ))}
+          </div>
+          <div className="chip-mode-row">
+            {(
+              [
+                ['us', '🇺🇸 美式'],
+                ['tw', '🇹🇼 台式'],
+              ] as const
+            ).map(([m, l]) => (
+              <button
+                key={m}
+                className={`cm-btn${chipMode === m ? ' active' : ''}`}
+                onClick={() => setChipMode(m)}
+              >
+                {l}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {chipRow && (
+          <div className="chip-charts-grid">
+            <div>
+              <div className="chart-sublabel">每日淨買超（$M）</div>
+              <div className="chart-wrap" style={{ height: '260px' }}>
+                <Bar
+                  data={{
+                    labels: chipRow.dates,
+                    datasets: [
+                      {
+                        label: chipLabels[0],
+                        data: chipRow.institutional,
+                        backgroundColor: 'rgba(74,144,226,0.75)',
+                        stack: 's',
+                      },
+                      {
+                        label: chipLabels[1],
+                        data: chipRow.smart_money,
+                        backgroundColor: 'rgba(142,68,173,0.65)',
+                        stack: 's',
+                      },
+                      {
+                        label: chipLabels[2],
+                        data: chipRow.retail,
+                        backgroundColor: 'rgba(231,76,60,0.55)',
+                        stack: 's',
+                      },
+                    ],
+                  }}
+                  options={
+                    {
+                      responsive: true,
+                      maintainAspectRatio: false,
+                      plugins: {
+                        legend: {
+                          labels: { color: '#8b949e', boxWidth: 12 },
+                        },
+                      },
+                      scales: {
+                        x: {
+                          ticks: {
+                            color: '#8b949e',
+                            maxTicksLimit: 8,
+                            maxRotation: 30,
+                          },
+                          grid: { color: '#21262d' },
+                          stacked: true,
+                        },
+                        y: {
+                          ticks: { color: '#8b949e' },
+                          grid: { color: '#21262d' },
+                          stacked: true,
+                          title: {
+                            display: true,
+                            text: '$M',
+                            color: '#8b949e',
+                          },
+                        },
+                      },
+                      animation: { duration: 300 },
+                    } as Record<string, unknown>
+                  }
+                />
+              </div>
+            </div>
+            <div>
+              <div className="chart-sublabel">累積機構籌碼 vs ETF 價格</div>
+              <div className="chart-wrap" style={{ height: '260px' }}>
+                <Line
+                  data={{
+                    labels: chipRow.dates,
+                    datasets: [
+                      {
+                        label: isTW ? '累積外資買超' : '累積機構買超',
+                        data: chipRow.cumulative,
+                        borderColor: '#4a90e2',
+                        backgroundColor: 'rgba(74,144,226,0.12)',
+                        fill: true,
+                        tension: 0.3,
+                        yAxisID: 'y',
+                        pointRadius: 0,
+                      },
+                      ...(secEtf
+                        ? [
+                            {
+                              label: `${secEtf.symbol} 現價`,
+                              data: chipRow.dates.map(() => secEtf.price),
+                              borderColor: '#f7931a',
+                              borderDash: [4, 3],
+                              pointRadius: 0,
+                              yAxisID: 'y2',
+                              backgroundColor: 'transparent',
+                              tension: 0.3,
+                            },
+                          ]
+                        : []),
+                    ],
+                  }}
+                  options={
+                    {
+                      responsive: true,
+                      maintainAspectRatio: false,
+                      plugins: {
+                        legend: {
+                          labels: { color: '#8b949e', boxWidth: 12 },
+                        },
+                      },
+                      scales: {
+                        x: {
+                          ticks: {
+                            color: '#8b949e',
+                            maxTicksLimit: 8,
+                            maxRotation: 30,
+                          },
+                          grid: { color: '#21262d' },
+                        },
+                        y: {
+                          ticks: { color: '#4a90e2' },
+                          grid: { color: '#21262d' },
+                          position: 'left',
+                          title: {
+                            display: true,
+                            text: '累積 $M',
+                            color: '#4a90e2',
+                          },
+                        },
+                        y2: {
+                          ticks: { color: '#f7931a' },
+                          grid: { display: false },
+                          position: 'right',
+                          title: {
+                            display: true,
+                            text: 'ETF 價格',
+                            color: '#f7931a',
+                          },
+                        },
+                      },
+                      animation: { duration: 300 },
+                    } as Record<string, unknown>
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Network Graph */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>板塊關係圖</h2>
+        </div>
+        <div className="network-subtabs">
+          {(
+            [
+              ['corr', '🕸 相關性網絡'],
+              ['flow', '↗ 資金輪動流向'],
+            ] as const
+          ).map(([k, l]) => (
+            <button
+              key={k}
+              className={`nsb${networkTab === k ? ' active' : ''}`}
+              onClick={() => setNetworkTab(k)}
+            >
+              {l}
+            </button>
+          ))}
+        </div>
+        {networkTab === 'corr' && (
+          <div>
+            <div className="panel-hint" style={{ marginBottom: '0.75rem' }}>
+              基於近1年月報酬相關性 — 藍線=正相關，橘線=負相關，節點大小=AUM
+            </div>
+            <div className="network-wrap">
+              <NetworkCorrCanvas data={flowData} />
+            </div>
+          </div>
+        )}
+        {networkTab === 'flow' && (
+          <div>
+            <div className="panel-hint" style={{ marginBottom: '0.75rem' }}>
+              箭頭方向 = 資金估計流出（紅）→ 流入（綠）板塊，根據流向強度差異繪製
+            </div>
+            <div className="network-wrap">
+              <RotationFlowCanvas data={flowData} />
+            </div>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/components/tabs/MacroTab.tsx
+++ b/src/components/tabs/MacroTab.tsx
@@ -1,0 +1,212 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { Doughnut, Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS, ArcElement, BarElement, CategoryScale, LinearScale,
+  Tooltip, Legend, type TooltipItem,
+} from 'chart.js';
+import { changeColor, changeTextColor, fmtPct } from '@/lib/utils/colors';
+import type { MacroNode, Period } from '@/types';
+
+ChartJS.register(ArcElement, BarElement, CategoryScale, LinearScale, Tooltip, Legend);
+
+function findNode(tree: MacroNode, id: string): MacroNode | null {
+  if (tree.id === id) return tree;
+  for (const c of tree.children ?? []) {
+    const found = findNode(c, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+interface Props {
+  macroData: MacroNode | null;
+  period: Period;
+}
+
+export default function MacroTab({ macroData, period }: Props) {
+  const [macroPath, setMacroPath] = useState<string[]>(['global']);
+
+  // Reset path when period changes
+  useEffect(() => { setMacroPath(['global']); }, [period]);
+
+  if (!macroData) return <div className="panel"><p style={{color:'#64748b'}}>載入中…</p></div>;
+
+  const currentId = macroPath[macroPath.length - 1];
+  const current = findNode(macroData, currentId) ?? macroData;
+  const totalAum = current.children?.length
+    ? current.children.reduce((s, c) => s + c.aum, 0)
+    : current.aum;
+  const children = (current.children?.length ? current.children : [current])
+    .slice().sort((a, b) => b.aum - a.aum);
+
+  function drillDown(nodeId: string) {
+    setMacroPath(prev => [...prev, nodeId]);
+  }
+  function breadcrumbClick(nodeId: string) {
+    const idx = macroPath.indexOf(nodeId);
+    if (idx >= 0) setMacroPath(macroPath.slice(0, idx + 1));
+  }
+
+  // Donut chart data
+  const donutData = {
+    labels: children.map(c => c.name),
+    datasets: [{
+      data: children.map(c => c.aum),
+      backgroundColor: children.map(c => c.color + 'cc'),
+      borderColor: children.map(c => c.color),
+      borderWidth: 2,
+    }],
+  };
+  const donutOptions = {
+    responsive: true, maintainAspectRatio: true, cutout: '65%',
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (ctx: TooltipItem<'doughnut'>) =>
+            ` ${ctx.label}: ${(ctx.raw as number) >= 1 ? (ctx.raw as number).toFixed(1)+'T' : ((ctx.raw as number)*1000).toFixed(0)+'B'} USD`,
+        },
+      },
+    },
+  };
+
+  // Bar chart data (sorted by change)
+  const sorted = [...children].sort((a, b) => b.change - a.change);
+  const barData = {
+    labels: sorted.map(c => c.name),
+    datasets: [{
+      label: '漲跌 %',
+      data: sorted.map(c => c.change),
+      backgroundColor: sorted.map(c => changeColor(c.change, 0.85)),
+      borderColor: sorted.map(c => changeColor(c.change, 1)),
+      borderWidth: 1, borderRadius: 4,
+    }],
+  };
+  const barOptions = {
+    indexAxis: 'y' as const,
+    responsive: true, maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: { callbacks: { label: (ctx: { raw: unknown }) => ` ${fmtPct(ctx.raw as number)}` } }
+    },
+    scales: {
+      x: {
+        grid: { color: 'rgba(255,255,255,0.05)' },
+        ticks: { color: '#94a3b8', callback: (v: string | number) => fmtPct(v as number) }
+      },
+      y: {
+        grid: { display: false },
+        ticks: { color: '#e2e8f0', font: { size: 11 } }
+      }
+    }
+  };
+
+  const etfs = current.etf_quotes ?? [];
+
+  return (
+    <main className="tab-panel active">
+      <section className="panel">
+        <div className="macro-breadcrumb">
+          {macroPath.map((id, i) => {
+            const node = findNode(macroData, id) ?? { name: id };
+            const isActive = i === macroPath.length - 1;
+            return (
+              <span key={id}>
+                {i > 0 && <span className="bc-sep">›</span>}
+                <span
+                  className={`bc-item${isActive ? ' bc-active' : ''} bc-home`}
+                  onClick={() => breadcrumbClick(id)}
+                >{node.name}</span>
+              </span>
+            );
+          })}
+        </div>
+
+        <div className="macro-summary">
+          <div className="macro-sum-item">
+            <span className="macro-sum-label">管理資產規模</span>
+            <span className="macro-sum-val">{totalAum.toFixed(1)} 兆美元</span>
+          </div>
+          <div className="macro-sum-item">
+            <span className="macro-sum-label">期間漲跌</span>
+            <span className="macro-sum-val" style={{color: changeTextColor(current.change)}}>{fmtPct(current.change)}</span>
+          </div>
+          <div className="macro-sum-item">
+            <span className="macro-sum-label">子類別數</span>
+            <span className="macro-sum-val">{current.children?.length ?? 0}</span>
+          </div>
+        </div>
+
+        <div className="macro-charts">
+          <div className="macro-donut-wrap">
+            <Doughnut data={donutData} options={donutOptions} />
+            <div className="donut-center">
+              <div className="donut-label">全球 AUM</div>
+              <div className="donut-value">{totalAum.toFixed(1)} T</div>
+            </div>
+          </div>
+          <div className="macro-bar-wrap">
+            <div className="panel-header" style={{marginBottom:'0.5rem'}}>
+              <h2>{current.name} — 子類別漲跌</h2>
+              <span className="panel-hint">依漲跌幅排序</span>
+            </div>
+            <div className="chart-wrap" style={{height:'300px'}}>
+              <Bar data={barData} options={barOptions} />
+            </div>
+          </div>
+        </div>
+
+        <div className="macro-cards">
+          {children.map(c => {
+            const hasChildren = (c.children?.length ?? 0) > 0;
+            const pct = c.aum / totalAum * 100;
+            return (
+              <div
+                key={c.id}
+                className={`macro-card${hasChildren ? ' macro-card-drillable' : ''}`}
+                onClick={() => hasChildren && drillDown(c.id)}
+                title={hasChildren ? '點擊深入查看' : ''}
+              >
+                <div className="macro-card-color" style={{background: c.color}} />
+                <div className="macro-card-body">
+                  <div className="macro-card-name">{c.name}</div>
+                  <div className="macro-card-aum">{c.aum >= 1 ? c.aum.toFixed(1)+'T' : (c.aum*1000).toFixed(0)+'B'}</div>
+                  <div className="macro-card-pct">{pct.toFixed(1)}% of total</div>
+                  <div className="macro-card-change" style={{color: changeTextColor(c.change)}}>{fmtPct(c.change)}</div>
+                  {hasChildren && <div className="macro-card-arrow">›</div>}
+                </div>
+                <div className="macro-card-bar">
+                  <div style={{width:`${Math.min(100,pct*3)}%`, background:changeColor(c.change,0.8), height:'100%', borderRadius:'2px'}} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {etfs.length > 0 && (
+          <div>
+            <div className="panel-header" style={{marginTop:'1.5rem'}}>
+              <h2>{current.name} — 代表 ETF</h2>
+            </div>
+            <div className="table-wrap">
+              <table className="etf-table">
+                <thead><tr><th>代碼</th><th>名稱</th><th>現價</th><th>漲跌 %</th></tr></thead>
+                <tbody>
+                  {etfs.map(e => (
+                    <tr key={e.symbol}>
+                      <td><strong>{e.symbol}</strong></td>
+                      <td className="name-cell">{e.name}</td>
+                      <td className="mono">${e.price.toFixed(2)}</td>
+                      <td className="mono" style={{color: changeTextColor(e.change)}}>{fmtPct(e.change)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/components/tabs/OverviewTab.tsx
+++ b/src/components/tabs/OverviewTab.tsx
@@ -1,0 +1,461 @@
+'use client';
+import { useRef, useEffect, useState } from 'react';
+import { Bar } from 'react-chartjs-2';
+import { Chart as ChartJS, BarElement, CategoryScale, LinearScale, Tooltip, Legend } from 'chart.js';
+import { SECTOR_COLORS, changeColor, changeTextColor, fmtPct } from '@/lib/utils/colors';
+import type { Quote, Period } from '@/types';
+
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend);
+
+// ── Squarify ────────────────────────────────────────────────────
+interface RectItem {
+  symbol: string; name: string; sector: string;
+  value: number; change: number;
+  x: number; y: number; w: number; h: number;
+}
+
+interface EtfInput {
+  symbol: string; name: string; sector: string; value: number; change: number;
+}
+
+interface SecItem {
+  sector: string; value: number; etfs: EtfInput[];
+  x?: number; y?: number; w?: number; h?: number;
+}
+
+function squarify(items: EtfInput[], x: number, y: number, w: number, h: number): RectItem[] {
+  const rects: RectItem[] = [];
+
+  function row(its: EtfInput[], rx: number, ry: number, rw: number, rh: number) {
+    const rt = its.reduce((s, i) => s + i.value, 0);
+    let cx = rx;
+    its.forEach(item => {
+      const fw = (item.value / rt) * rw;
+      rects.push({ ...item, x: cx, y: ry, w: fw, h: rh });
+      cx += fw;
+    });
+  }
+
+  function layoutETFs(etfs: EtfInput[], x0: number, y0: number, w0: number, h0: number) {
+    if (!etfs.length) return;
+    if (etfs.length === 1) {
+      rects.push({ ...etfs[0], x: x0, y: y0, w: w0, h: h0 });
+      return;
+    }
+    const total0 = etfs.reduce((s, e) => s + e.value, 0);
+    const half = total0 / 2;
+    let acc = 0, split = 1;
+    for (let k = 0; k < etfs.length - 1; k++) {
+      acc += etfs[k].value;
+      if (acc >= half) { split = k + 1; break; }
+    }
+    const first = etfs.slice(0, split);
+    const rest = etfs.slice(split);
+    const frac = first.reduce((s, e) => s + e.value, 0) / total0;
+    if (w0 >= h0) {
+      const fw = w0 * frac;
+      row(first, x0, y0, fw, h0);
+      layoutETFs(rest, x0 + fw, y0, w0 - fw, h0);
+    } else {
+      const fh = h0 * frac;
+      row(first, x0, y0, w0, fh);
+      layoutETFs(rest, x0, y0 + fh, w0, h0 - fh);
+    }
+  }
+
+  const sectors: Record<string, SecItem> = {};
+  items.forEach(it => {
+    if (!sectors[it.sector]) sectors[it.sector] = { sector: it.sector, value: 0, etfs: [] };
+    sectors[it.sector].etfs.push(it);
+    sectors[it.sector].value += it.value;
+  });
+  const secItems = Object.values(sectors).sort((a, b) => b.value - a.value);
+
+  function layoutSectors(its: SecItem[], x0: number, y0: number, w0: number, h0: number) {
+    if (!its.length) return;
+    if (its.length === 1) {
+      its[0].x = x0; its[0].y = y0; its[0].w = w0; its[0].h = h0;
+      return;
+    }
+    const total0 = its.reduce((s, i) => s + i.value, 0);
+    const half = total0 / 2;
+    let acc = 0, split = 1;
+    for (let k = 0; k < its.length - 1; k++) {
+      acc += its[k].value;
+      if (acc >= half) { split = k + 1; break; }
+    }
+    const first = its.slice(0, split);
+    const rest = its.slice(split);
+    const frac = first.reduce((s, i) => s + i.value, 0) / total0;
+    if (w0 >= h0) {
+      const fw = w0 * frac;
+      const ft = first.reduce((s, i) => s + i.value, 0);
+      let cx = x0;
+      first.forEach(i => { const iw = (i.value / ft) * fw; i.x = cx; i.y = y0; i.w = iw; i.h = h0; cx += iw; });
+      layoutSectors(rest, x0 + fw, y0, w0 - fw, h0);
+    } else {
+      const fh = h0 * frac;
+      const ft = first.reduce((s, i) => s + i.value, 0);
+      let cy = y0;
+      first.forEach(i => { const ih = (i.value / ft) * fh; i.x = x0; i.y = cy; i.w = w0; i.h = ih; cy += ih; });
+      layoutSectors(rest, x0, y0 + fh, w0, h0 - fh);
+    }
+  }
+
+  layoutSectors(secItems, x, y, w, h);
+
+  secItems.forEach(sr => {
+    if (sr.w === undefined || sr.h === undefined) return;
+    const PAD = 2;
+    const inner = { x: sr.x! + PAD, y: sr.y! + PAD, w: sr.w - PAD * 2, h: sr.h - PAD * 2 };
+    if (inner.w < 1 || inner.h < 1) return;
+    layoutETFs(sr.etfs.slice().sort((a, b) => b.value - a.value), inner.x, inner.y, inner.w, inner.h);
+  });
+
+  return rects;
+}
+
+// ── HeatmapCanvas component ──────────────────────────────────────
+function HeatmapCanvas({ quotes, period }: { quotes: Quote[]; period: Period }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !quotes.length) return;
+    const wrap = canvas.parentElement;
+    if (!wrap) return;
+    const W = wrap.clientWidth || 900;
+    const H = Math.max(360, Math.min(500, W * 0.45));
+    canvas.width = W * devicePixelRatio;
+    canvas.height = H * devicePixelRatio;
+    canvas.style.width = W + 'px';
+    canvas.style.height = H + 'px';
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.scale(devicePixelRatio, devicePixelRatio);
+    ctx.clearRect(0, 0, W, H);
+
+    const key = `change_${period}` as keyof Quote;
+    const items: EtfInput[] = quotes
+      .filter(q => q.symbol !== 'SPY')
+      .map(q => ({
+        symbol: q.symbol,
+        name: q.name,
+        sector: q.sector,
+        value: q.mcap,
+        change: (q[key] as number) ?? 0,
+      }));
+
+    const rects = squarify(items, 0, 0, W, H);
+    rects.forEach(r => {
+      if (!r.symbol || r.w < 2 || r.h < 2) return;
+      const PAD = 1;
+      const rx = r.x + PAD, ry = r.y + PAD, rw = r.w - PAD * 2, rh = r.h - PAD * 2;
+      if (rw < 1 || rh < 1) return;
+      ctx.fillStyle = changeColor(r.change, 0.85);
+      ctx.beginPath();
+      ctx.roundRect(rx, ry, rw, rh, 3);
+      ctx.fill();
+      ctx.strokeStyle = 'rgba(255,255,255,0.06)';
+      ctx.lineWidth = 0.5;
+      ctx.stroke();
+      if (rw < 28 || rh < 18) return;
+      ctx.fillStyle = '#e2e8f0';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      const fontSize = Math.max(8, Math.min(14, rw / 5, rh / 3));
+      ctx.font = `600 ${fontSize}px Inter, sans-serif`;
+      const cx = rx + rw / 2, cy = ry + rh / 2;
+      if (rh > 36) {
+        ctx.fillText(r.symbol, cx, cy - fontSize * 0.6);
+        const cf = Math.max(7, fontSize * 0.85);
+        ctx.font = `500 ${cf}px JetBrains Mono, monospace`;
+        ctx.fillStyle = r.change >= 0 ? '#86efac' : '#fca5a5';
+        ctx.fillText(fmtPct(r.change), cx, cy + cf * 0.8);
+      } else {
+        ctx.fillText(r.symbol, cx, cy);
+      }
+    });
+  }, [quotes, period]);
+
+  return (
+    <div className="heatmap-wrap">
+      <canvas ref={canvasRef} />
+    </div>
+  );
+}
+
+// ── Main OverviewTab ───────────────────────────────────────────
+interface Props {
+  quotes: Quote[];
+  period: Period;
+  onSelectSymbolForTrend: (sym: string) => void;
+}
+
+export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: Props) {
+  const [sortAsc, setSortAsc] = useState(false);
+  const [mapSector, setMapSector] = useState('all');
+  const [mapSearch, setMapSearch] = useState('');
+  const [mapSortCol, setMapSortCol] = useState('sector');
+  const [mapSortAsc, setMapSortAsc] = useState(true);
+
+  if (!quotes.length) return (
+    <main className="tab-panel active">
+      <div className="panel"><p style={{color:'#64748b'}}>載入中…</p></div>
+    </main>
+  );
+
+  const key = `change_${period}` as keyof Quote;
+  const nonSpy = quotes.filter(q => q.symbol !== 'SPY');
+  const spy = quotes.find(q => q.symbol === 'SPY');
+
+  // Stat cards
+  const sortedQuotes = [...quotes].sort((a, b) => ((b[key] as number) ?? 0) - ((a[key] as number) ?? 0));
+  const best = sortedQuotes[0];
+  const worst = sortedQuotes[sortedQuotes.length - 1];
+
+  const secMap: Record<string, { sum: number; count: number }> = {};
+  quotes.forEach(q => {
+    if (!secMap[q.sector]) secMap[q.sector] = { sum: 0, count: 0 };
+    secMap[q.sector].sum += (q[key] as number) ?? 0;
+    secMap[q.sector].count++;
+  });
+  const hotSector = Object.entries(secMap)
+    .map(([s, d]) => ({ sector: s, avg: d.sum / d.count }))
+    .sort((a, b) => b.avg - a.avg)[0];
+
+  // Sector bar
+  const secBar: Record<string, { sum: number; tw: number }> = {};
+  nonSpy.forEach(q => {
+    if (!secBar[q.sector]) secBar[q.sector] = { sum: 0, tw: 0 };
+    secBar[q.sector].sum += ((q[key] as number) ?? 0) * q.mcap;
+    secBar[q.sector].tw += q.mcap;
+  });
+  const secData = Object.entries(secBar)
+    .map(([sec, d]) => ({ sector: sec, change: d.tw ? d.sum / d.tw : 0 }))
+    .sort((a, b) => b.change - a.change);
+
+  const barData = {
+    labels: secData.map(d => d.sector),
+    datasets: [{
+      label: '漲跌 %',
+      data: secData.map(d => +d.change.toFixed(2)),
+      backgroundColor: secData.map(d => changeColor(d.change, 0.85)),
+      borderColor: secData.map(d => changeColor(d.change, 1)),
+      borderWidth: 1, borderRadius: 4,
+    }],
+  };
+  const barOptions = {
+    indexAxis: 'y' as const,
+    responsive: true, maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: { callbacks: { label: (c: { raw: unknown }) => ` ${fmtPct(c.raw as number)}` } },
+    },
+    scales: {
+      x: {
+        grid: { color: 'rgba(255,255,255,0.05)' },
+        ticks: { color: '#94a3b8', callback: (v: string | number) => fmtPct(v as number) },
+      },
+      y: {
+        grid: { display: false },
+        ticks: { color: '#e2e8f0', font: { size: 11 } },
+      },
+    },
+  };
+
+  // ETF ranking table
+  const etfSorted = [...nonSpy].sort((a, b) =>
+    sortAsc
+      ? ((a[key] as number) ?? 0) - ((b[key] as number) ?? 0)
+      : ((b[key] as number) ?? 0) - ((a[key] as number) ?? 0)
+  );
+
+  // ETF mapping table
+  const sectors = ['all', ...[...new Set(nonSpy.map(q => q.sector))].sort()];
+  let mapRows = [...nonSpy];
+  if (mapSector !== 'all') mapRows = mapRows.filter(r => r.sector === mapSector);
+  const s = mapSearch.toLowerCase();
+  if (s) mapRows = mapRows.filter(r => r.symbol.toLowerCase().includes(s) || r.name.toLowerCase().includes(s));
+  mapRows.sort((a, b) => {
+    const va = (a as unknown as Record<string, unknown>)[mapSortCol] ?? '';
+    const vb = (b as unknown as Record<string, unknown>)[mapSortCol] ?? '';
+    return (va < vb ? -1 : va > vb ? 1 : 0) * (mapSortAsc ? 1 : -1);
+  });
+
+  function handleMapSort(col: string) {
+    setMapSortAsc(mapSortCol === col ? !mapSortAsc : true);
+    setMapSortCol(col);
+  }
+
+  const mapColumns: [string, string][] = [
+    ['symbol', '代碼'], ['', '名稱'], ['sector', '板塊'], ['price', '現價'],
+    ['change_1d', '1D'], ['change_1m', '1M'], ['change_1y', '1Y'], ['mcap', 'AUM(B)'],
+  ];
+
+  return (
+    <main className="tab-panel active">
+      {/* Stat Cards */}
+      <section className="stat-row">
+        <div className="stat-card">
+          <div className="stat-label">🔥 最強</div>
+          <div className="stat-symbol">{best?.symbol ?? '—'}</div>
+          <div className="stat-change" style={{color: changeTextColor((best?.[key] as number) ?? 0)}}>
+            {fmtPct((best?.[key] as number) ?? 0)}
+          </div>
+          <div className="stat-sector">{best?.sector ?? '—'}</div>
+        </div>
+        <div className="stat-card">
+          <div className="stat-label">🧊 最弱</div>
+          <div className="stat-symbol">{worst?.symbol ?? '—'}</div>
+          <div className="stat-change" style={{color: changeTextColor((worst?.[key] as number) ?? 0)}}>
+            {fmtPct((worst?.[key] as number) ?? 0)}
+          </div>
+          <div className="stat-sector">{worst?.sector ?? '—'}</div>
+        </div>
+        <div className="stat-card">
+          <div className="stat-label">🌊 熱門板塊</div>
+          <div className="stat-symbol">{hotSector?.sector ?? '—'}</div>
+          <div className="stat-change" style={{color: changeTextColor(hotSector?.avg ?? 0)}}>
+            {fmtPct(hotSector?.avg ?? 0)}
+          </div>
+          <div className="stat-sector">加權平均漲幅</div>
+        </div>
+        <div className="stat-card">
+          <div className="stat-label">📍 大盤 SPY</div>
+          <div className="stat-symbol">{spy ? `$${spy.price.toFixed(2)}` : '—'}</div>
+          <div className="stat-change" style={{color: changeTextColor((spy?.[key] as number) ?? 0)}}>
+            {spy ? fmtPct((spy[key] as number) ?? 0) : '—'}
+          </div>
+          <div className="stat-sector">S&P 500 ETF</div>
+        </div>
+      </section>
+
+      {/* Heatmap */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>全球資金熱力圖</h2>
+          <span className="panel-hint">色塊大小 = 市值規模 ／ 顏色深淺 = 漲跌幅</span>
+        </div>
+        <HeatmapCanvas quotes={quotes} period={period} />
+        <div className="heatmap-legend">
+          <span className="legend-label">跌 &lt; −3%</span>
+          <div className="legend-bar"></div>
+          <span className="legend-label">漲 &gt; +3%</span>
+        </div>
+      </section>
+
+      {/* Sector bar */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>板塊漲跌排行</h2>
+          <span className="panel-hint">各板塊加權平均漲跌幅</span>
+        </div>
+        <div className="chart-wrap medium">
+          <Bar data={barData} options={barOptions} />
+        </div>
+      </section>
+
+      {/* ETF ranking table */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>ETF 漲跌排行</h2>
+          <button className="icon-btn" onClick={() => setSortAsc(!sortAsc)} title="切換排序">↕</button>
+        </div>
+        <div className="table-wrap">
+          <table className="etf-table">
+            <thead>
+              <tr>
+                <th>代碼</th><th>名稱</th><th>板塊</th><th>現價</th><th>漲跌 %</th>
+              </tr>
+            </thead>
+            <tbody>
+              {etfSorted.map(q => (
+                <tr key={q.symbol}>
+                  <td><strong>{q.symbol}</strong></td>
+                  <td className="name-cell">{q.name}</td>
+                  <td><span className="sector-tag">{q.sector}</span></td>
+                  <td className="mono">${q.price.toFixed(2)}</td>
+                  <td className="mono" style={{color: changeTextColor((q[key] as number) ?? 0)}}>
+                    {fmtPct((q[key] as number) ?? 0)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* ETF Mapping Table */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>ETF 產業對應總表</h2>
+          <span className="panel-hint">點選標的可加入趨勢比較</span>
+        </div>
+        <div className="etfmap-controls">
+          <input
+            type="text"
+            placeholder="搜尋代碼或名稱…"
+            className="etfmap-search"
+            value={mapSearch}
+            onChange={e => setMapSearch(e.target.value)}
+          />
+          <div className="etfmap-filters">
+            {sectors.map(sec => (
+              <button
+                key={sec}
+                className={`ef-btn${mapSector === sec ? ' active' : ''}`}
+                onClick={() => setMapSector(sec)}
+              >
+                {sec === 'all' ? '全部' : sec}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="table-wrap">
+          <table className="etf-table etfmap-table">
+            <thead>
+              <tr>
+                {mapColumns.map(([col, label]) => (
+                  <th
+                    key={`${col}-${label}`}
+                    data-col={col}
+                    className={col ? 'sortable' : ''}
+                    style={col ? { cursor: 'pointer' } : {}}
+                    onClick={() => col && handleMapSort(col)}
+                  >
+                    {label}{col ? ' ↕' : ''}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {mapRows.map(r => (
+                <tr
+                  key={r.symbol}
+                  className="etfmap-row"
+                  style={{ cursor: 'pointer' }}
+                  title="點選加入趨勢比較"
+                  onClick={() => onSelectSymbolForTrend(r.symbol)}
+                >
+                  <td>
+                    <span className="sym-badge" style={{ background: SECTOR_COLORS[r.sector] ?? '#444' }}>
+                      {r.symbol}
+                    </span>
+                  </td>
+                  <td className="name-cell">{r.name}</td>
+                  <td><span className="sector-tag">{r.sector}</span></td>
+                  <td>${r.price}</td>
+                  <td style={{color: changeTextColor(r.change_1d)}}>{fmtPct(r.change_1d)}</td>
+                  <td style={{color: changeTextColor(r.change_1m)}}>{fmtPct(r.change_1m)}</td>
+                  <td style={{color: changeTextColor(r.change_1y)}}>{fmtPct(r.change_1y)}</td>
+                  <td>${r.mcap}B</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/tabs/TrendTab.tsx
+++ b/src/components/tabs/TrendTab.tsx
@@ -1,0 +1,287 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS, LineElement, PointElement, CategoryScale, LinearScale,
+  Tooltip, Legend, Filler,
+} from 'chart.js';
+import { SECTOR_COLORS, TREND_PALETTE, fmtPct } from '@/lib/utils/colors';
+import type { Quote, MockEvent, Period, DailySeries } from '@/types';
+
+ChartJS.register(LineElement, PointElement, CategoryScale, LinearScale, Tooltip, Legend, Filler);
+
+// fmtPct is imported but used indirectly through the correlation table values
+void fmtPct;
+
+const EVENT_COLORS: Record<string, string> = {
+  fed: '#4a90e2',
+  macro: '#27ae60',
+  earnings: '#f7931a',
+  geopolitical: '#e74c3c',
+};
+
+interface Props {
+  quotes: Quote[];
+  eventsData: MockEvent[] | null;
+  period: Period;
+  selected: string[];
+  onSelectedChange: (sel: string[]) => void;
+}
+
+function computeCorr(a: (number | null)[], b: (number | null)[]): number {
+  const pairs = a
+    .map((v, i) => [v, b[i]] as [number | null, number | null])
+    .filter(([x, y]) => x !== null && y !== null) as [number, number][];
+  if (pairs.length < 5) return 0;
+  const n = pairs.length;
+  const ma = pairs.reduce((s, [x]) => s + x, 0) / n;
+  const mb = pairs.reduce((s, [, y]) => s + y, 0) / n;
+  const num = pairs.reduce((s, [x, y]) => s + (x - ma) * (y - mb), 0);
+  const da = Math.sqrt(pairs.reduce((s, [x]) => s + (x - ma) ** 2, 0));
+  const db = Math.sqrt(pairs.reduce((s, [, y]) => s + (y - mb) ** 2, 0));
+  return da * db === 0 ? 0 : +(num / (da * db)).toFixed(2);
+}
+
+export default function TrendTab({
+  quotes,
+  eventsData,
+  period,
+  selected,
+  onSelectedChange,
+}: Props) {
+  const [seriesCache, setSeriesCache] = useState<Record<string, DailySeries[]>>({});
+  const [loading, setLoading] = useState(false);
+
+  const effectivePeriod = period === '1d' ? '5d' : period;
+
+  useEffect(() => {
+    const missing = selected.filter(sym => !seriesCache[sym + effectivePeriod]);
+    if (!missing.length) return;
+    setLoading(true);
+    Promise.all(
+      missing.map(async sym => {
+        try {
+          const r = await fetch(`/api/history?symbol=${sym}&period=${effectivePeriod}`);
+          const data = await r.json();
+          return { sym, series: data.series as DailySeries[] };
+        } catch {
+          return { sym, series: [] as DailySeries[] };
+        }
+      }),
+    ).then(results => {
+      setSeriesCache(prev => {
+        const next = { ...prev };
+        results.forEach(({ sym, series }) => {
+          next[sym + effectivePeriod] = series;
+        });
+        return next;
+      });
+      setLoading(false);
+    });
+  }, [selected, effectivePeriod]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function toggleSymbol(sym: string) {
+    if (selected.includes(sym)) {
+      if (selected.length <= 1) return;
+      onSelectedChange(selected.filter(s => s !== sym));
+    } else {
+      const next =
+        selected.length >= 6 ? [...selected.slice(1), sym] : [...selected, sym];
+      onSelectedChange(next);
+    }
+  }
+
+  // Build chart data
+  const allSeries: Record<string, DailySeries[]> = {};
+  selected.forEach(sym => {
+    if (seriesCache[sym + effectivePeriod]) {
+      allSeries[sym] = seriesCache[sym + effectivePeriod];
+    }
+  });
+
+  const allDatesSet = Object.values(allSeries).reduce<Set<string> | null>(
+    (acc, s) => {
+      const ds = new Set(s.map(b => b.date));
+      return acc === null ? ds : new Set([...acc].filter(d => ds.has(d)));
+    },
+    null,
+  ) ?? new Set<string>();
+  const dates = [...allDatesSet].sort();
+
+  const eventsPlugin = {
+    id: 'eventAnnotations',
+    afterDraw(chart: ChartJS) {
+      if (!eventsData?.length) return;
+      const { ctx, chartArea, scales } = chart as unknown as {
+        ctx: CanvasRenderingContext2D;
+        chartArea: { left: number; right: number; top: number; bottom: number };
+        scales: { x: { getPixelForValue: (v: string) => number } };
+      };
+      eventsData.forEach(ev => {
+        const xPx = scales.x.getPixelForValue(ev.date);
+        if (!xPx || xPx < chartArea.left || xPx > chartArea.right) return;
+        ctx.save();
+        ctx.globalAlpha = 0.55;
+        ctx.strokeStyle = EVENT_COLORS[ev.type] ?? '#58a6ff';
+        ctx.lineWidth = 1.2;
+        ctx.setLineDash([4, 3]);
+        ctx.beginPath();
+        ctx.moveTo(xPx, chartArea.top);
+        ctx.lineTo(xPx, chartArea.bottom);
+        ctx.stroke();
+        ctx.globalAlpha = 0.9;
+        ctx.fillStyle = EVENT_COLORS[ev.type] ?? '#58a6ff';
+        ctx.font = '10px Inter,sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText(
+          ev.magnitude > 0 ? '▲' : ev.magnitude < 0 ? '▼' : '●',
+          xPx,
+          chartArea.top + 8,
+        );
+        ctx.restore();
+      });
+    },
+  };
+
+  const datasets = selected.map((sym, i) => {
+    const s = allSeries[sym] ?? [];
+    const byDate = Object.fromEntries(s.map(b => [b.date, b.close]));
+    const values = dates.map(d => byDate[d] ?? null);
+    const base = values.find(v => v !== null) ?? 1;
+    return {
+      label: sym,
+      data: values.map(v => (v === null ? null : +(v / base * 100).toFixed(3))),
+      borderColor: TREND_PALETTE[i % TREND_PALETTE.length],
+      backgroundColor: TREND_PALETTE[i % TREND_PALETTE.length] + '22',
+      borderWidth: 2,
+      pointRadius: 0,
+      tension: 0.3,
+      fill: false,
+      spanGaps: true,
+    };
+  });
+
+  const chartData = { labels: dates, datasets };
+  const chartOptions: Record<string, unknown> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: 'index', intersect: false },
+    plugins: {
+      legend: { labels: { color: '#e2e8f0', font: { size: 12 } } },
+      tooltip: {
+        callbacks: {
+          label: (ctx: { dataset: { label: string }; raw: number | null }) =>
+            ` ${ctx.dataset.label}: ${ctx.raw?.toFixed(2) ?? '—'}`,
+        },
+      },
+    },
+    scales: {
+      x: {
+        ticks: { color: '#64748b', maxTicksLimit: 10, maxRotation: 0 },
+        grid: { color: 'rgba(255,255,255,0.04)' },
+      },
+      y: {
+        ticks: {
+          color: '#94a3b8',
+          callback: (v: unknown) => (v as number).toFixed(0),
+        },
+        grid: { color: 'rgba(255,255,255,0.06)' },
+      },
+    },
+  };
+
+  // Correlation matrix
+  const syms = selected.filter(s => allSeries[s]);
+  const returns: Record<string, (number | null)[]> = {};
+  syms.forEach(sym => {
+    const s = allSeries[sym];
+    const byDate = Object.fromEntries(s.map(b => [b.date, b.close]));
+    const vals = dates.map(d => byDate[d] ?? null);
+    returns[sym] = vals.slice(1).map((v, i) =>
+      v !== null && vals[i] !== null ? v / (vals[i] as number) - 1 : null,
+    );
+  });
+
+  return (
+    <main className="tab-panel active">
+      <section className="panel">
+        <div className="panel-header">
+          <h2>多標的趨勢比較</h2>
+          <span className="panel-hint">
+            選擇最多 6 個標的進行比較（基準化 = 起點 100）
+          </span>
+        </div>
+        <div className="symbol-picker">
+          {quotes
+            .filter(q => q.symbol !== 'SPY')
+            .map(q => (
+              <button
+                key={q.symbol}
+                className={`sym-btn${selected.includes(q.symbol) ? ' active' : ''}`}
+                title={q.name}
+                style={
+                  { '--sc': SECTOR_COLORS[q.sector] ?? '#888' } as React.CSSProperties
+                }
+                onClick={() => toggleSymbol(q.symbol)}
+              >
+                {q.symbol}
+              </button>
+            ))}
+        </div>
+        <div className="chart-wrap tall">
+          {loading && (
+            <p style={{ color: '#64748b', textAlign: 'center' }}>載入中…</p>
+          )}
+          {!loading && dates.length > 0 && (
+            <Line
+              data={chartData}
+              options={chartOptions}
+              plugins={[eventsPlugin as unknown as import('chart.js').Plugin]}
+            />
+          )}
+        </div>
+
+        {/* Correlation matrix */}
+        <div className="panel-header" style={{ marginTop: '2rem' }}>
+          <h2>相關性矩陣</h2>
+          <span className="panel-hint">所選標的間的收益率相關係數</span>
+        </div>
+        <div className="corr-wrap">
+          {syms.length < 2 ? (
+            <p style={{ color: '#64748b' }}>選 2+ 個標的</p>
+          ) : (
+            <table className="corr-table">
+              <thead>
+                <tr>
+                  <th></th>
+                  {syms.map(s => (
+                    <th key={s}>{s}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {syms.map(sa => (
+                  <tr key={sa}>
+                    <th>{sa}</th>
+                    {syms.map(sb => {
+                      const c = computeCorr(returns[sa] ?? [], returns[sb] ?? []);
+                      const bg =
+                        c >= 0
+                          ? `rgba(74,144,226,${Math.abs(c) * 0.7})`
+                          : `rgba(248,113,113,${Math.abs(c) * 0.7})`;
+                      return (
+                        <td key={sb} style={{ background: bg, color: '#e2e8f0' }}>
+                          {c.toFixed(2)}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/lib/data-engine/backtest.ts
+++ b/src/lib/data-engine/backtest.ts
@@ -1,0 +1,168 @@
+import { THEME_ETF } from './constants';
+import { generateSeries } from './series';
+import { computeStats, IndexedPoint, StatsResult } from './stats';
+
+export interface BacktestResult {
+  portfolio: IndexedPoint[];
+  benchmark: IndexedPoint[];
+  stats: (StatsResult & { spy_return: number }) | Record<string, never>;
+}
+
+export interface StrategyResult {
+  momentum: IndexedPoint[];
+  equal_weight: IndexedPoint[];
+  spy: IndexedPoint[];
+  theme_names: Record<string, string>;
+  stats: {
+    momentum:     StatsResult | Record<string, never>;
+    equal_weight: StatsResult | Record<string, never>;
+    spy:          StatsResult | Record<string, never>;
+  };
+}
+
+const BACKTEST_PERIOD_DAYS: Record<string, number> = { '1y': 365, '3y': 1095, '5y': 1825 };
+
+export function runBacktest(
+  weights: Record<string, number>,
+  period: string,
+): BacktestResult {
+  const periodDays = BACKTEST_PERIOD_DAYS[period] ?? 365;
+
+  const seriesMap: Record<string, ReturnType<typeof generateSeries>> = {};
+  for (const sym of Object.keys(weights)) {
+    seriesMap[sym] = generateSeries(sym, periodDays + 30);
+  }
+  const spySeries = generateSeries('SPY', periodDays + 30);
+
+  const allDates = Array.from(new Set(spySeries.map(b => b.date))).sort().slice(-periodDays);
+
+  const makeIndex = (series: ReturnType<typeof generateSeries>) => {
+    const m: Record<string, number> = {};
+    for (const b of series) m[b.date] = b.close;
+    return m;
+  };
+  const spyIdx: Record<string, number> = makeIndex(spySeries);
+  const symIdx: Record<string, Record<string, number>> = {};
+  for (const [sym, s] of Object.entries(seriesMap)) symIdx[sym] = makeIndex(s);
+
+  const portfolio: IndexedPoint[] = [];
+  const bench: IndexedPoint[] = [];
+  let basePt: number | null = null;
+  let baseSpy: number | null = null;
+
+  for (const date of allDates) {
+    let portVal = 0;
+    for (const [sym, w] of Object.entries(weights)) {
+      if (symIdx[sym][date]) portVal += w * symIdx[sym][date];
+    }
+    const spyVal = spyIdx[date];
+    if (!portVal || !spyVal) continue;
+    if (basePt === null) { basePt = portVal; baseSpy = spyVal; }
+    portfolio.push({ date, value: Math.round(portVal / basePt! * 10000) / 100 });
+    bench.push(    { date, value: Math.round(spyVal  / baseSpy! * 10000) / 100 });
+  }
+
+  if (portfolio.length < 2) return { portfolio: [], benchmark: [], stats: {} };
+
+  const spyRet   = bench.length ? bench[bench.length - 1].value / 100 - 1 : 0;
+  const baseStats = computeStats(portfolio);
+  if (!('total_return' in baseStats)) return { portfolio: [], benchmark: [], stats: {} };
+
+  const stats: StatsResult & { spy_return: number } = {
+    ...(baseStats as StatsResult),
+    spy_return: Math.round(spyRet * 10000) / 100,
+  };
+
+  return { portfolio, benchmark: bench, stats };
+}
+
+export function runStrategyBacktest(period: string, topN = 3): StrategyResult {
+  const periodDays = BACKTEST_PERIOD_DAYS[period] ?? 365;
+  const themeSyms  = Object.values(THEME_ETF);
+
+  const seriesMap: Record<string, ReturnType<typeof generateSeries>> = {};
+  for (const sym of themeSyms) seriesMap[sym] = generateSeries(sym, periodDays + 30);
+  const spySeries = generateSeries('SPY', periodDays + 30);
+
+  const allDates = Array.from(new Set(
+    themeSyms.flatMap(s => seriesMap[s].map(b => b.date)),
+  )).sort().slice(-periodDays);
+
+  const symIdx: Record<string, Record<string, number>> = {};
+  for (const sym of themeSyms) {
+    symIdx[sym] = {};
+    for (const b of seriesMap[sym]) symIdx[sym][b.date] = b.close;
+  }
+
+  const p = (sym: string, date: string): number | null => symIdx[sym][date] ?? null;
+
+  const REBAL = 21;
+  let momH: Record<string, number> = {};
+  for (const s of themeSyms) momH[s] = 1 / themeSyms.length;
+  const momVals: IndexedPoint[] = [];
+
+  for (let i = 0; i < allDates.length; i++) {
+    const date = allDates[i];
+
+    if (i > 0 && i % REBAL === 0) {
+      const lookback = allDates[Math.max(0, i - REBAL)];
+      const rets: Record<string, number> = {};
+      for (const s of themeSyms) {
+        const p0 = p(s, lookback), p1 = p(s, date);
+        if (p0 && p1) rets[s] = p1 / p0 - 1;
+      }
+      if (Object.keys(rets).length >= topN) {
+        const winners = Object.entries(rets)
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, topN)
+          .map(e => e[0]);
+        momH = {};
+        for (const s of themeSyms) momH[s] = winners.includes(s) ? 1 / topN : 0;
+      }
+    }
+
+    if (i === 0) {
+      momVals.push({ date, value: 100.0 });
+    } else {
+      const prev  = allDates[i - 1];
+      const daily = themeSyms.reduce((s, sym) => {
+        const p0 = p(sym, prev), p1 = p(sym, date);
+        return (p0 && p1) ? s + momH[sym] * (p1 / p0 - 1) : s;
+      }, 0);
+      momVals.push({ date, value: Math.round(momVals[i - 1].value * (1 + daily) * 10000) / 10000 });
+    }
+  }
+
+  const eqW    = 1 / themeSyms.length;
+  const eqVals: IndexedPoint[] = [{ date: allDates[0], value: 100.0 }];
+  for (let i = 1; i < allDates.length; i++) {
+    const date = allDates[i], prev = allDates[i - 1];
+    const daily = themeSyms.reduce((s, sym) => {
+      const p0 = p(sym, prev), p1 = p(sym, date);
+      return (p0 && p1) ? s + eqW * (p1 / p0 - 1) : s;
+    }, 0);
+    eqVals.push({ date, value: Math.round(eqVals[i - 1].value * (1 + daily) * 10000) / 10000 });
+  }
+
+  const spyByDate: Record<string, number> = {};
+  for (const b of spySeries) spyByDate[b.date] = b.close;
+  const spyBase = spyByDate[allDates[0]] ?? 1;
+  const spyVals: IndexedPoint[] = allDates
+    .filter(d => spyByDate[d])
+    .map(d => ({ date: d, value: Math.round(spyByDate[d] / spyBase * 100 * 10000) / 10000 }));
+
+  const themeNames: Record<string, string> = {};
+  for (const [k, v] of Object.entries(THEME_ETF)) themeNames[v] = k;
+
+  return {
+    momentum:     momVals,
+    equal_weight: eqVals,
+    spy:          spyVals,
+    theme_names:  themeNames,
+    stats: {
+      momentum:     computeStats(momVals),
+      equal_weight: computeStats(eqVals),
+      spy:          computeStats(spyVals),
+    },
+  };
+}

--- a/src/lib/data-engine/chips.ts
+++ b/src/lib/data-engine/chips.ts
@@ -1,0 +1,124 @@
+import { SECTOR_ETFS, ETF_UNIVERSE } from './constants';
+import { SeededRandom, seedFor } from './prng';
+import { generateSeries } from './series';
+import { getAllQuotes, Quote } from './quotes';
+
+export interface ChipRow {
+  sector: string;
+  flow_score: number;
+  dates: string[];
+  institutional: number[];
+  smart_money: number[];
+  retail: number[];
+  cumulative: number[];
+}
+
+export interface FlowMatrix {
+  sectors: string[];
+  flow_scores: number[];
+  volume_ratios: number[];
+  mcaps: number[];
+  rotation_matrix: number[][];
+}
+
+const CHIP_DAYS: Record<string, number> = {
+  '1d': 5, '5d': 10, '1m': 22, '3m': 66, '6m': 130, '1y': 252, 'ytd': 100,
+};
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function getChipsData(period: string): ChipRow[] {
+  const days   = CHIP_DAYS[period] ?? 22;
+  const quotes = getAllQuotes();
+  const qmap: Record<string, Quote> = {};
+  for (const q of quotes) qmap[q.symbol] = q;
+
+  const result: ChipRow[] = [];
+  const today    = new Date();
+  const todayMs  = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
+  const changeKey = `change_${period}` as keyof Quote;
+
+  for (const [sector, etfs] of Object.entries(SECTOR_ETFS)) {
+    const validEtfs = etfs.filter(e => qmap[e]);
+    const momentum  = validEtfs.length
+      ? validEtfs.reduce((s, e) => s + ((qmap[e][changeKey] as number) ?? 0), 0) / validEtfs.length
+      : 0;
+    const instBias = momentum * 30;
+
+    const rngI = new SeededRandom(seedFor(sector + '_inst'));
+    const rngS = new SeededRandom(seedFor(sector + '_smart'));
+    const rngR = new SeededRandom(seedFor(sector + '_retail'));
+
+    const dates: string[]        = [];
+    const institutional: number[] = [];
+    const smart_money: number[]   = [];
+    const retail: number[]        = [];
+    const cumulative: number[]    = [];
+    let cum = 0;
+
+    for (let i = 0; i < days; i++) {
+      const d = new Date(todayMs - (days - 1 - i) * 86400000);
+      if (d.getUTCDay() === 0 || d.getUTCDay() === 6) continue;
+      dates.push(isoDate(d));
+
+      const inst  = Math.round(rngI.gauss(instBias * 0.6,  Math.abs(instBias) * 0.8 + 80) * 10) / 10;
+      const smart = Math.round(rngS.gauss(instBias * 0.3,  Math.abs(instBias) * 0.5 + 40) * 10) / 10;
+      const ret   = Math.round(rngR.gauss(-instBias * 0.2, Math.abs(instBias) * 0.6 + 50) * 10) / 10;
+      cum = Math.round((cum + inst) * 10) / 10;
+
+      institutional.push(inst);
+      smart_money.push(smart);
+      retail.push(ret);
+      cumulative.push(cum);
+    }
+
+    result.push({
+      sector,
+      flow_score: Math.round(momentum * 1.5 * 100) / 100,
+      dates, institutional, smart_money, retail, cumulative,
+    });
+  }
+
+  result.sort((a, b) => b.flow_score - a.flow_score);
+  return result;
+}
+
+export function getFlowMatrix(period: string): FlowMatrix {
+  const chips      = getChipsData(period);
+  const sectors    = chips.map(c => c.sector);
+  const flowScores = chips.map(c => c.flow_score);
+  const mcaps      = sectors.map(s =>
+    (SECTOR_ETFS[s] ?? []).reduce((sum, e) => sum + (ETF_UNIVERSE[e]?.mcap ?? 0), 0),
+  );
+
+  const quotes = getAllQuotes();
+  const qmap: Record<string, Quote> = {};
+  for (const q of quotes) qmap[q.symbol] = q;
+
+  // Volume ratio: current quote volume vs 22-day average from a fresh series slice.
+  // Only the first ETF in the sector is used for the base (matches data.js behaviour).
+  const volumeRatios = sectors.map(s => {
+    const etfs = (SECTOR_ETFS[s] ?? []).slice(0, 2);
+    if (!etfs.length) return 1;
+    const curVol = etfs.reduce((sum, e) => sum + (qmap[e]?.volume ?? 0), 0) / etfs.length;
+    const series = generateSeries(etfs[0], 35);
+    const baseVol = series.length > 22
+      ? series.slice(-22).reduce((s, b) => s + b.volume, 0) / 22
+      : curVol;
+    return Math.round((curVol / (baseVol || curVol)) * 100) / 100;
+  });
+
+  const n = sectors.length;
+  const rotationMatrix: number[][] = Array.from({ length: n }, (_, i) =>
+    Array.from({ length: n }, (_, j) => {
+      if (i === j) return 1;
+      const diff = Math.abs(flowScores[i] - flowScores[j]);
+      const sign = (flowScores[i] > 0) === (flowScores[j] > 0) ? 1 : -1;
+      return Math.round(sign * Math.max(0, 1 - diff / 6) * 100) / 100;
+    }),
+  );
+
+  return { sectors, flow_scores: flowScores, volume_ratios: volumeRatios, mcaps, rotation_matrix: rotationMatrix };
+}

--- a/src/lib/data-engine/constants.ts
+++ b/src/lib/data-engine/constants.ts
@@ -1,0 +1,161 @@
+export interface EtfInfo {
+  name: string;
+  sector: string;
+  base: number;
+  vol: number;
+  mcap: number;
+}
+
+export interface MacroTreeNode {
+  id: string;
+  name: string;
+  parent: string;
+  aum: number;
+  vol: number;
+  color: string;
+  etfs: string[];
+}
+
+export interface MockEvent {
+  date: string;
+  title: string;
+  type: 'fed' | 'macro' | 'geopolitical' | 'earnings';
+  sectors: string[];
+  magnitude: number;
+  detail: string;
+}
+
+export const ETF_UNIVERSE: Record<string, EtfInfo> = {
+  IBIT: { name: 'iShares Bitcoin Trust',    sector: 'Crypto',        base: 55.40,  vol: 0.045, mcap: 38  },
+  BITO: { name: 'ProShares Bitcoin ETF',    sector: 'Crypto',        base: 28.15,  vol: 0.042, mcap: 12  },
+  QQQ:  { name: 'Nasdaq 100',               sector: 'Technology',    base: 484.50, vol: 0.015, mcap: 280 },
+  XLK:  { name: 'Technology Select SPDR',   sector: 'Technology',    base: 215.30, vol: 0.014, mcap: 68  },
+  SMH:  { name: 'VanEck Semiconductor',     sector: 'Technology',    base: 218.40, vol: 0.020, mcap: 22  },
+  ARKK: { name: 'ARK Innovation',           sector: 'Technology',    base: 55.80,  vol: 0.030, mcap: 8   },
+  VNQ:  { name: 'Vanguard Real Estate',     sector: 'Real Estate',   base: 84.20,  vol: 0.012, mcap: 34  },
+  IYR:  { name: 'iShares Real Estate',      sector: 'Real Estate',   base: 87.50,  vol: 0.012, mcap: 28  },
+  XLE:  { name: 'Energy Select SPDR',       sector: 'Energy',        base: 91.80,  vol: 0.018, mcap: 38  },
+  XOP:  { name: 'Oil & Gas E&P SPDR',       sector: 'Energy',        base: 147.60, vol: 0.022, mcap: 4   },
+  XLV:  { name: 'Healthcare Select SPDR',   sector: 'Healthcare',    base: 148.20, vol: 0.010, mcap: 38  },
+  IBB:  { name: 'iShares Biotech',          sector: 'Healthcare',    base: 137.80, vol: 0.018, mcap: 8   },
+  XLF:  { name: 'Financials Select SPDR',   sector: 'Financials',    base: 45.20,  vol: 0.013, mcap: 42  },
+  KBE:  { name: 'SPDR S&P Bank ETF',        sector: 'Financials',    base: 47.90,  vol: 0.016, mcap: 2   },
+  XLY:  { name: 'Consumer Discret. SPDR',   sector: 'Consumer',      base: 194.60, vol: 0.014, mcap: 20  },
+  XLP:  { name: 'Consumer Staples SPDR',    sector: 'Consumer',      base: 78.40,  vol: 0.008, mcap: 15  },
+  XLI:  { name: 'Industrials Select SPDR',  sector: 'Industrials',   base: 137.50, vol: 0.011, mcap: 20  },
+  XLB:  { name: 'Materials Select SPDR',    sector: 'Materials',     base: 92.10,  vol: 0.013, mcap: 6   },
+  XLU:  { name: 'Utilities Select SPDR',    sector: 'Utilities',     base: 71.80,  vol: 0.009, mcap: 14  },
+  TLT:  { name: 'iShares 20+ Year Bonds',   sector: 'Bonds',         base: 91.50,  vol: 0.010, mcap: 50  },
+  AGG:  { name: 'iShares Core Agg Bond',    sector: 'Bonds',         base: 97.20,  vol: 0.005, mcap: 100 },
+  HYG:  { name: 'iShares High Yield Corp',  sector: 'Bonds',         base: 78.60,  vol: 0.007, mcap: 14  },
+  GLD:  { name: 'SPDR Gold Trust',          sector: 'Commodities',   base: 239.80, vol: 0.012, mcap: 70  },
+  SLV:  { name: 'iShares Silver Trust',     sector: 'Commodities',   base: 27.90,  vol: 0.018, mcap: 12  },
+  USO:  { name: 'United States Oil Fund',   sector: 'Commodities',   base: 68.40,  vol: 0.022, mcap: 2   },
+  DBA:  { name: 'Invesco Agriculture Fund', sector: 'Commodities',   base: 20.15,  vol: 0.010, mcap: 1   },
+  EEM:  { name: 'iShares Emerging Markets', sector: 'International', base: 45.30,  vol: 0.014, mcap: 22  },
+  VEA:  { name: 'Vanguard Dev. Markets',    sector: 'International', base: 52.10,  vol: 0.011, mcap: 100 },
+  EWJ:  { name: 'iShares Japan',            sector: 'International', base: 69.80,  vol: 0.013, mcap: 10  },
+  FXI:  { name: 'iShares China Large-Cap',  sector: 'International', base: 32.80,  vol: 0.020, mcap: 5   },
+  SPY:  { name: 'S&P 500 SPDR',             sector: 'Broad Market',  base: 578.50, vol: 0.012, mcap: 550 },
+};
+
+export const SECTOR_DRIFT: Record<string, number> = {
+  'Crypto':        0.00080,
+  'Technology':    0.00045,
+  'Real Estate':  -0.00030,
+  'Energy':        0.00020,
+  'Healthcare':    0.00010,
+  'Financials':    0.00025,
+  'Consumer':      0.00010,
+  'Industrials':   0.00015,
+  'Materials':     0.00000,
+  'Utilities':    -0.00015,
+  'Bonds':        -0.00010,
+  'Commodities':   0.00035,
+  'International': 0.00010,
+  'Broad Market':  0.00025,
+};
+
+export const PERIOD_DAYS: Record<string, number> = {
+  '1d': 2, '5d': 7, '1m': 35, '3m': 100, '6m': 195, '1y': 380, 'ytd': 200,
+};
+
+export const PERIOD_VOL_SCALE: Record<string, number> = {
+  '1d': 1, '5d': 2.2, '1m': 4.5, '3m': 7.5, '6m': 10, '1y': 14, 'ytd': 10,
+};
+
+export const MACRO_TREE: MacroTreeNode[] = [
+  { id: 'equities',        name: '全球股市',      parent: 'global',      aum: 109.0, vol: 0.013, color: '#4a90e2', etfs: [] },
+  { id: 'bonds',           name: '全球債券',      parent: 'global',      aum: 130.0, vol: 0.005, color: '#3f51b5', etfs: [] },
+  { id: 'real_estate',     name: '房地產',        parent: 'global',      aum:  11.0, vol: 0.012, color: '#8b6d4f', etfs: [] },
+  { id: 'crypto',          name: '加密貨幣',      parent: 'global',      aum:   2.5, vol: 0.045, color: '#f7931a', etfs: [] },
+  { id: 'commodities',     name: '大宗商品',      parent: 'global',      aum:   0.8, vol: 0.018, color: '#ffc107', etfs: [] },
+  { id: 'cash_mm',         name: '現金/貨幣市場', parent: 'global',      aum:   6.5, vol: 0.001, color: '#607d8b', etfs: [] },
+  { id: 'us_equities',     name: '美國股市',      parent: 'equities',    aum: 46.0,  vol: 0.013, color: '#5ba3f5',
+    etfs: ['QQQ','XLK','SMH','XLF','XLV','XLE','XLI','XLY','XLP','XLB','XLU'] },
+  { id: 'dev_equities',    name: '已開發市場',    parent: 'equities',    aum: 40.0,  vol: 0.011, color: '#7cbcf7', etfs: ['VEA','EWJ'] },
+  { id: 'em_equities',     name: '新興市場',      parent: 'equities',    aum: 23.0,  vol: 0.014, color: '#a0d0fa', etfs: ['EEM','FXI'] },
+  { id: 'us_treasury',     name: '美國國債',      parent: 'bonds',       aum: 30.0,  vol: 0.009, color: '#5c6bc0', etfs: ['TLT'] },
+  { id: 'agg_bonds',       name: '投資級債券',    parent: 'bonds',       aum: 55.0,  vol: 0.005, color: '#7986cb', etfs: ['AGG'] },
+  { id: 'hy_bonds',        name: '高收益債券',    parent: 'bonds',       aum: 20.0,  vol: 0.007, color: '#9fa8da', etfs: ['HYG'] },
+  { id: 'intl_bonds',      name: '國際債券',      parent: 'bonds',       aum: 25.0,  vol: 0.006, color: '#b3bcec', etfs: [] },
+  { id: 'us_reits',        name: '美國 REITs',    parent: 'real_estate', aum:  4.5,  vol: 0.012, color: '#a08060', etfs: ['VNQ','IYR'] },
+  { id: 'asia_reits',      name: '亞太房地產',    parent: 'real_estate', aum:  4.0,  vol: 0.013, color: '#b8966e', etfs: ['EWJ'] },
+  { id: 'eu_reits',        name: '歐洲房地產',    parent: 'real_estate', aum:  2.5,  vol: 0.012, color: '#c9a87c', etfs: [] },
+  { id: 'btc_seg',         name: 'Bitcoin',       parent: 'crypto',      aum:  1.3,  vol: 0.045, color: '#f7931a', etfs: ['IBIT','BITO'] },
+  { id: 'eth_seg',         name: 'Ethereum',      parent: 'crypto',      aum:  0.5,  vol: 0.050, color: '#627eea', etfs: [] },
+  { id: 'alt_crypto',      name: '其他加密資產',  parent: 'crypto',      aum:  0.7,  vol: 0.060, color: '#e91e8c', etfs: ['ARKK'] },
+  { id: 'precious_metals', name: '貴金屬',        parent: 'commodities', aum:  0.40, vol: 0.013, color: '#ffd700', etfs: ['GLD','SLV'] },
+  { id: 'energy_comm',     name: '能源原物料',    parent: 'commodities', aum:  0.25, vol: 0.022, color: '#ff8c00', etfs: ['USO','XOP'] },
+  { id: 'agri_comm',       name: '農業',          parent: 'commodities', aum:  0.15, vol: 0.010, color: '#8bc34a', etfs: ['DBA'] },
+  { id: 'tech_sector',     name: '科技/半導體',   parent: 'us_equities', aum: 16.0,  vol: 0.016, color: '#4a90e2', etfs: ['QQQ','XLK','SMH','ARKK'] },
+  { id: 'health_sector',   name: '醫療生技',      parent: 'us_equities', aum:  7.0,  vol: 0.010, color: '#27ae60', etfs: ['XLV','IBB'] },
+  { id: 'fin_sector',      name: '金融',          parent: 'us_equities', aum:  8.0,  vol: 0.013, color: '#8e44ad', etfs: ['XLF','KBE'] },
+  { id: 'energy_sector',   name: '能源',          parent: 'us_equities', aum:  3.0,  vol: 0.018, color: '#e67e22', etfs: ['XLE','XOP'] },
+  { id: 'cons_disc',       name: '非必需消費',    parent: 'us_equities', aum:  4.0,  vol: 0.014, color: '#e91e8c', etfs: ['XLY'] },
+  { id: 'cons_staples',    name: '必需消費',      parent: 'us_equities', aum:  3.0,  vol: 0.008, color: '#9c27b0', etfs: ['XLP'] },
+  { id: 'industrial',      name: '工業',          parent: 'us_equities', aum:  3.0,  vol: 0.011, color: '#607d8b', etfs: ['XLI'] },
+  { id: 'materials',       name: '材料',          parent: 'us_equities', aum:  1.5,  vol: 0.013, color: '#795548', etfs: ['XLB'] },
+  { id: 'utilities',       name: '公用事業',      parent: 'us_equities', aum:  1.5,  vol: 0.009, color: '#00bcd4', etfs: ['XLU'] },
+];
+
+export const THEME_ETF: Record<string, string> = {
+  '科技': 'XLK', '加密': 'IBIT', '房地產': 'VNQ',
+  '能源': 'XLE', '醫療': 'XLV', '金融':   'XLF',
+  '消費': 'XLY', '工業': 'XLI', '材料':   'XLB',
+  '公用': 'XLU', '債券': 'AGG', '黃金':   'GLD',
+  '國際': 'VEA',
+};
+
+export const MOCK_EVENTS: MockEvent[] = [
+  { date: '2024-03-20', title: 'Fed 維持利率 5.25–5.50%',       type: 'fed',          sectors: ['Bonds','Financials','Utilities'],                   magnitude: 0,  detail: 'FOMC 決議維持利率不變，點陣圖暗示年內 3 次降息。' },
+  { date: '2024-05-01', title: 'Fed 暗示降息時間表延後',         type: 'fed',          sectors: ['Bonds','Technology','Real Estate'],                 magnitude: -1, detail: '通膨數據持續頑固，市場降息預期大幅後移，科技股承壓。' },
+  { date: '2024-07-11', title: 'CPI 低於預期，降息希望升溫',     type: 'macro',        sectors: ['Bonds','Real Estate','Utilities'],                  magnitude: 2,  detail: '6 月 CPI YoY 3.0%，低於預期，市場押注 9 月降息。' },
+  { date: '2024-08-05', title: '日圓套利交易解除，全球股市暴跌', type: 'geopolitical', sectors: ['International','Technology','Crypto'],              magnitude: -3, detail: '日銀升息導致日圓套利交易平倉潮，VIX 飆升至 38。' },
+  { date: '2024-09-18', title: 'Fed 首次降息 50bps',             type: 'fed',          sectors: ['Bonds','Real Estate','Financials'],                 magnitude: 2,  detail: '聯準會宣布降息 2 碼，為 4 年來首次降息。' },
+  { date: '2024-10-17', title: 'Nvidia Blackwell 晶片量產確認',  type: 'earnings',     sectors: ['Technology'],                                       magnitude: 2,  detail: 'Blackwell GPU 需求爆炸，AI 基礎建設投資持續加速。' },
+  { date: '2024-11-06', title: '川普當選美國總統',               type: 'geopolitical', sectors: ['Financials','Energy','Crypto'],                     magnitude: 3,  detail: '共和黨橫掃國會，市場預期減稅＋鬆綁金融監管，金融股大漲。' },
+  { date: '2024-12-18', title: 'Fed 降息但點陣圖偏鷹',           type: 'fed',          sectors: ['Bonds','Technology','Real Estate'],                 magnitude: -2, detail: '降息 1 碼但 2025 年預期僅 2 次降息，遠少於市場預期，股市大跌。' },
+  { date: '2025-01-20', title: '川普就職，宣布緊急經濟狀態',     type: 'geopolitical', sectors: ['Energy','Commodities','International'],             magnitude: 1,  detail: '宣布對中國、加拿大、墨西哥加徵關稅，能源政策大轉向。' },
+  { date: '2025-01-27', title: 'DeepSeek R1 震撼 AI 市場',       type: 'earnings',     sectors: ['Technology','Commodities'],                         magnitude: -2, detail: '中國 DeepSeek 以低成本媲美 GPT-4，Nvidia 單日市值蒸發約 6000 億美元。' },
+  { date: '2025-02-19', title: '比特幣突破 $100,000',             type: 'macro',        sectors: ['Crypto'],                                           magnitude: 3,  detail: '機構持續買進 IBIT，比特幣市值超越白銀，加密板塊整體大漲。' },
+  { date: '2025-03-04', title: '關稅戰升級，中美貿易緊張',       type: 'geopolitical', sectors: ['International','Materials','Consumer'],             magnitude: -2, detail: '美國宣布對中國商品加徵額外 25% 關稅，供應鏈重組預期升溫。' },
+  { date: '2025-04-02', title: '解放日：史上最大規模關稅宣布',   type: 'geopolitical', sectors: ['International','Consumer','Industrials','Materials'], magnitude: -3, detail: '對逾 90 個國家課徵對等關稅，全球股市劇烈震盪。' },
+  { date: '2025-04-09', title: '關稅暫停 90 天，市場強彈',       type: 'geopolitical', sectors: ['Technology','Consumer','International'],             magnitude: 3,  detail: '川普宣布對多數國家關稅暫停，納指單日漲逾 12%，史上前三大漲幅之一。' },
+  { date: '2025-04-22', title: 'Fed 鮑威爾警告關稅推升通膨',     type: 'fed',          sectors: ['Bonds','Technology'],                               magnitude: -1, detail: '主席強調通膨風險上升，降息時間表更加不確定。' },
+  { date: '2025-05-07', title: 'Fed 維持利率不變',               type: 'fed',          sectors: ['Bonds','Real Estate'],                              magnitude: 0,  detail: 'Fed 會後聲明維持謹慎立場，等待更多通膨數據明朗化。' },
+];
+
+export const SECTOR_ETFS: Record<string, string[]> = (() => {
+  const map: Record<string, string[]> = {};
+  for (const [sym, info] of Object.entries(ETF_UNIVERSE)) {
+    if (sym === 'SPY') continue;
+    if (!map[info.sector]) map[info.sector] = [];
+    map[info.sector].push(sym);
+  }
+  return map;
+})();
+
+export const TRADING_DAYS_PER_YEAR = 252;
+
+export const MONTH_NAMES = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];

--- a/src/lib/data-engine/cycle.ts
+++ b/src/lib/data-engine/cycle.ts
@@ -1,0 +1,101 @@
+import { SECTOR_ETFS, MACRO_TREE, MONTH_NAMES } from './constants';
+import { generateSeries } from './series';
+import { getAllQuotes, Quote } from './quotes';
+
+export interface CycleRow {
+  sector: string;
+  monthly_returns: Record<string, number>;
+  percentile_rank: number;
+  current_1y: number;
+  best_months: string[];
+  worst_months: string[];
+  color: string;
+}
+
+// Sector colour map that mirrors data.js SECTOR_COLORS_MAP as fallback.
+const SECTOR_COLORS_MAP: Record<string, string> = {
+  Crypto:         '#f7931a',
+  Technology:     '#4a90e2',
+  'Real Estate':  '#8b6d4f',
+  Energy:         '#e67e22',
+  Healthcare:     '#27ae60',
+  Financials:     '#8e44ad',
+  Consumer:       '#e91e8c',
+  Industrials:    '#607d8b',
+  Materials:      '#795548',
+  Utilities:      '#00bcd4',
+  Bonds:          '#3f51b5',
+  Commodities:    '#ffc107',
+  International:  '#ff9800',
+};
+
+export function getCycleData(): CycleRow[] {
+  const quotes = getAllQuotes();
+  const qmap: Record<string, Quote> = {};
+  for (const q of quotes) qmap[q.symbol] = q;
+
+  const today   = new Date();
+  const curYr   = today.getUTCFullYear();
+  const curMon  = today.getUTCMonth() + 1;
+
+  const result: CycleRow[] = [];
+
+  for (const [sector, etfs] of Object.entries(SECTOR_ETFS)) {
+    const validEtfs = etfs.filter(e => qmap[e]).slice(0, 2);
+    if (!validEtfs.length) continue;
+
+    const seriesList = validEtfs.map(e => generateSeries(e, 800));
+    const monthly: Record<string, number> = {};
+
+    for (let yOff = 0; yOff < 3; yOff++) {
+      for (let m = 1; m <= 12; m++) {
+        const yr = curYr - yOff;
+        if (yr === curYr && m > curMon) continue;
+        const key    = `${yr}-${String(m).padStart(2, '0')}`;
+        const prefix = key + '-';
+        const bars   = seriesList.flatMap(s => s.filter(b => b.date.startsWith(prefix)));
+        if (bars.length < 2) continue;
+        bars.sort((a, b) => (a.date < b.date ? -1 : 1));
+        monthly[key] = Math.round((bars[bars.length - 1].close / bars[0].close - 1) * 10000) / 100;
+      }
+    }
+
+    const sortedMonthly = Object.fromEntries(
+      Object.entries(monthly).sort(([a], [b]) => (a < b ? -1 : 1)),
+    );
+    const allRets = Object.values(sortedMonthly);
+    const cur1y   = validEtfs.reduce((s, e) => s + (qmap[e].change_1y ?? 0), 0) / validEtfs.length;
+    const rank    = allRets.length
+      ? Math.round(allRets.filter(r => r <= cur1y).length / allRets.length * 100)
+      : 50;
+
+    const byMonth: Record<number, number[]> = {};
+    for (const [k, v] of Object.entries(monthly)) {
+      const mo = parseInt(k.split('-')[1], 10);
+      (byMonth[mo] = byMonth[mo] ?? []).push(v);
+    }
+    const avgByMonth = Object.entries(byMonth)
+      .map(([m, v]): [number, number] => [+m, v.reduce((s, r) => s + r, 0) / v.length])
+      .sort((a, b) => a[1] - b[1]);
+    const worstMonths = avgByMonth.slice(0, 2).map(([m]) => MONTH_NAMES[m - 1]);
+    const bestMonths  = avgByMonth.slice(-2).map(([m])  => MONTH_NAMES[m - 1]);
+
+    // Colour: prefer MACRO_TREE node that lists this sector's first ETF,
+    // then fall back to the sector colour map.
+    const macroColor = MACRO_TREE.find(
+      n => n.etfs?.length && n.etfs.includes(validEtfs[0]),
+    )?.color;
+
+    result.push({
+      sector,
+      monthly_returns: sortedMonthly,
+      percentile_rank: rank,
+      current_1y:      Math.round(cur1y * 100) / 100,
+      best_months:     bestMonths,
+      worst_months:    worstMonths,
+      color:           SECTOR_COLORS_MAP[sector] ?? macroColor ?? '#58a6ff',
+    });
+  }
+
+  return result;
+}

--- a/src/lib/data-engine/index.ts
+++ b/src/lib/data-engine/index.ts
@@ -1,0 +1,36 @@
+export type { EtfInfo, MacroTreeNode, MockEvent } from './constants';
+export {
+  ETF_UNIVERSE,
+  SECTOR_DRIFT,
+  PERIOD_DAYS,
+  PERIOD_VOL_SCALE,
+  MACRO_TREE,
+  THEME_ETF,
+  MOCK_EVENTS,
+  SECTOR_ETFS,
+  TRADING_DAYS_PER_YEAR,
+  MONTH_NAMES,
+} from './constants';
+
+export { SeededRandom, seedFor } from './prng';
+
+export type { DailySeries } from './series';
+export { generateSeries } from './series';
+
+export type { Quote } from './quotes';
+export { QuoteCache, getAllQuotes } from './quotes';
+
+export type { IndexedPoint, StatsResult } from './stats';
+export { computeStats } from './stats';
+
+export type { BacktestResult, StrategyResult } from './backtest';
+export { runBacktest, runStrategyBacktest } from './backtest';
+
+export type { EtfQuote, MacroNode } from './macro';
+export { getMacroData } from './macro';
+
+export type { ChipRow, FlowMatrix } from './chips';
+export { getChipsData, getFlowMatrix } from './chips';
+
+export type { CycleRow } from './cycle';
+export { getCycleData } from './cycle';

--- a/src/lib/data-engine/macro.ts
+++ b/src/lib/data-engine/macro.ts
@@ -1,0 +1,100 @@
+import { MACRO_TREE, PERIOD_VOL_SCALE, MacroTreeNode } from './constants';
+import { SeededRandom } from './prng';
+import { getAllQuotes, Quote } from './quotes';
+
+export interface EtfQuote {
+  symbol: string;
+  name: string;
+  price: number;
+  change: number;
+}
+
+export interface MacroNode {
+  id: string;
+  name: string;
+  aum: number;
+  change: number;
+  color: string;
+  etfs: string[];
+  etf_quotes: EtfQuote[];
+  children: MacroNode[];
+}
+
+function nodeChange(
+  node: MacroTreeNode,
+  period: string,
+  qmap: Record<string, Quote>,
+): number {
+  const key  = `change_${period}` as keyof Quote;
+  const etfs = (node.etfs ?? []).filter(e => qmap[e]);
+  if (etfs.length > 0) {
+    const sum = etfs.reduce((s, e) => s + (qmap[e][key] as number), 0);
+    return Math.round(sum / etfs.length * 100) / 100;
+  }
+
+  // No mapped ETFs — derive a stable random change from the node id + day.
+  // Matches data.js nodeChange exactly: seed = (base + daily) >>> 0.
+  let hexStr = '';
+  for (let i = 0; i < node.id.length; i++) {
+    hexStr += node.id.charCodeAt(i).toString(16).padStart(2, '0');
+  }
+  const base  = Number(BigInt('0x' + hexStr) % 999983n);
+  const daily = Math.floor(Date.now() / 86400000);
+  const rng   = new SeededRandom((base + daily) >>> 0);
+  const scale = PERIOD_VOL_SCALE[period] ?? 1;
+  return Math.round(rng.gauss(0, node.vol * 100 * scale) * 100) / 100;
+}
+
+export function getMacroData(period: string): MacroNode {
+  const quotes = getAllQuotes();
+  const qmap: Record<string, Quote> = {};
+  for (const q of quotes) qmap[q.symbol] = q;
+
+  const children: Record<string, string[]> = { global: [] };
+  for (const node of MACRO_TREE) {
+    if (!children[node.parent]) children[node.parent] = [];
+    children[node.parent].push(node.id);
+  }
+  const nodeById: Record<string, MacroTreeNode> = {};
+  for (const node of MACRO_TREE) nodeById[node.id] = node;
+
+  function enrich(nodeId: string): MacroNode {
+    if (nodeId === 'global') {
+      const kids     = (children['global'] ?? []).map(enrich);
+      const totalAum = kids.reduce((s, k) => s + k.aum, 0);
+      const wChange  = kids.reduce((s, k) => s + k.aum * k.change, 0) / (totalAum || 1);
+      return {
+        id: 'global', name: '全球資金',
+        aum: Math.round(totalAum * 10) / 10,
+        change: Math.round(wChange * 100) / 100,
+        color: '#58a6ff',
+        etfs: [], etf_quotes: [],
+        children: kids,
+      };
+    }
+
+    const raw  = { ...nodeById[nodeId] };
+    let change = nodeChange(raw, period, qmap);
+    const kids = (children[nodeId] ?? []).map(enrich);
+
+    if (kids.length > 0) {
+      const total = kids.reduce((s, k) => s + k.aum, 0);
+      change = total > 0
+        ? Math.round(kids.reduce((s, k) => s + k.aum * k.change, 0) / total * 100) / 100
+        : change;
+    }
+
+    const etf_quotes: EtfQuote[] = (raw.etfs ?? [])
+      .filter(e => qmap[e])
+      .map(e => ({
+        symbol: e,
+        name:   qmap[e].name,
+        price:  qmap[e].price,
+        change: (qmap[e][`change_${period}` as keyof Quote] as number) ?? 0,
+      }));
+
+    return { id: raw.id, name: raw.name, aum: raw.aum, change, color: raw.color, etfs: raw.etfs, etf_quotes, children: kids };
+  }
+
+  return enrich('global');
+}

--- a/src/lib/data-engine/prng.ts
+++ b/src/lib/data-engine/prng.ts
@@ -1,0 +1,31 @@
+export class SeededRandom {
+  private _s: number;
+
+  constructor(seed: number) {
+    this._s = (seed >>> 0) || 1;
+  }
+
+  private _next(): number {
+    let z = (this._s = (this._s + 0x6D2B79F5) >>> 0);
+    z = Math.imul(z ^ (z >>> 14), (z & 0xFFFF0000) | 1);
+    z ^= z + Math.imul(z ^ (z >>> 7), z | 0x3D8193B);
+    return ((z ^ (z >>> 14)) >>> 0) / 4294967296;
+  }
+
+  gauss(mu: number, sigma: number): number {
+    const u1 = Math.max(1e-10, this._next());
+    const u2 = this._next();
+    const z0 = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+    return mu + z0 * sigma;
+  }
+}
+
+export function seedFor(symbol: string, dayOffset = 0): number {
+  let hexStr = '';
+  for (let i = 0; i < symbol.length; i++) {
+    hexStr += symbol.charCodeAt(i).toString(16).padStart(2, '0');
+  }
+  const base  = BigInt('0x' + hexStr) % 999983n;
+  const daily = BigInt(Math.floor(Date.now() / 86400000)) + BigInt(dayOffset);
+  return Number((base * 6364136223846793005n + daily) % 4294967296n);
+}

--- a/src/lib/data-engine/quotes.ts
+++ b/src/lib/data-engine/quotes.ts
@@ -1,0 +1,78 @@
+import { ETF_UNIVERSE } from './constants';
+import { generateSeries } from './series';
+
+export interface Quote {
+  symbol: string;
+  name: string;
+  sector: string;
+  mcap: number;
+  price: number;
+  change_1d: number;
+  change_5d: number;
+  change_1m: number;
+  change_3m: number;
+  change_6m: number;
+  change_1y: number;
+  change_ytd: number;
+  volume: number;
+}
+
+export class QuoteCache {
+  private static readonly TTL = 60_000;
+  private _data: Quote[] | null = null;
+  private _ts = 0;
+
+  get(): Quote[] {
+    if (this._data && Date.now() - this._ts < QuoteCache.TTL) {
+      return this._data;
+    }
+    return this._refresh();
+  }
+
+  private _refresh(): Quote[] {
+    const yearStart = new Date().getUTCFullYear() + '-01-01';
+    const result: Quote[] = [];
+
+    for (const sym of Object.keys(ETF_UNIVERSE)) {
+      const series = generateSeries(sym, 380);
+      if (series.length < 30) continue;
+
+      const n   = series.length;
+      const cur = series[n - 1].close;
+
+      const p = (idx: number) =>
+        idx >= 0 && idx < n ? series[idx].close : series[0].close;
+
+      const ytdI = series.findIndex(b => b.date >= yearStart);
+      const cYtd = ytdI >= 0 ? series[ytdI].close : series[0].close;
+
+      const pct = (a: number, b: number) => Math.round((a / b - 1) * 10000) / 100;
+
+      result.push({
+        symbol:     sym,
+        name:       ETF_UNIVERSE[sym].name,
+        sector:     ETF_UNIVERSE[sym].sector,
+        mcap:       ETF_UNIVERSE[sym].mcap,
+        price:      Math.round(cur * 100) / 100,
+        change_1d:  pct(cur, p(n - 2)),
+        change_5d:  pct(cur, p(n - 6)),
+        change_1m:  pct(cur, p(n - 22)),
+        change_3m:  pct(cur, p(n - 66)),
+        change_6m:  pct(cur, p(n - 130)),
+        change_1y:  pct(cur, series[0].close),
+        change_ytd: pct(cur, cYtd),
+        volume:     series[n - 1].volume,
+      });
+    }
+
+    this._data = result;
+    this._ts   = Date.now();
+    return result;
+  }
+}
+
+const _quoteCache = new QuoteCache();
+
+export function getAllQuotes(): Quote[] {
+  return _quoteCache.get();
+}

--- a/src/lib/data-engine/series.ts
+++ b/src/lib/data-engine/series.ts
@@ -1,0 +1,58 @@
+import { ETF_UNIVERSE, SECTOR_DRIFT } from './constants';
+import { SeededRandom, seedFor } from './prng';
+
+export interface DailySeries {
+  date: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function generateSeries(symbol: string, days: number): DailySeries[] {
+  const info = ETF_UNIVERSE[symbol];
+  if (!info) return [];
+
+  const rng   = new SeededRandom(seedFor(symbol));
+  const vol   = info.vol;
+  const drift = SECTOR_DRIFT[info.sector] ?? 0;
+
+  const raw: number[] = [info.base];
+  for (let i = 0; i < days; i++) {
+    raw.push(raw[raw.length - 1] * (1 + rng.gauss(drift, vol)));
+  }
+
+  const scale = info.base / raw[raw.length - 1];
+  for (let i = 0; i < raw.length; i++) raw[i] *= scale;
+
+  const series: DailySeries[] = [];
+  const today  = new Date();
+  const todayMs = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
+
+  for (let i = 0; i <= days; i++) {
+    const d = new Date(todayMs - (days - i) * 86400000);
+    if (d.getUTCDay() === 0 || d.getUTCDay() === 6) continue;
+
+    const close = raw[i];
+    const o  = close * (1 + rng.gauss(0, vol * 0.25));
+    const h  = Math.max(close, o) * (1 + Math.abs(rng.gauss(0, vol * 0.15)));
+    const lo = Math.min(close, o) * (1 - Math.abs(rng.gauss(0, vol * 0.15)));
+    const v  = Math.max(100000, Math.round(rng.gauss(5000000, 1200000)));
+
+    series.push({
+      date:   isoDate(d),
+      open:   Math.round(o  * 100) / 100,
+      high:   Math.round(h  * 100) / 100,
+      low:    Math.round(lo * 100) / 100,
+      close:  Math.round(close * 100) / 100,
+      volume: v,
+    });
+  }
+
+  return series;
+}

--- a/src/lib/data-engine/stats.ts
+++ b/src/lib/data-engine/stats.ts
@@ -1,0 +1,40 @@
+import { TRADING_DAYS_PER_YEAR } from './constants';
+
+export interface IndexedPoint {
+  date: string;
+  value: number;
+}
+
+export interface StatsResult {
+  total_return: number;
+  cagr: number;
+  sharpe: number;
+  max_drawdown: number;
+}
+
+export function computeStats(vals: IndexedPoint[]): StatsResult | Record<string, never> {
+  if (vals.length < 5) return {};
+
+  const ret  = vals[vals.length - 1].value / 100 - 1;
+  const ny   = vals.length / TRADING_DAYS_PER_YEAR;
+  const cagr = ny > 0 ? Math.pow(1 + ret, 1 / ny) - 1 : 0;
+
+  const dr   = vals.slice(1).map((v, i) => v.value / vals[i].value - 1);
+  const mean = dr.reduce((s, r) => s + r, 0) / dr.length;
+  const std  = Math.sqrt(dr.reduce((s, r) => s + (r - mean) ** 2, 0) / dr.length);
+  const sharpe = std > 0 ? (mean / std) * Math.sqrt(TRADING_DAYS_PER_YEAR) : 0;
+
+  let peak = vals[0].value;
+  let maxDd = 0;
+  for (const v of vals) {
+    if (v.value > peak) peak = v.value;
+    maxDd = Math.max(maxDd, (peak - v.value) / peak);
+  }
+
+  return {
+    total_return: Math.round(ret    * 10000) / 100,
+    cagr:         Math.round(cagr   * 10000) / 100,
+    sharpe:       Math.round(sharpe * 100)   / 100,
+    max_drawdown: Math.round(maxDd  * 10000) / 100,
+  };
+}

--- a/src/lib/utils/colors.ts
+++ b/src/lib/utils/colors.ts
@@ -1,0 +1,42 @@
+export const SECTOR_COLORS: Record<string, string> = {
+  "Crypto":        "#f7931a",
+  "Technology":    "#4a90e2",
+  "Real Estate":   "#8b6d4f",
+  "Energy":        "#e67e22",
+  "Healthcare":    "#27ae60",
+  "Financials":    "#8e44ad",
+  "Consumer":      "#e91e8c",
+  "Industrials":   "#607d8b",
+  "Materials":     "#795548",
+  "Utilities":     "#00bcd4",
+  "Bonds":         "#3f51b5",
+  "Commodities":   "#ffc107",
+  "International": "#ff9800",
+  "Broad Market":  "#9e9e9e",
+};
+
+export const TREND_PALETTE = ["#4a90e2","#f7931a","#27ae60","#e91e8c","#ffc107","#00bcd4","#e74c3c","#8e44ad"];
+
+export function changeColor(pct: number, alpha = 1): string {
+  const clamp = Math.max(-6, Math.min(6, pct));
+  if (clamp >= 0) {
+    const t = clamp / 6;
+    const g = Math.round(80 + t * 155);
+    return `rgba(0,${g},60,${alpha})`;
+  } else {
+    const t = -clamp / 6;
+    const r = Math.round(80 + t * 160);
+    return `rgba(${r},20,20,${alpha})`;
+  }
+}
+
+export function changeTextColor(pct: number): string {
+  if (pct > 0.1)  return "#4ade80";
+  if (pct < -0.1) return "#f87171";
+  return "#94a3b8";
+}
+
+export function fmtPct(v: number, alwaysSign = true): string {
+  const sign = v >= 0 ? "+" : "";
+  return (alwaysSign ? sign : "") + v.toFixed(2) + "%";
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,54 @@
+// Matches the Quote type from src/lib/data-engine
+export interface Quote {
+  symbol: string; name: string; sector: string; mcap: number;
+  price: number;
+  change_1d: number; change_5d: number; change_1m: number;
+  change_3m: number; change_6m: number; change_1y: number; change_ytd: number;
+  volume: number;
+}
+
+export interface MacroNode {
+  id: string; name: string; aum: number; change: number;
+  color: string; etfs: string[];
+  etf_quotes: { symbol: string; name: string; price: number; change: number }[];
+  children: MacroNode[];
+}
+
+export interface MockEvent {
+  date: string; title: string; type: 'fed' | 'macro' | 'geopolitical' | 'earnings';
+  sectors: string[]; magnitude: number; detail: string;
+}
+
+export interface CycleRow {
+  sector: string; color: string;
+  monthly_returns: Record<string, number>;
+  percentile_rank: number; current_1y: number;
+  best_months: string[]; worst_months: string[];
+}
+
+export interface ChipRow {
+  sector: string;
+  dates: string[];
+  institutional: number[]; smart_money: number[]; retail: number[];
+  cumulative: number[];
+  flow_score: number;
+}
+
+export interface FlowMatrix {
+  sectors: string[]; flow_scores: number[]; volume_ratios: number[];
+  mcaps: number[]; rotation_matrix: number[][];
+}
+
+export interface DailySeries {
+  date: string; open: number; high: number; low: number;
+  close: number; volume: number;
+}
+
+export type Period = '1d' | '5d' | '1m' | '3m' | '6m' | '1y' | 'ytd';
+
+export const TEMPLATES: Record<string, Record<string, number>> = {
+  aggressive: {QQQ:25, SMH:20, IBIT:15, XLE:10, XLF:10, XLY:10, EEM:10},
+  balanced:   {QQQ:20, GLD:10, AGG:15, VNQ:15, EEM:10, XLE:10, XLV:10, TLT:10},
+  defensive:  {AGG:30, TLT:20, XLP:15, XLU:10, GLD:15, VNQ:10},
+  crypto:     {IBIT:50, BITO:30, QQQ:10, ARKK:10},
+};

--- a/style.css
+++ b/style.css
@@ -1019,3 +1019,40 @@ body {
   .chart-wrap.medium { height: 200px; }
   .name-cell    { display: none; }
 }
+
+/* ══════════════════════════════════════════════════════════════════
+   ECONOMIC CYCLE LOCATOR
+══════════════════════════════════════════════════════════════════ */
+.cycle-clock-wrap {
+  display: flex;
+  align-items: flex-start;
+  gap: 2rem;
+  justify-content: center;
+  padding: 0.5rem 0;
+}
+#cycleClockCanvas {
+  flex-shrink: 0;
+  max-width: 500px;
+  width: 62%;
+  background: transparent;
+}
+.cycle-clock-info {
+  flex: 1;
+  min-width: 160px;
+  max-width: 220px;
+  padding-top: 1.25rem;
+}
+.cc-subtitle   { font-size: 0.78rem; color: var(--muted); margin-bottom: 0.35rem; }
+.cc-phase      { font-size: 1.4rem; font-weight: 700; margin-bottom: 0.2rem; }
+.cc-note       { font-size: 0.82rem; color: var(--muted); margin-bottom: 0.9rem; }
+.cc-divider    { border: none; border-top: 1px solid var(--border); margin: 0.6rem 0; }
+.cc-legend-title { font-size: 0.78rem; font-weight: 600; color: var(--text-secondary); margin-bottom: 0.5rem; }
+.cc-row        { display: flex; align-items: center; gap: 0.4rem; margin-bottom: 0.4rem; font-size: 0.8rem; }
+.cc-dot        { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+.cc-row-note   { color: var(--muted); font-size: 0.74rem; margin-left: 0.2rem; }
+
+@media (max-width: 768px) {
+  .cycle-clock-wrap { flex-direction: column; align-items: center; }
+  #cycleClockCanvas { width: 100%; max-width: 420px; }
+  .cycle-clock-info { max-width: 100%; padding-top: 0.5rem; }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
+  theme: { extend: {} },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- **Chord Diagram** replaces the force-directed spring-physics network graph in Tab 5 (板塊關係圖). Sector arcs arranged in a circle; bezier chords connect correlated pairs (blue = positive, orange = negative); chord weight and opacity scale with |correlation| ≥ 0.2. Cleaner and far more readable than the previous jittery node-link layout.

- **Economic Cycle Locator** new section at top of Tab 6 (Events & Cycles). Canvas rotation clock based on Pring-Stovall sector rotation theory. Four phase arcs (擴張期 / 後期擴張 / 收縮衰退 / 復甦期) with each of 14 sectors plotted at its canonical cycle position. White needle computed from flow-score-weighted average of current sector positions. Strong-flow sectors glow. Tab 6 now parallel-fetches flow-matrix + events + cycle data on first open.

## Test plan

- [ ] `python serve.py` → open http://localhost:8000
- [ ] Tab 5 → 板塊關係圖 → 相關性網絡 subtab: chord diagram renders with colored arcs and curved chords
- [ ] Tab 6: rotation clock appears at top with phase arcs, sector dots, and white needle
- [ ] Cycle clock info panel shows current phase label + legend
- [ ] Visiting Tab 6 without Tab 5 still renders the clock (flow-matrix fetched automatically)
- [ ] Responsive layout collapses to column on narrow screens

https://claude.ai/code/session_01SguioBWvxpBCjkosJrMpCx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SguioBWvxpBCjkosJrMpCx)_