### PR TITLE
feat: light/dark theme, full English UI, enhanced Sankey chart

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,24 @@
   --radius:    10px;
   --radius-sm: 6px;
   --shadow:    0 4px 16px rgba(0,0,0,0.4);
+  --chart-grid:rgba(255,255,255,0.05);
+  --chart-tick:#94a3b8;
+}
+
+[data-theme="light"] {
+  --bg:        #f6f8fa;
+  --surface:   #ffffff;
+  --surface2:  #eef0f3;
+  --border:    #d0d7de;
+  --text:      #1f2328;
+  --text-muted:#636c76;
+  --accent:    #0969da;
+  --accent2:   #0550ae;
+  --pos:       #1a7f37;
+  --neg:       #cf222e;
+  --shadow:    0 4px 16px rgba(0,0,0,0.12);
+  --chart-grid:rgba(0,0,0,0.06);
+  --chart-tick:#57606a;
 }
 
 html { scroll-behavior: smooth; }
@@ -99,11 +117,11 @@ body {
 }
 .data-badge {
   font-size: 0.7rem;
-  background: #2d333b;
+  background: var(--surface2);
   color: #ffc107;
   padding: 3px 8px;
   border-radius: 20px;
-  border: 1px solid #4a3f1a;
+  border: 1px solid var(--border);
 }
 .update-time {
   font-size: 0.7rem;
@@ -974,7 +992,7 @@ body {
   display: none;
   position: fixed;
   inset: 0;
-  background: rgba(13, 17, 23, 0.75);
+  background: rgba(0, 0, 0, 0.55);
   backdrop-filter: blur(4px);
   z-index: 999;
   flex-direction: column;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,18 +2,26 @@ import type { Metadata } from 'next';
 import './globals.css';
 
 export const metadata: Metadata = {
-  title: 'Fund Flow Dashboard | 全球資金流向',
+  title: 'Fund Flow Dashboard | Global Capital Flow',
   description: 'Global capital flow analysis platform',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="zh-TW">
+    <html lang="en">
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" crossOrigin="anonymous" />
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" media="print" />
       </head>
-      <body>{children}</body>
+      <body>
+        <script dangerouslySetInnerHTML={{__html: `
+          (function(){
+            var t = localStorage.getItem('theme') || 'dark';
+            document.documentElement.setAttribute('data-theme', t);
+          })();
+        `}} />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -64,7 +64,7 @@ export default function DashboardPage() {
         setEventsData(e);
         setCycleData(c);
         setUpdateTime(
-          '更新於 ' + new Date().toLocaleTimeString('zh-TW'),
+          'Updated ' + new Date().toLocaleTimeString('en-US'),
         );
       })
       .finally(() => setLoading(false));
@@ -86,7 +86,7 @@ export default function DashboardPage() {
         r.json(),
       )) as Quote[];
       setQuotes(q);
-      setUpdateTime('更新於 ' + new Date().toLocaleTimeString('zh-TW'));
+      setUpdateTime('Updated ' + new Date().toLocaleTimeString('en-US'));
     }, 60_000);
     return () => clearInterval(id);
   }, []);

--- a/src/components/charts/RotationClock.tsx
+++ b/src/components/charts/RotationClock.tsx
@@ -24,28 +24,28 @@ interface Phase {
 
 const PHASES: Phase[] = [
   {
-    name: 'Expansion',   nameZh: '擴張期',
+    name: 'Expansion',   nameZh: 'Expansion',
     startAngle: 0,
     color: '#4a90e2',
-    description: '科技/工業/加密領漲，成長加速',
+    description: 'Tech / Industrials / Crypto lead; growth accelerates',
   },
   {
-    name: 'Slowdown',    nameZh: '放緩期',
+    name: 'Slowdown',    nameZh: 'Slowdown',
     startAngle: Math.PI / 2,
     color: '#f7931a',
-    description: '能源/原物料強勢，通膨升溫',
+    description: 'Energy / Commodities strong; inflation rising',
   },
   {
-    name: 'Contraction', nameZh: '收縮期',
+    name: 'Contraction', nameZh: 'Contraction',
     startAngle: Math.PI,
     color: '#e74c3c',
-    description: '防禦板塊：醫療/債券/公用事業',
+    description: 'Defensive sectors: Healthcare / Bonds / Utilities',
   },
   {
-    name: 'Recovery',    nameZh: '復甦期',
+    name: 'Recovery',    nameZh: 'Recovery',
     startAngle: (3 * Math.PI) / 2,
     color: '#27ae60',
-    description: '金融/房地產/消費性股票復甦',
+    description: 'Financials / Real Estate / Consumer recovering',
   },
 ];
 

--- a/src/components/charts/SankeyChart.tsx
+++ b/src/components/charts/SankeyChart.tsx
@@ -40,8 +40,8 @@ export interface SankeyLayout {
 
 // ── Layout constants ────────────────────────────────────────────────────────
 const NODE_WIDTH = 136;
-const NODE_GAP   = 8;
-const MARGIN     = { top: 24, right: 16, bottom: 24, left: 16 };
+const NODE_GAP   = 10;
+const MARGIN     = { top: 28, right: 16, bottom: 28, left: 16 };
 
 // ── Pure layout algorithm (exported for unit tests) ─────────────────────────
 export function computeSankeyLayout(
@@ -80,7 +80,7 @@ export function computeSankeyLayout(
     const totalVal = nodes.reduce((s, n) => s + n.value, 0) || 1;
     let y = MARGIN.top;
     nodes.forEach(n => {
-      n.height = Math.max(22, ((n.value / totalVal) * (availH - totalPad)));
+      n.height = Math.max(28, ((n.value / totalVal) * (availH - totalPad)));
       n.y      = y;
       y += n.height + NODE_GAP;
     });
@@ -179,18 +179,106 @@ export default function SankeyChart({ data }: Props) {
   const totalFlow = sources.reduce((s, n) => s + n.mcap * Math.abs(n.score), 0);
   const totalFlowB = (totalFlow / 100).toFixed(1);
 
+  // Node renderer: gradient + accent bar + label + score badge + AUM
+  function renderNode(n: SankeyNode, x: number, isSource: boolean) {
+    const gradId = `ng-${n.id.replace(/\s+/g, '-')}`;
+    const accentBarW = 3;
+    const labelX = x + NODE_WIDTH / 2;
+    const labelY = n.y + n.height / 2;
+    // Score display
+    const isOut = isSource;
+    const scoreStr = isOut
+      ? `▼ ${Math.abs(n.score).toFixed(1)}`
+      : `▲ ${n.score.toFixed(1)}`;
+    const scoreColor = isOut ? '#f87171' : '#4ade80';
+
+    return (
+      <g key={n.id}>
+        <defs>
+          <linearGradient id={gradId} x1="0%" y1="0%" x2="0%" y2="100%">
+            <stop offset="0%"   stopColor={n.color + 'dd'} />
+            <stop offset="100%" stopColor={n.color + '88'} />
+          </linearGradient>
+        </defs>
+
+        {/* Main node rect with gradient */}
+        <rect
+          x={x} y={n.y}
+          width={NODE_WIDTH} height={n.height}
+          rx={6}
+          fill={`url(#${gradId})`}
+        />
+
+        {/* Accent bar */}
+        <rect
+          x={x} y={n.y}
+          width={accentBarW} height={n.height}
+          rx={3}
+          fill={n.color}
+          fillOpacity={1}
+        />
+
+        {/* Name label */}
+        {n.height >= 20 && (
+          <text
+            x={labelX}
+            y={labelY - (n.height >= 52 ? 14 : 6)}
+            textAnchor="middle"
+            fill="#fff"
+            fontSize={11}
+            fontWeight="700"
+            fontFamily="Inter, sans-serif"
+          >
+            {n.id.length > 14 ? n.id.slice(0, 13) + '…' : n.id}
+          </text>
+        )}
+
+        {/* Score badge */}
+        {n.height >= 38 && (
+          <text
+            x={labelX}
+            y={labelY + 4}
+            textAnchor="middle"
+            fill={scoreColor}
+            fontSize={10}
+            fontWeight="600"
+            fontFamily="Inter, sans-serif"
+          >
+            {scoreStr}
+          </text>
+        )}
+
+        {/* AUM sub-label */}
+        {n.height >= 52 && (
+          <text
+            x={labelX}
+            y={labelY + 18}
+            textAnchor="middle"
+            fill="rgba(255,255,255,0.55)"
+            fontSize={9}
+            fontFamily="Inter, sans-serif"
+          >
+            AUM ${n.mcap}B
+          </text>
+        )}
+      </g>
+    );
+  }
+
   return (
     <div style={{ position: 'relative', width: '100%' }}>
       {/* Legend row */}
       <div className="sankey-legend">
         <span className="sankey-legend-item sankey-legend-out">
-          ← 資金流出板塊
+          <span style={{ display: 'inline-block', width: 8, height: 8, borderRadius: '50%', background: '#f87171', marginRight: 5 }} />
+          Outflow
         </span>
         <span className="sankey-legend-center">
-          估計轉移總量 ~${totalFlowB}B
+          Est. total rotation ~${totalFlowB}B
         </span>
         <span className="sankey-legend-item sankey-legend-in">
-          資金流入板塊 →
+          Inflow
+          <span style={{ display: 'inline-block', width: 8, height: 8, borderRadius: '50%', background: '#4ade80', marginLeft: 5 }} />
         </span>
       </div>
 
@@ -200,6 +288,11 @@ export default function SankeyChart({ data }: Props) {
         aria-label="Capital flow Sankey diagram"
       >
         <defs>
+          <radialGradient id="bg-grad" cx="50%" cy="50%" r="70%">
+            <stop offset="0%"   stopColor="var(--accent)" stopOpacity="0.03" />
+            <stop offset="100%" stopColor="transparent"   stopOpacity="0" />
+          </radialGradient>
+
           {links.map((lk, i) => (
             <linearGradient
               key={i}
@@ -212,6 +305,9 @@ export default function SankeyChart({ data }: Props) {
           ))}
         </defs>
 
+        {/* Subtle radial background */}
+        <rect width="100%" height="100%" fill="url(#bg-grad)" />
+
         {/* Links (drawn behind nodes) */}
         {links.map((lk, i) => {
           const srcX  = srcRightX;
@@ -221,131 +317,75 @@ export default function SankeyChart({ data }: Props) {
           const y2top = lk.target.y + lk.ty;
           const y2bot = y2top + lk.width;
           const isHov = hoveredLink === i;
+          const midX  = (srcX + snkX) / 2;
+          const midY  = (y1top + y2top) / 2 + lk.width / 2;
+          const flowB = (lk.value * lk.source.mcap * 0.01).toFixed(1);
 
           return (
-            <path
-              key={i}
-              d={linkPath(srcX, y1top, y1bot, snkX, y2top, y2bot)}
-              fill={`url(#lg-${i})`}
-              opacity={hoveredLink === null ? 0.65 : isHov ? 0.9 : 0.2}
-              style={{ cursor: 'pointer', transition: 'opacity 0.15s' }}
-              onMouseEnter={e => {
-                setHoveredLink(i);
-                setTooltip({
-                  text: `${lk.source.id} → ${lk.target.id}：估計 $${(lk.value * lk.source.mcap * 0.01).toFixed(1)}B`,
-                  x: e.clientX + 12,
-                  y: e.clientY - 30,
-                });
-              }}
-              onMouseLeave={() => { setHoveredLink(null); setTooltip(null); }}
-            />
+            <g key={i}>
+              <path
+                d={linkPath(srcX, y1top, y1bot, snkX, y2top, y2bot)}
+                fill={`url(#lg-${i})`}
+                fillOpacity={hoveredLink === null ? 0.45 : isHov ? 0.85 : 0.2}
+                style={{
+                  cursor: 'pointer',
+                  transition: 'fill-opacity 0.15s',
+                  filter: isHov
+                    ? `drop-shadow(0 0 6px rgb(${hexToRgb(lk.source.color)}))`
+                    : undefined,
+                }}
+                onMouseEnter={e => {
+                  setHoveredLink(i);
+                  setTooltip({
+                    text: `${lk.source.id} → ${lk.target.id}: ~$${(lk.value * lk.source.mcap * 0.01).toFixed(1)}B`,
+                    x: e.clientX + 12,
+                    y: e.clientY - 30,
+                  });
+                }}
+                onMouseLeave={() => { setHoveredLink(null); setTooltip(null); }}
+              />
+              {/* Flow label on wide links */}
+              {lk.width > 12 && (
+                <text
+                  x={midX}
+                  y={midY}
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  fill="#fff"
+                  fontSize={8}
+                  opacity={0.7}
+                  fontFamily="Inter, sans-serif"
+                  style={{ pointerEvents: 'none' }}
+                >
+                  ${flowB}b
+                </text>
+              )}
+            </g>
           );
         })}
 
         {/* Source nodes */}
-        {sources.map(n => (
-          <g key={n.id}>
-            <rect
-              x={sourceX} y={n.y}
-              width={NODE_WIDTH} height={n.height}
-              rx={4}
-              fill={n.color}
-              fillOpacity={0.85}
-            />
-            <text
-              x={sourceX + NODE_WIDTH / 2}
-              y={n.y + n.height / 2 - 7}
-              textAnchor="middle"
-              fill="#fff"
-              fontSize={11}
-              fontWeight="600"
-              fontFamily="Inter, sans-serif"
-            >
-              {n.id.length > 14 ? n.id.slice(0, 13) + '…' : n.id}
-            </text>
-            <text
-              x={sourceX + NODE_WIDTH / 2}
-              y={n.y + n.height / 2 + 8}
-              textAnchor="middle"
-              fill="#f87171"
-              fontSize={10}
-              fontFamily="Inter, sans-serif"
-            >
-              {n.score.toFixed(1)} 流出
-            </text>
-            <text
-              x={sourceX + NODE_WIDTH / 2}
-              y={n.y + n.height / 2 + 21}
-              textAnchor="middle"
-              fill="rgba(255,255,255,0.55)"
-              fontSize={9}
-              fontFamily="Inter, sans-serif"
-            >
-              AUM ${n.mcap}B
-            </text>
-          </g>
-        ))}
+        {sources.map(n => renderNode(n, sourceX, true))}
 
         {/* Sink nodes */}
-        {sinks.map(n => (
-          <g key={n.id}>
-            <rect
-              x={sinkX} y={n.y}
-              width={NODE_WIDTH} height={n.height}
-              rx={4}
-              fill={n.color}
-              fillOpacity={0.85}
-            />
-            <text
-              x={sinkX + NODE_WIDTH / 2}
-              y={n.y + n.height / 2 - 7}
-              textAnchor="middle"
-              fill="#fff"
-              fontSize={11}
-              fontWeight="600"
-              fontFamily="Inter, sans-serif"
-            >
-              {n.id.length > 14 ? n.id.slice(0, 13) + '…' : n.id}
-            </text>
-            <text
-              x={sinkX + NODE_WIDTH / 2}
-              y={n.y + n.height / 2 + 8}
-              textAnchor="middle"
-              fill="#4ade80"
-              fontSize={10}
-              fontFamily="Inter, sans-serif"
-            >
-              +{n.score.toFixed(1)} 流入
-            </text>
-            <text
-              x={sinkX + NODE_WIDTH / 2}
-              y={n.y + n.height / 2 + 21}
-              textAnchor="middle"
-              fill="rgba(255,255,255,0.55)"
-              fontSize={9}
-              fontFamily="Inter, sans-serif"
-            >
-              AUM ${n.mcap}B
-            </text>
-          </g>
-        ))}
+        {sinks.map(n => renderNode(n, sinkX, false))}
 
         {/* Column headers */}
         <text
-          x={sourceX + NODE_WIDTH / 2} y={12}
+          x={sourceX + NODE_WIDTH / 2} y={14}
           textAnchor="middle" fill="#f87171"
           fontSize={11} fontWeight="700"
           fontFamily="Inter, sans-serif"
         >
-          流出板塊
+          Outflow
         </text>
         <text
-          x={sinkX + NODE_WIDTH / 2} y={12}
+          x={sinkX + NODE_WIDTH / 2} y={14}
           textAnchor="middle" fill="#4ade80"
           fontSize={11} fontWeight="700"
           fontFamily="Inter, sans-serif"
         >
-          流入板塊
+          Inflow
         </text>
       </svg>
 

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useState, useEffect } from 'react';
 import type { Period } from '@/types';
 
 const PERIODS: Period[] = ['1d', '5d', '1m', '3m', '6m', '1y', 'ytd'];
@@ -10,12 +11,26 @@ interface Props {
 }
 
 export default function TopBar({ period, onPeriodChange, updateTime }: Props) {
+  const [theme, setTheme] = useState<'dark' | 'light'>('dark');
+
+  useEffect(() => {
+    const t = document.documentElement.getAttribute('data-theme') as 'dark' | 'light';
+    setTheme(t === 'light' ? 'light' : 'dark');
+  }, []);
+
+  function toggleTheme() {
+    const next = theme === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+  }
+
   return (
     <header className="topbar">
       <div className="topbar-brand">
         <span className="brand-icon">⚡</span>
         <span className="brand-name">Fund Flow</span>
-        <span className="brand-sub">全球資金流向分析</span>
+        <span className="brand-sub">Global Capital Flow Analytics</span>
       </div>
       <div className="topbar-period" id="periodBar">
         {PERIODS.map(p => (
@@ -26,6 +41,22 @@ export default function TopBar({ period, onPeriodChange, updateTime }: Props) {
         ))}
       </div>
       <div className="topbar-meta">
+        <button
+          onClick={toggleTheme}
+          title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+          style={{
+            background: 'var(--surface2)',
+            border: '1px solid var(--border)',
+            color: 'var(--text)',
+            padding: '4px 8px',
+            borderRadius: 'var(--radius-sm)',
+            cursor: 'pointer',
+            fontSize: '1rem',
+            lineHeight: 1,
+          }}
+        >
+          {theme === 'dark' ? '☀️' : '🌙'}
+        </button>
         <span className="data-badge">⚙ Mock Data</span>
         <span className="update-time">{updateTime}</span>
       </div>

--- a/src/components/tabs/BacktestTab.tsx
+++ b/src/components/tabs/BacktestTab.tsx
@@ -12,6 +12,7 @@ import {
   Filler,
 } from 'chart.js';
 import { SECTOR_COLORS, fmtPct } from '@/lib/utils/colors';
+import { getChartTheme } from '@/lib/utils/chartTheme';
 import { TEMPLATES } from '@/types';
 import type { Quote } from '@/types';
 
@@ -122,12 +123,13 @@ export default function BacktestTab({ quotes }: Props) {
     }
   }
 
+  const ct = getChartTheme();
   const lineOpts: Record<string, unknown> = {
     responsive: true,
     maintainAspectRatio: false,
     interaction: { mode: 'index', intersect: false },
     plugins: {
-      legend: { labels: { color: '#e2e8f0', font: { size: 12 } } },
+      legend: { labels: { color: ct.text, font: { size: 12 } } },
       tooltip: {
         callbacks: {
           label: (ctx: { dataset: { label: string }; raw: number | null }) =>
@@ -137,35 +139,35 @@ export default function BacktestTab({ quotes }: Props) {
     },
     scales: {
       x: {
-        ticks: { color: '#64748b', maxTicksLimit: 12, maxRotation: 0 },
-        grid: { color: 'rgba(255,255,255,0.04)' },
+        ticks: { color: ct.tick, maxTicksLimit: 12, maxRotation: 0 },
+        grid: { color: ct.grid },
       },
       y: {
         ticks: {
-          color: '#94a3b8',
+          color: ct.tick,
           callback: (v: unknown) => (v as number).toFixed(0),
         },
-        grid: { color: 'rgba(255,255,255,0.06)' },
+        grid: { color: ct.grid },
         title: {
           display: true,
-          text: '指數化報酬（起點=100）',
-          color: '#64748b',
+          text: 'Indexed Return (base = 100)',
+          color: ct.tick,
         },
       },
     },
   };
 
   const STRATS = [
-    { key: 'momentum' as const, label: `動量輪動 (Top${topN})`, color: '#4ade80' },
-    { key: 'equal_weight' as const, label: '等權重', color: '#60a5fa' },
-    { key: 'spy' as const, label: 'SPY 大盤', color: '#94a3b8' },
+    { key: 'momentum' as const, label: `Momentum Rotation (Top${topN})`, color: '#4ade80' },
+    { key: 'equal_weight' as const, label: 'Equal Weight', color: '#60a5fa' },
+    { key: 'spy' as const, label: 'SPY Benchmark', color: '#94a3b8' },
   ];
 
   const STAT_ROWS = [
-    { key: 'total_return' as const, label: '總報酬' },
-    { key: 'cagr' as const, label: '年化 CAGR' },
+    { key: 'total_return' as const, label: 'Total Return' },
+    { key: 'cagr' as const, label: 'CAGR' },
     { key: 'sharpe' as const, label: 'Sharpe Ratio' },
-    { key: 'max_drawdown' as const, label: '最大回撤' },
+    { key: 'max_drawdown' as const, label: 'Max Drawdown' },
   ];
 
   return (
@@ -173,8 +175,8 @@ export default function BacktestTab({ quotes }: Props) {
       {/* Strategy Comparison */}
       <section className="panel">
         <div className="panel-header">
-          <h2>策略比較</h2>
-          <span className="panel-hint">動量輪動 vs 等權重 vs SPY 大盤</span>
+          <h2>Strategy Comparison</h2>
+          <span className="panel-hint">Momentum rotation vs Equal-weight vs SPY</span>
         </div>
         <div className="strat-controls">
           <div className="bt-period-row">
@@ -184,12 +186,12 @@ export default function BacktestTab({ quotes }: Props) {
                 className={`sc-period-btn${scPeriod === p ? ' active' : ''}`}
                 onClick={() => setScPeriod(p)}
               >
-                {p === '1y' ? '1 年' : p === '3y' ? '3 年' : '5 年'}
+                {p === '1y' ? '1Y' : p === '3y' ? '3Y' : '5Y'}
               </button>
             ))}
           </div>
           <div className="strat-topn">
-            每次輪動持有前
+            Hold top
             <select
               className="topn-select"
               value={topN}
@@ -201,7 +203,7 @@ export default function BacktestTab({ quotes }: Props) {
                 </option>
               ))}
             </select>
-            強勢主題
+            Top sectors
           </div>
           <button
             className="run-btn"
@@ -209,7 +211,7 @@ export default function BacktestTab({ quotes }: Props) {
             onClick={runStrategy}
             disabled={stratLoading}
           >
-            {stratLoading ? '計算中…' : '▶ 執行比較'}
+            {stratLoading ? 'Computing…' : '▶ Run Comparison'}
           </button>
         </div>
 
@@ -282,9 +284,8 @@ export default function BacktestTab({ quotes }: Props) {
               />
             </div>
             <div className="strat-note">
-              <strong>動量輪動：</strong>
-              每 21 個交易日，依過去一個月報酬選出前 N
-              強板塊，等權重持有至下次調倉。
+              <strong>Momentum Rotation:</strong>{' '}
+              Every 21 trading days, select the top-N sectors by prior-month return and hold equal-weight until the next rebalance.
             </div>
           </div>
         )}
@@ -293,14 +294,14 @@ export default function BacktestTab({ quotes }: Props) {
       {/* Custom Backtest */}
       <section className="panel">
         <div className="panel-header">
-          <h2>自訂組合回測</h2>
+          <h2>Custom Portfolio Backtest</h2>
           <span className="panel-hint">
-            配置各 ETF 權重，系統計算歷史績效並與 S&P 500 比較
+            Assign ETF weights to compute historical performance vs S&P 500
           </span>
         </div>
         <div className="backtest-builder">
           <div className="builder-controls">
-            <label className="field-label">回測區間</label>
+            <label className="field-label">Backtest Period</label>
             <div className="bt-period-row">
               {['1y', '3y', '5y'].map(p => (
                 <button
@@ -308,12 +309,12 @@ export default function BacktestTab({ quotes }: Props) {
                   className={`bt-period-btn${btPeriod === p ? ' active' : ''}`}
                   onClick={() => setBtPeriod(p)}
                 >
-                  {p === '1y' ? '1 年' : p === '3y' ? '3 年' : '5 年'}
+                  {p === '1y' ? '1Y' : p === '3y' ? '3Y' : '5Y'}
                 </button>
               ))}
             </div>
             <label className="field-label" style={{ marginTop: '1rem' }}>
-              快速模板
+              Quick Templates
             </label>
             <div className="template-row">
               {['aggressive', 'balanced', 'defensive', 'crypto'].map(tpl => (
@@ -323,12 +324,12 @@ export default function BacktestTab({ quotes }: Props) {
                   onClick={() => applyTemplate(tpl)}
                 >
                   {tpl === 'aggressive'
-                    ? '進攻型'
+                    ? 'Aggressive'
                     : tpl === 'balanced'
-                      ? '均衡型'
+                      ? 'Balanced'
                       : tpl === 'defensive'
-                        ? '防禦型'
-                        : '加密貨幣'}
+                        ? 'Defensive'
+                        : 'Crypto'}
                 </button>
               ))}
             </div>
@@ -371,9 +372,9 @@ export default function BacktestTab({ quotes }: Props) {
           </div>
           <div className="builder-actions">
             <div className="alloc-total">
-              已配置：<span>{Math.round(allocTotal)}</span>%{' '}
+              Allocated: <span>{Math.round(allocTotal)}</span>%{' '}
               {Math.round(allocTotal) !== 100 && (
-                <span className="alloc-warn">需配置 100%</span>
+                <span className="alloc-warn">Must sum to 100%</span>
               )}
             </div>
             <button
@@ -381,7 +382,7 @@ export default function BacktestTab({ quotes }: Props) {
               onClick={runBacktest}
               disabled={btLoading || Math.round(allocTotal) !== 100}
             >
-              {btLoading ? '計算中…' : '▶ 執行回測'}
+              {btLoading ? 'Computing…' : '▶ Run Backtest'}
             </button>
           </div>
         </div>
@@ -391,12 +392,12 @@ export default function BacktestTab({ quotes }: Props) {
             <div className="stats-row">
               {[
                 {
-                  label: '總報酬率',
+                  label: 'Total Return',
                   val: fmtPct(btData.stats.total_return),
                   pos: btData.stats.total_return >= 0,
                 },
                 {
-                  label: '年化報酬 CAGR',
+                  label: 'CAGR',
                   val: fmtPct(btData.stats.cagr),
                   pos: btData.stats.cagr >= 0,
                 },
@@ -406,17 +407,17 @@ export default function BacktestTab({ quotes }: Props) {
                   pos: btData.stats.sharpe >= 1,
                 },
                 {
-                  label: '最大回撤',
+                  label: 'Max Drawdown',
                   val: `-${btData.stats.max_drawdown.toFixed(2)}%`,
                   pos: false,
                 },
                 {
-                  label: 'SPY 報酬',
+                  label: 'SPY Return',
                   val: fmtPct(btData.stats.spy_return),
                   pos: btData.stats.spy_return >= 0,
                 },
                 {
-                  label: '超額報酬',
+                  label: 'Excess Return',
                   val: fmtPct(
                     btData.stats.total_return - btData.stats.spy_return,
                   ),
@@ -441,7 +442,7 @@ export default function BacktestTab({ quotes }: Props) {
                   labels: btData.portfolio.map(p => p.date),
                   datasets: [
                     {
-                      label: '我的組合',
+                      label: 'My Portfolio',
                       data: btData.portfolio.map(p => p.value),
                       borderColor: '#4a90e2',
                       backgroundColor: '#4a90e222',
@@ -451,7 +452,7 @@ export default function BacktestTab({ quotes }: Props) {
                       tension: 0.3,
                     },
                     {
-                      label: 'SPY (標普500)',
+                      label: 'SPY (S&P 500)',
                       data: btData.benchmark.map(b => b.value),
                       borderColor: '#94a3b8',
                       backgroundColor: 'transparent',
@@ -473,7 +474,7 @@ export default function BacktestTab({ quotes }: Props) {
                   marginBottom: '0.75rem',
                 }}
               >
-                組合配置
+                Portfolio Weights
               </h3>
               <div className="comp-grid">
                 {allSyms

--- a/src/components/tabs/CycleTab.tsx
+++ b/src/components/tabs/CycleTab.tsx
@@ -129,16 +129,16 @@ export default function CycleTab({ eventsData, cycleData }: Props) {
       {/* Economic Cycle Rotation Clock ─────────────────────────── */}
       <section className="panel">
         <div className="panel-header">
-          <h2>經濟週期定位儀</h2>
+          <h2>Economic Cycle Locator</h2>
           <span className="panel-hint">
-            根據各板塊 52 週百分位排名推估當前市場所處的經濟週期階段
+            Phase estimated from 52-week percentile rank across sectors
           </span>
         </div>
         {cycleData && cycleData.length > 0 ? (
           <div className="clock-layout">
             <RotationClock cycleData={cycleData} />
             <div className="clock-sidebar">
-              <div className="clock-sidebar-title">板塊強弱排名</div>
+              <div className="clock-sidebar-title">Sector Strength Rank</div>
               {sortedCycle.slice(0, 8).map(d => {
                 const clr = d.percentile_rank >= 70 ? '#4ade80'
                           : d.percentile_rank >= 40 ? '#fbbf24'
@@ -163,24 +163,24 @@ export default function CycleTab({ eventsData, cycleData }: Props) {
             </div>
           </div>
         ) : (
-          <p style={{ color: '#64748b' }}>載入中…</p>
+          <p style={{ color: '#64748b' }}>Loading…</p>
         )}
       </section>
 
       {/* Event Timeline ─────────────────────────────────────────── */}
       <section className="panel">
         <div className="panel-header">
-          <h2>重大市場事件時間軸</h2>
-          <span className="panel-hint">點選事件卡查看詳情與受影響板塊</span>
+          <h2>Major Market Events</h2>
+          <span className="panel-hint">Event details and affected sectors</span>
         </div>
         <div className="event-filters">
           {(
             [
-              ['all', '全部'],
-              ['fed', 'Fed/央行'],
-              ['macro', '總體經濟'],
-              ['earnings', '財報/科技'],
-              ['geopolitical', '地緣政治'],
+              ['all', 'All'],
+              ['fed', 'Fed / CB'],
+              ['macro', 'Macro'],
+              ['earnings', 'Earnings'],
+              ['geopolitical', 'Geopolitical'],
             ] as [string, string][]
           ).map(([t, l]) => (
             <button
@@ -208,7 +208,7 @@ export default function CycleTab({ eventsData, cycleData }: Props) {
                   </span>
                   <span className="ev-mag">
                     {'★'.repeat(Math.abs(ev.magnitude)) || '—'}
-                    {ev.magnitude < 0 ? ' 利空' : ' 利多'}
+                    {ev.magnitude < 0 ? ' Bearish' : ' Bullish'}
                   </span>
                 </div>
                 <div className="ev-title">{ev.title}</div>
@@ -233,9 +233,9 @@ export default function CycleTab({ eventsData, cycleData }: Props) {
       {/* Cycle Heatmap ──────────────────────────────────────────── */}
       <section className="panel">
         <div className="panel-header">
-          <h2>板塊歷史月份熱力圖</h2>
+          <h2>Sector Monthly Return Heatmap</h2>
           <span className="panel-hint">
-            各板塊過去 ~25 個月漲跌幅 — 顏色越深代表漲跌越大
+            ~25-month sector returns — deeper color = larger move
           </span>
         </div>
         {cycleData && <CycleHeatmapCanvas cycleData={cycleData} />}
@@ -244,9 +244,9 @@ export default function CycleTab({ eventsData, cycleData }: Props) {
       {/* Percentile Ranks ───────────────────────────────────────── */}
       <section className="panel">
         <div className="panel-header">
-          <h2>52 週百分位排名</h2>
+          <h2>52-Week Percentile Rank</h2>
           <span className="panel-hint">
-            目前1年期報酬在過去 2 年歷史中的相對位置，100 = 歷史最高
+            1Y return ranked against 2Y history · 100 = all-time high
           </span>
         </div>
         <div className="percentile-grid">

--- a/src/components/tabs/FlowChipsTab.tsx
+++ b/src/components/tabs/FlowChipsTab.tsx
@@ -15,6 +15,7 @@ import {
   Filler,
 } from 'chart.js';
 import { SECTOR_COLORS, changeColor } from '@/lib/utils/colors';
+import { getChartTheme } from '@/lib/utils/chartTheme';
 import { SankeyChart } from '@/components/charts';
 import type { Quote, ChipRow, FlowMatrix } from '@/types';
 
@@ -69,11 +70,13 @@ export default function FlowChipsTab({ quotes, period }: Props) {
     return (
       <main className="tab-panel active">
         <div className="panel">
-          <p style={{ color: '#64748b' }}>載入中…</p>
+          <p style={{ color: '#64748b' }}>Loading…</p>
         </div>
       </main>
     );
   }
+
+  const ct = getChartTheme();
 
   const n = flowData.sectors.length;
 
@@ -145,8 +148,8 @@ export default function FlowChipsTab({ quotes, period }: Props) {
       },
     },
     scales: {
-      x: { ticks: { color: '#8b949e' }, grid: { color: '#21262d' } },
-      y: { ticks: { color: '#cdd9e5', font: { size: 11 } }, grid: { color: '#21262d' } },
+      x: { ticks: { color: ct.tick }, grid: { color: ct.grid } },
+      y: { ticks: { color: ct.text, font: { size: 11 } }, grid: { color: ct.grid } },
     },
     animation: { duration: 300 },
   };
@@ -155,7 +158,7 @@ export default function FlowChipsTab({ quotes, period }: Props) {
   const chipRow = chipsData?.find(c => c.sector === chipSector) ?? chipsData?.[0] ?? null;
   const sectors = [...new Set((chipsData ?? []).map(c => c.sector))].sort();
   const isTW = chipMode === 'tw';
-  const chipLabels = isTW ? ['外資', '投信', '自營商'] : ['機構法人', '聰明錢', '散戶'];
+  const chipLabels = isTW ? ['外資', '投信', '自營商'] : ['Institutional', 'Smart Money', 'Retail'];
   const secEtf = quotes.find(q => q.sector === chipRow?.sector && q.symbol !== 'SPY');
 
   return (
@@ -163,9 +166,9 @@ export default function FlowChipsTab({ quotes, period }: Props) {
       {/* Sankey: Capital Rotation Flow ─────────────────────────── */}
       <section className="panel">
         <div className="panel-header">
-          <h2>板塊資金輪動 Sankey</h2>
+          <h2>Sector Rotation Sankey</h2>
           <span className="panel-hint">
-            左側：資金流出板塊 → 右側：資金流入板塊　節點高度 = AUM × 動能強度
+            Left = outflow sectors · Right = inflow sectors · Node height ∝ AUM × momentum
           </span>
         </div>
         <SankeyChart data={flowData} />
@@ -174,14 +177,14 @@ export default function FlowChipsTab({ quotes, period }: Props) {
       {/* Flow Direction ─────────────────────────────────────────── */}
       <section className="panel">
         <div className="panel-header">
-          <h2>資金流向分析</h2>
+          <h2>Capital Flow Analysis</h2>
           <span className="panel-hint">
-            代理指標：動能 × 成交量異常 推估各板塊資金流向
+            Proxy: momentum × volume anomaly — estimated sector capital flows
           </span>
         </div>
         <div className="flow-top-grid">
           <div>
-            <div className="chart-sublabel">板塊輪動象限圖</div>
+            <div className="chart-sublabel">Rotation Quadrant</div>
             <div className="chart-wrap" style={{ height: '340px' }}>
               <Bubble
                 data={{ datasets: bubbleDatasets }}
@@ -196,22 +199,22 @@ export default function FlowChipsTab({ quotes, period }: Props) {
                           const d = ctx.raw as { x: number; y: number; r: number };
                           const sec = ctx.dataset.label ?? '';
                           const score = flowData.flow_scores[flowData.sectors.indexOf(sec)];
-                          return `${sec} | 動能排名:${d.x} | 成交量比:${d.y.toFixed(2)}x | 流向:${score > 0 ? '+' : ''}${score}`;
+                          return `${sec} | Momentum rank:${d.x} | Volume ratio:${d.y.toFixed(2)}x | Flow Score:${score > 0 ? '+' : ''}${score}`;
                         },
                       },
                     },
                   },
                   scales: {
                     x: {
-                      title: { display: true, text: '動能排名 →（右=資金流入）', color: '#8b949e' },
-                      ticks: { color: '#8b949e' },
-                      grid: { color: '#21262d' },
+                      title: { display: true, text: 'Momentum Rank → (right = inflow)', color: ct.tick },
+                      ticks: { color: ct.tick },
+                      grid: { color: ct.grid },
                       min: 0, max: n + 1,
                     },
                     y: {
-                      title: { display: true, text: '成交量比率（vs 30日均）', color: '#8b949e' },
-                      ticks: { color: '#8b949e' },
-                      grid: { color: '#21262d' },
+                      title: { display: true, text: 'Volume Ratio (vs 30d avg)', color: ct.tick },
+                      ticks: { color: ct.tick },
+                      grid: { color: ct.grid },
                     },
                   },
                   animation: { duration: 400 },
@@ -220,14 +223,14 @@ export default function FlowChipsTab({ quotes, period }: Props) {
               />
             </div>
             <div className="quadrant-legend">
-              <span className="ql ql-tr">↗ 強勢流入</span>
-              <span className="ql ql-tl">↖ 高量洗盤</span>
-              <span className="ql ql-br">↘ 整理蓄勢</span>
-              <span className="ql ql-bl">↙ 弱勢流出</span>
+              <span className="ql ql-tr">↗ Strong Inflow</span>
+              <span className="ql ql-tl">↖ High-vol Washout</span>
+              <span className="ql ql-br">↘ Consolidation</span>
+              <span className="ql ql-bl">↙ Weak Outflow</span>
             </div>
           </div>
           <div>
-            <div className="chart-sublabel">板塊資金流向強度</div>
+            <div className="chart-sublabel">Sector Flow Score</div>
             <div className="chart-wrap" style={{ height: '340px' }}>
               <Bar data={scoreBarData} options={barOpts} />
             </div>
@@ -238,13 +241,13 @@ export default function FlowChipsTab({ quotes, period }: Props) {
       {/* Institutional Chips ────────────────────────────────────── */}
       <section className="panel">
         <div className="panel-header">
-          <h2>法人籌碼</h2>
+          <h2>Institutional Chips</h2>
           <span className="panel-hint">
-            模擬三大法人每日淨買超，單位：百萬美元
+            Simulated daily net institutional buy, unit: $M
           </span>
         </div>
         <div className="chip-controls">
-          <label className="field-label">板塊：</label>
+          <label className="field-label">Sector:</label>
           <select
             className="chip-select"
             value={chipSector}
@@ -283,7 +286,7 @@ export default function FlowChipsTab({ quotes, period }: Props) {
         {chipRow && (
           <div className="chip-charts-grid">
             <div>
-              <div className="chart-sublabel">每日淨買超（$M）</div>
+              <div className="chart-sublabel">Daily Net Buy ($M)</div>
               <div className="chart-wrap" style={{ height: '260px' }}>
                 <Bar
                   data={{
@@ -313,11 +316,11 @@ export default function FlowChipsTab({ quotes, period }: Props) {
                     responsive: true,
                     maintainAspectRatio: false,
                     plugins: {
-                      legend: { labels: { color: '#8b949e', boxWidth: 12 } },
+                      legend: { labels: { color: ct.tick, boxWidth: 12 } },
                     },
                     scales: {
-                      x: { ticks: { color: '#8b949e', maxTicksLimit: 8, maxRotation: 30 }, grid: { color: '#21262d' }, stacked: true },
-                      y: { ticks: { color: '#8b949e' }, grid: { color: '#21262d' }, stacked: true, title: { display: true, text: '$M', color: '#8b949e' } },
+                      x: { ticks: { color: ct.tick, maxTicksLimit: 8, maxRotation: 30 }, grid: { color: ct.grid }, stacked: true },
+                      y: { ticks: { color: ct.tick }, grid: { color: ct.grid }, stacked: true, title: { display: true, text: '$M', color: ct.tick } },
                     },
                     animation: { duration: 300 },
                   } as Record<string, unknown>}
@@ -325,14 +328,14 @@ export default function FlowChipsTab({ quotes, period }: Props) {
               </div>
             </div>
             <div>
-              <div className="chart-sublabel">累積機構籌碼 vs ETF 價格</div>
+              <div className="chart-sublabel">Cumulative Institutional vs ETF Price</div>
               <div className="chart-wrap" style={{ height: '260px' }}>
                 <Line
                   data={{
                     labels: chipRow.dates,
                     datasets: [
                       {
-                        label: isTW ? '累積外資買超' : '累積機構買超',
+                        label: isTW ? 'Cumulative Foreign Buy' : 'Cumulative Institutional Buy',
                         data: chipRow.cumulative,
                         borderColor: '#4a90e2',
                         backgroundColor: 'rgba(74,144,226,0.12)',
@@ -357,12 +360,12 @@ export default function FlowChipsTab({ quotes, period }: Props) {
                     responsive: true,
                     maintainAspectRatio: false,
                     plugins: {
-                      legend: { labels: { color: '#8b949e', boxWidth: 12 } },
+                      legend: { labels: { color: ct.tick, boxWidth: 12 } },
                     },
                     scales: {
-                      x: { ticks: { color: '#8b949e', maxTicksLimit: 8, maxRotation: 30 }, grid: { color: '#21262d' } },
-                      y: { ticks: { color: '#4a90e2' }, grid: { color: '#21262d' }, position: 'left', title: { display: true, text: '累積 $M', color: '#4a90e2' } },
-                      y2: { ticks: { color: '#f7931a' }, grid: { display: false }, position: 'right', title: { display: true, text: 'ETF 價格', color: '#f7931a' } },
+                      x: { ticks: { color: ct.tick, maxTicksLimit: 8, maxRotation: 30 }, grid: { color: ct.grid } },
+                      y: { ticks: { color: '#4a90e2' }, grid: { color: ct.grid }, position: 'left', title: { display: true, text: 'Cumul. $M', color: '#4a90e2' } },
+                      y2: { ticks: { color: '#f7931a' }, grid: { display: false }, position: 'right', title: { display: true, text: 'ETF Price', color: '#f7931a' } },
                     },
                     animation: { duration: 300 },
                   } as Record<string, unknown>}

--- a/src/components/tabs/MacroTab.tsx
+++ b/src/components/tabs/MacroTab.tsx
@@ -6,6 +6,7 @@ import {
   Tooltip, Legend, type TooltipItem,
 } from 'chart.js';
 import { changeColor, changeTextColor, fmtPct } from '@/lib/utils/colors';
+import { getChartTheme } from '@/lib/utils/chartTheme';
 import type { MacroNode, Period } from '@/types';
 
 ChartJS.register(ArcElement, BarElement, CategoryScale, LinearScale, Tooltip, Legend);
@@ -30,8 +31,9 @@ export default function MacroTab({ macroData, period }: Props) {
   // Reset path when period changes
   useEffect(() => { setMacroPath(['global']); }, [period]);
 
-  if (!macroData) return <div className="panel"><p style={{color:'#64748b'}}>載入中…</p></div>;
+  if (!macroData) return <div className="panel"><p style={{color:'var(--text-muted)'}}>Loading…</p></div>;
 
+  const ct = getChartTheme();
   const currentId = macroPath[macroPath.length - 1];
   const current = findNode(macroData, currentId) ?? macroData;
   const totalAum = current.children?.length
@@ -76,7 +78,7 @@ export default function MacroTab({ macroData, period }: Props) {
   const barData = {
     labels: sorted.map(c => c.name),
     datasets: [{
-      label: '漲跌 %',
+      label: 'Return %',
       data: sorted.map(c => c.change),
       backgroundColor: sorted.map(c => changeColor(c.change, 0.85)),
       borderColor: sorted.map(c => changeColor(c.change, 1)),
@@ -92,12 +94,12 @@ export default function MacroTab({ macroData, period }: Props) {
     },
     scales: {
       x: {
-        grid: { color: 'rgba(255,255,255,0.05)' },
-        ticks: { color: '#94a3b8', callback: (v: string | number) => fmtPct(v as number) }
+        grid: { color: ct.grid },
+        ticks: { color: ct.tick, callback: (v: string | number) => fmtPct(v as number) }
       },
       y: {
         grid: { display: false },
-        ticks: { color: '#e2e8f0', font: { size: 11 } }
+        ticks: { color: ct.text, font: { size: 11 } }
       }
     }
   };
@@ -125,15 +127,15 @@ export default function MacroTab({ macroData, period }: Props) {
 
         <div className="macro-summary">
           <div className="macro-sum-item">
-            <span className="macro-sum-label">管理資產規模</span>
-            <span className="macro-sum-val">{totalAum.toFixed(1)} 兆美元</span>
+            <span className="macro-sum-label">Total AUM</span>
+            <span className="macro-sum-val">{totalAum.toFixed(1)} T USD</span>
           </div>
           <div className="macro-sum-item">
-            <span className="macro-sum-label">期間漲跌</span>
+            <span className="macro-sum-label">Period Return</span>
             <span className="macro-sum-val" style={{color: changeTextColor(current.change)}}>{fmtPct(current.change)}</span>
           </div>
           <div className="macro-sum-item">
-            <span className="macro-sum-label">子類別數</span>
+            <span className="macro-sum-label">Sub-categories</span>
             <span className="macro-sum-val">{current.children?.length ?? 0}</span>
           </div>
         </div>
@@ -142,14 +144,14 @@ export default function MacroTab({ macroData, period }: Props) {
           <div className="macro-donut-wrap">
             <Doughnut data={donutData} options={donutOptions} />
             <div className="donut-center">
-              <div className="donut-label">全球 AUM</div>
+              <div className="donut-label">Global AUM</div>
               <div className="donut-value">{totalAum.toFixed(1)} T</div>
             </div>
           </div>
           <div className="macro-bar-wrap">
             <div className="panel-header" style={{marginBottom:'0.5rem'}}>
-              <h2>{current.name} — 子類別漲跌</h2>
-              <span className="panel-hint">依漲跌幅排序</span>
+              <h2>{current.name} — Sub-category Returns</h2>
+              <span className="panel-hint">Sorted by return</span>
             </div>
             <div className="chart-wrap" style={{height:'300px'}}>
               <Bar data={barData} options={barOptions} />
@@ -166,7 +168,7 @@ export default function MacroTab({ macroData, period }: Props) {
                 key={c.id}
                 className={`macro-card${hasChildren ? ' macro-card-drillable' : ''}`}
                 onClick={() => hasChildren && drillDown(c.id)}
-                title={hasChildren ? '點擊深入查看' : ''}
+                title={hasChildren ? 'Click to drill down' : ''}
               >
                 <div className="macro-card-color" style={{background: c.color}} />
                 <div className="macro-card-body">
@@ -187,11 +189,11 @@ export default function MacroTab({ macroData, period }: Props) {
         {etfs.length > 0 && (
           <div>
             <div className="panel-header" style={{marginTop:'1.5rem'}}>
-              <h2>{current.name} — 代表 ETF</h2>
+              <h2>{current.name} — Representative ETFs</h2>
             </div>
             <div className="table-wrap">
               <table className="etf-table">
-                <thead><tr><th>代碼</th><th>名稱</th><th>現價</th><th>漲跌 %</th></tr></thead>
+                <thead><tr><th>Ticker</th><th>Name</th><th>Price</th><th>Change %</th></tr></thead>
                 <tbody>
                   {etfs.map(e => (
                     <tr key={e.symbol}>

--- a/src/components/tabs/OverviewTab.tsx
+++ b/src/components/tabs/OverviewTab.tsx
@@ -3,6 +3,7 @@ import { useRef, useEffect, useState } from 'react';
 import { Bar } from 'react-chartjs-2';
 import { Chart as ChartJS, BarElement, CategoryScale, LinearScale, Tooltip, Legend } from 'chart.js';
 import { SECTOR_COLORS, changeColor, changeTextColor, fmtPct } from '@/lib/utils/colors';
+import { getChartTheme } from '@/lib/utils/chartTheme';
 import type { Quote, Period } from '@/types';
 
 ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend);
@@ -201,7 +202,7 @@ export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: 
 
   if (!quotes.length) return (
     <main className="tab-panel active">
-      <div className="panel"><p style={{color:'#64748b'}}>載入中…</p></div>
+      <div className="panel"><p style={{color:'#64748b'}}>Loading…</p></div>
     </main>
   );
 
@@ -238,13 +239,14 @@ export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: 
   const barData = {
     labels: secData.map(d => d.sector),
     datasets: [{
-      label: '漲跌 %',
+      label: 'Return %',
       data: secData.map(d => +d.change.toFixed(2)),
       backgroundColor: secData.map(d => changeColor(d.change, 0.85)),
       borderColor: secData.map(d => changeColor(d.change, 1)),
       borderWidth: 1, borderRadius: 4,
     }],
   };
+  const ct = getChartTheme();
   const barOptions = {
     indexAxis: 'y' as const,
     responsive: true, maintainAspectRatio: false,
@@ -254,12 +256,12 @@ export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: 
     },
     scales: {
       x: {
-        grid: { color: 'rgba(255,255,255,0.05)' },
-        ticks: { color: '#94a3b8', callback: (v: string | number) => fmtPct(v as number) },
+        grid: { color: ct.grid },
+        ticks: { color: ct.tick, callback: (v: string | number) => fmtPct(v as number) },
       },
       y: {
         grid: { display: false },
-        ticks: { color: '#e2e8f0', font: { size: 11 } },
+        ticks: { color: ct.text, font: { size: 11 } },
       },
     },
   };
@@ -289,7 +291,7 @@ export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: 
   }
 
   const mapColumns: [string, string][] = [
-    ['symbol', '代碼'], ['', '名稱'], ['sector', '板塊'], ['price', '現價'],
+    ['symbol', 'Ticker'], ['', 'Name'], ['sector', 'Sector'], ['price', 'Price'],
     ['change_1d', '1D'], ['change_1m', '1M'], ['change_1y', '1Y'], ['mcap', 'AUM(B)'],
   ];
 
@@ -298,7 +300,7 @@ export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: 
       {/* Stat Cards */}
       <section className="stat-row">
         <div className="stat-card">
-          <div className="stat-label">🔥 最強</div>
+          <div className="stat-label">🔥 Top Gainer</div>
           <div className="stat-symbol">{best?.symbol ?? '—'}</div>
           <div className="stat-change" style={{color: changeTextColor((best?.[key] as number) ?? 0)}}>
             {fmtPct((best?.[key] as number) ?? 0)}
@@ -306,7 +308,7 @@ export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: 
           <div className="stat-sector">{best?.sector ?? '—'}</div>
         </div>
         <div className="stat-card">
-          <div className="stat-label">🧊 最弱</div>
+          <div className="stat-label">🧊 Top Loser</div>
           <div className="stat-symbol">{worst?.symbol ?? '—'}</div>
           <div className="stat-change" style={{color: changeTextColor((worst?.[key] as number) ?? 0)}}>
             {fmtPct((worst?.[key] as number) ?? 0)}
@@ -314,15 +316,15 @@ export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: 
           <div className="stat-sector">{worst?.sector ?? '—'}</div>
         </div>
         <div className="stat-card">
-          <div className="stat-label">🌊 熱門板塊</div>
+          <div className="stat-label">🌊 Hot Sector</div>
           <div className="stat-symbol">{hotSector?.sector ?? '—'}</div>
           <div className="stat-change" style={{color: changeTextColor(hotSector?.avg ?? 0)}}>
             {fmtPct(hotSector?.avg ?? 0)}
           </div>
-          <div className="stat-sector">加權平均漲幅</div>
+          <div className="stat-sector">Weighted avg. return</div>
         </div>
         <div className="stat-card">
-          <div className="stat-label">📍 大盤 SPY</div>
+          <div className="stat-label">📍 S&amp;P 500 SPY</div>
           <div className="stat-symbol">{spy ? `$${spy.price.toFixed(2)}` : '—'}</div>
           <div className="stat-change" style={{color: changeTextColor((spy?.[key] as number) ?? 0)}}>
             {spy ? fmtPct((spy[key] as number) ?? 0) : '—'}
@@ -334,22 +336,22 @@ export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: 
       {/* Heatmap */}
       <section className="panel">
         <div className="panel-header">
-          <h2>全球資金熱力圖</h2>
-          <span className="panel-hint">色塊大小 = 市值規模 ／ 顏色深淺 = 漲跌幅</span>
+          <h2>Global Capital Heatmap</h2>
+          <span className="panel-hint">Size = market cap · Color = % change</span>
         </div>
         <HeatmapCanvas quotes={quotes} period={period} />
         <div className="heatmap-legend">
-          <span className="legend-label">跌 &lt; −3%</span>
+          <span className="legend-label">&lt; −3%</span>
           <div className="legend-bar"></div>
-          <span className="legend-label">漲 &gt; +3%</span>
+          <span className="legend-label">&gt; +3%</span>
         </div>
       </section>
 
       {/* Sector bar */}
       <section className="panel">
         <div className="panel-header">
-          <h2>板塊漲跌排行</h2>
-          <span className="panel-hint">各板塊加權平均漲跌幅</span>
+          <h2>Sector Performance</h2>
+          <span className="panel-hint">Market-cap weighted avg. return per sector</span>
         </div>
         <div className="chart-wrap medium">
           <Bar data={barData} options={barOptions} />
@@ -359,14 +361,14 @@ export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: 
       {/* ETF ranking table */}
       <section className="panel">
         <div className="panel-header">
-          <h2>ETF 漲跌排行</h2>
-          <button className="icon-btn" onClick={() => setSortAsc(!sortAsc)} title="切換排序">↕</button>
+          <h2>ETF Performance Ranking</h2>
+          <button className="icon-btn" onClick={() => setSortAsc(!sortAsc)} title="Toggle sort">↕</button>
         </div>
         <div className="table-wrap">
           <table className="etf-table">
             <thead>
               <tr>
-                <th>代碼</th><th>名稱</th><th>板塊</th><th>現價</th><th>漲跌 %</th>
+                <th>Ticker</th><th>Name</th><th>Sector</th><th>Price</th><th>Change %</th>
               </tr>
             </thead>
             <tbody>
@@ -389,13 +391,13 @@ export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: 
       {/* ETF Mapping Table */}
       <section className="panel">
         <div className="panel-header">
-          <h2>ETF 產業對應總表</h2>
-          <span className="panel-hint">點選標的可加入趨勢比較</span>
+          <h2>ETF Universe</h2>
+          <span className="panel-hint">Click a row to add to Trend Analysis</span>
         </div>
         <div className="etfmap-controls">
           <input
             type="text"
-            placeholder="搜尋代碼或名稱…"
+            placeholder="Search symbol or name…"
             className="etfmap-search"
             value={mapSearch}
             onChange={e => setMapSearch(e.target.value)}
@@ -407,7 +409,7 @@ export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: 
                 className={`ef-btn${mapSector === sec ? ' active' : ''}`}
                 onClick={() => setMapSector(sec)}
               >
-                {sec === 'all' ? '全部' : sec}
+                {sec === 'all' ? 'All' : sec}
               </button>
             ))}
           </div>
@@ -435,7 +437,7 @@ export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: 
                   key={r.symbol}
                   className="etfmap-row"
                   style={{ cursor: 'pointer' }}
-                  title="點選加入趨勢比較"
+                  title="Click to add to Trend Analysis"
                   onClick={() => onSelectSymbolForTrend(r.symbol)}
                 >
                   <td>

--- a/src/components/tabs/TrendTab.tsx
+++ b/src/components/tabs/TrendTab.tsx
@@ -6,6 +6,7 @@ import {
   Tooltip, Legend, Filler,
 } from 'chart.js';
 import { SECTOR_COLORS, TREND_PALETTE, fmtPct } from '@/lib/utils/colors';
+import { getChartTheme } from '@/lib/utils/chartTheme';
 import type { Quote, MockEvent, Period, DailySeries } from '@/types';
 
 ChartJS.register(LineElement, PointElement, CategoryScale, LinearScale, Tooltip, Legend, Filler);
@@ -162,12 +163,13 @@ export default function TrendTab({
   });
 
   const chartData = { labels: dates, datasets };
+  const ct = getChartTheme();
   const chartOptions: Record<string, unknown> = {
     responsive: true,
     maintainAspectRatio: false,
     interaction: { mode: 'index', intersect: false },
     plugins: {
-      legend: { labels: { color: '#e2e8f0', font: { size: 12 } } },
+      legend: { labels: { color: ct.text, font: { size: 12 } } },
       tooltip: {
         callbacks: {
           label: (ctx: { dataset: { label: string }; raw: number | null }) =>
@@ -177,15 +179,15 @@ export default function TrendTab({
     },
     scales: {
       x: {
-        ticks: { color: '#64748b', maxTicksLimit: 10, maxRotation: 0 },
-        grid: { color: 'rgba(255,255,255,0.04)' },
+        ticks: { color: ct.tick, maxTicksLimit: 10, maxRotation: 0 },
+        grid: { color: ct.grid },
       },
       y: {
         ticks: {
-          color: '#94a3b8',
+          color: ct.tick,
           callback: (v: unknown) => (v as number).toFixed(0),
         },
-        grid: { color: 'rgba(255,255,255,0.06)' },
+        grid: { color: ct.grid },
       },
     },
   };
@@ -206,9 +208,9 @@ export default function TrendTab({
     <main className="tab-panel active">
       <section className="panel">
         <div className="panel-header">
-          <h2>多標的趨勢比較</h2>
+          <h2>Multi-asset Trend Comparison</h2>
           <span className="panel-hint">
-            選擇最多 6 個標的進行比較（基準化 = 起點 100）
+            Select up to 6 assets to compare (indexed to 100)
           </span>
         </div>
         <div className="symbol-picker">
@@ -230,7 +232,7 @@ export default function TrendTab({
         </div>
         <div className="chart-wrap tall">
           {loading && (
-            <p style={{ color: '#64748b', textAlign: 'center' }}>載入中…</p>
+            <p style={{ color: '#64748b', textAlign: 'center' }}>Loading…</p>
           )}
           {!loading && dates.length > 0 && (
             <Line
@@ -243,12 +245,12 @@ export default function TrendTab({
 
         {/* Correlation matrix */}
         <div className="panel-header" style={{ marginTop: '2rem' }}>
-          <h2>相關性矩陣</h2>
-          <span className="panel-hint">所選標的間的收益率相關係數</span>
+          <h2>Correlation Matrix</h2>
+          <span className="panel-hint">Return correlation among selected assets</span>
         </div>
         <div className="corr-wrap">
           {syms.length < 2 ? (
-            <p style={{ color: '#64748b' }}>選 2+ 個標的</p>
+            <p style={{ color: '#64748b' }}>Select 2+ assets</p>
           ) : (
             <table className="corr-table">
               <thead>

--- a/src/lib/utils/chartTheme.ts
+++ b/src/lib/utils/chartTheme.ts
@@ -1,0 +1,10 @@
+export function getChartTheme() {
+  const light =
+    typeof document !== 'undefined' &&
+    document.documentElement.getAttribute('data-theme') === 'light';
+  return {
+    tick:    light ? '#57606a' : '#8b949e',
+    grid:    light ? 'rgba(0,0,0,0.07)' : '#21262d',
+    text:    light ? '#1f2328' : '#cdd9e5',
+  };
+}


### PR DESCRIPTION
## Summary

- **Light / Dark theme**: CSS custom-property dual-theme system with a ☀️/🌙 toggle button in the TopBar; preference persisted to `localStorage`; anti-FOUC inline script in `layout.tsx` prevents flash on reload
- **Full English UI**: all Chinese UI text translated across every tab component; Taiwan-specific chip labels (`外資` / `投信` / `自營商`) retained as-is; data-layer names (node names from constants) left unchanged
- **Enhanced Sankey chart**: gradient node cards with accent side-bar, colored score badges (▲/▼), hover glow via `drop-shadow` filter, radial background wash, flow-amount labels on links, improved spacing

## Changes

| File | What changed |
|------|-------------|
| `src/app/globals.css` | Added `[data-theme="light"]` token overrides; added `--chart-grid` / `--chart-tick` variables |
| `src/app/layout.tsx` | Anti-FOUC `<script>` reads `localStorage` before first paint |
| `src/lib/utils/chartTheme.ts` | New utility: `getChartTheme()` returns tick/grid/text colors based on active theme |
| `src/components/layout/TopBar.tsx` | Theme toggle button; subtitle → "Global Capital Flow Analytics" |
| `src/app/page.tsx` | Update time string → English locale |
| `src/components/tabs/MacroTab.tsx` | English labels; `getChartTheme()` for chart colors |
| `src/components/tabs/OverviewTab.tsx` | English labels; `getChartTheme()` for chart colors |
| `src/components/tabs/BacktestTab.tsx` | English labels; template names; `getChartTheme()` |
| `src/components/tabs/TrendTab.tsx` | English labels; `getChartTheme()` |
| `src/components/tabs/FlowChipsTab.tsx` | English labels; TW chip labels kept |
| `src/components/tabs/CycleTab.tsx` | English labels; event filter buttons |
| `src/components/charts/RotationClock.tsx` | English phase names and descriptions |
| `src/components/charts/SankeyChart.tsx` | Visual overhaul: gradient nodes, hover glow, flow labels, radial bg |

## Test plan

- [ ] `npm run build` passes (✅ verified)
- [ ] `npm run type-check` no new errors (✅ verified)
- [ ] TopBar shows ☀️ in dark mode, 🌙 in light mode; toggling switches the entire page theme
- [ ] Refreshing the page preserves the selected theme (localStorage)
- [ ] All tab panels render in both light and dark mode without contrast issues
- [ ] Sankey: nodes show gradient fill + score badge; hover link shows glow + tooltip
- [ ] No Chinese text visible in UI except Taiwan chip labels (外資/投信/自營商)

https://claude.ai/code/session_01QV5U9ugz9rMMfvrnXzXT8W

---
_Generated by [Claude Code](https://claude.ai/code/session_01QV5U9ugz9rMMfvrnXzXT8W)_