### PR TITLE
feat: Crisis Atlas — historical crash timeline, sector drawdowns, buy signal scanner

### DIFF
--- a/src/app/api/crisis/route.ts
+++ b/src/app/api/crisis/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { getCrisisData } from '@/lib/data-engine';
+
+export async function GET() {
+  return NextResponse.json(getCrisisData());
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1184,3 +1184,228 @@ body {
   .clock-phase-cards  { grid-template-columns: 1fr; }
   .sankey-legend-center { display: none; }
 }
+
+/* ── Crisis Atlas ──────────────────────────────────────────────── */
+.crisis-wrap {
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.crisis-timeline-wrap {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem 0.75rem;
+}
+
+.crisis-timeline-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 0.75rem;
+}
+
+.crisis-cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 1rem;
+}
+
+.crisis-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem 1.125rem;
+  cursor: pointer;
+  transition: border-color 0.18s, background 0.18s, box-shadow 0.18s;
+}
+.crisis-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+.crisis-card.crisis-card-active {
+  border-color: var(--accent);
+  background: rgba(88, 166, 255, 0.06);
+}
+
+.crisis-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.6rem;
+}
+
+.crisis-card-title {
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.3;
+}
+
+.crisis-card-sev {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #e74c3c;
+  white-space: nowrap;
+  padding-top: 0.1rem;
+}
+
+.crisis-card-date {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+}
+
+.crisis-type-badge {
+  display: inline-block;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 4px;
+  color: #fff;
+  margin-right: 0.4rem;
+}
+
+.crisis-sec-tag {
+  display: inline-block;
+  font-size: 0.66rem;
+  padding: 1px 6px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  margin: 2px;
+}
+
+.crisis-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.4rem;
+  margin-top: 0.6rem;
+}
+
+.crisis-metric {
+  background: var(--surface2);
+  border-radius: var(--radius-sm);
+  padding: 0.35rem 0.5rem;
+  text-align: center;
+}
+
+.crisis-metric-label {
+  font-size: 0.62rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.2rem;
+}
+
+.crisis-metric-val {
+  font-size: 0.88rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+}
+
+.crisis-detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.crisis-detail-stat {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+}
+
+.crisis-detail-stat h4 {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  margin-bottom: 0.75rem;
+}
+
+.comparison-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+}
+
+.comparison-chart-wrap {
+  background: var(--surface2);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem;
+}
+
+.comparison-chart-title {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.5rem;
+  text-align: center;
+}
+
+.crisis-signal-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+}
+
+.crisis-signal-table th {
+  text-align: left;
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.crisis-signal-table td {
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  vertical-align: middle;
+}
+
+.crisis-signal-table tr:last-child td {
+  border-bottom: none;
+}
+
+.crisis-signal-table tr:hover td {
+  background: var(--surface2);
+}
+
+.crisis-buy-gain {
+  font-weight: 700;
+  color: #27ae60;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+}
+
+.crisis-drawdown-val {
+  font-weight: 700;
+  color: #e74c3c;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+}
+
+@media (max-width: 900px) {
+  .crisis-detail-grid  { grid-template-columns: 1fr; }
+  .comparison-grid     { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 600px) {
+  .crisis-cards-grid   { grid-template-columns: 1fr; }
+  .crisis-metrics      { grid-template-columns: repeat(2, 1fr); }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic';
 import TopBar from '@/components/layout/TopBar';
 import TabNav from '@/components/layout/TabNav';
 import Loader from '@/components/layout/Loader';
-import type { Quote, MacroNode, MockEvent, CycleRow, Period } from '@/types';
+import type { Quote, MacroNode, MockEvent, CycleRow, CrisisEvent, Period } from '@/types';
 
 // Dynamic imports to avoid SSR for canvas/chart components
 const MacroTab = dynamic(() => import('@/components/tabs/MacroTab'), {
@@ -25,6 +25,9 @@ const FlowChipsTab = dynamic(() => import('@/components/tabs/FlowChipsTab'), {
 const CycleTab = dynamic(() => import('@/components/tabs/CycleTab'), {
   ssr: false,
 });
+const CrisisTab = dynamic(() => import('@/components/tabs/CrisisTab'), {
+  ssr: false,
+});
 
 export default function DashboardPage() {
   const [loading, setLoading] = useState(true);
@@ -34,6 +37,7 @@ export default function DashboardPage() {
   const [macroData, setMacroData] = useState<MacroNode | null>(null);
   const [eventsData, setEventsData] = useState<MockEvent[] | null>(null);
   const [cycleData, setCycleData] = useState<CycleRow[] | null>(null);
+  const [crisisData, setCrisisData] = useState<CrisisEvent[] | null>(null);
   const [updateTime, setUpdateTime] = useState('—');
   // Trend tab selected symbols
   const [selected, setSelected] = useState<string[]>([
@@ -57,12 +61,14 @@ export default function DashboardPage() {
       fetchMacro(period),
       fetch('/api/events').then(r => r.json()) as Promise<MockEvent[]>,
       fetch('/api/cycle').then(r => r.json()) as Promise<CycleRow[]>,
+      fetch('/api/crisis').then(r => r.json()) as Promise<CrisisEvent[]>,
     ])
-      .then(([q, m, e, c]) => {
+      .then(([q, m, e, c, cr]) => {
         setQuotes(q);
         setMacroData(m);
         setEventsData(e);
         setCycleData(c);
+        setCrisisData(cr);
         setUpdateTime(
           'Updated ' + new Date().toLocaleTimeString('en-US'),
         );
@@ -133,6 +139,9 @@ export default function DashboardPage() {
       )}
       {activeTab === 'cycle' && (
         <CycleTab eventsData={eventsData} cycleData={cycleData} />
+      )}
+      {activeTab === 'crisis' && (
+        <CrisisTab crisisData={crisisData} allEvents={eventsData} />
       )}
     </>
   );

--- a/src/components/layout/TabNav.tsx
+++ b/src/components/layout/TabNav.tsx
@@ -11,6 +11,7 @@ const TABS = [
   { id: 'backtest', label: '🔬 Backtest' },
   { id: 'flow',     label: '📡 Flow & Chips' },
   { id: 'cycle',    label: '📅 Events & Cycles' },
+  { id: 'crisis',   label: '🚨 Crisis Atlas' },
 ];
 
 export default function TabNav({ activeTab, onTabChange }: Props) {

--- a/src/components/tabs/CrisisTab.tsx
+++ b/src/components/tabs/CrisisTab.tsx
@@ -1,0 +1,562 @@
+'use client';
+import { useState, useRef, useEffect } from 'react';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS, BarElement, CategoryScale, LinearScale, Tooltip, Legend,
+} from 'chart.js';
+import { SECTOR_COLORS } from '@/lib/utils/colors';
+import { getChartTheme } from '@/lib/utils/chartTheme';
+import type { CrisisEvent, CrisisPricePoint } from '@/types';
+
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend);
+
+const TYPE_COLORS: Record<string, string> = {
+  fed:          '#4a90e2',
+  macro:        '#27ae60',
+  earnings:     '#f7931a',
+  geopolitical: '#e74c3c',
+};
+
+// ── Mini price chart (SVG sparkline) ─────────────────────────────
+function CrisisSparkline({
+  track,
+  buySignalDay,
+  drawdownDays,
+  width = 260,
+  height = 90,
+}: {
+  track: CrisisPricePoint[];
+  buySignalDay: number;
+  drawdownDays: number;
+  width?: number;
+  height?: number;
+}) {
+  if (!track.length) return null;
+  const days   = track.map(p => p.day);
+  const prices = track.map(p => p.price);
+  const minD = days[0], maxD = days[days.length - 1];
+  const minP = Math.min(...prices) - 1;
+  const maxP = Math.max(...prices) + 1;
+
+  function px(day: number) { return ((day - minD) / (maxD - minD)) * width; }
+  function py(price: number) { return height - ((price - minP) / (maxP - minP)) * height; }
+
+  const pathD = track
+    .map((p, i) => `${i === 0 ? 'M' : 'L'} ${px(p.day).toFixed(1)} ${py(p.price).toFixed(1)}`)
+    .join(' ');
+
+  const areaD = pathD + ` L ${px(maxD).toFixed(1)} ${height} L ${px(minD).toFixed(1)} ${height} Z`;
+
+  const baseline100Y = py(100);
+  const bottomD      = drawdownDays;
+  const signalD      = drawdownDays + buySignalDay;
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} style={{ width: '100%', display: 'block' }}>
+      {/* Baseline */}
+      <line x1={0} y1={baseline100Y} x2={width} y2={baseline100Y}
+        stroke="#30363d" strokeWidth={1} strokeDasharray="3,3" />
+
+      {/* Area fill */}
+      <defs>
+        <linearGradient id="spark-grad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%"   stopColor="#f87171" stopOpacity="0.3" />
+          <stop offset="100%" stopColor="#f87171" stopOpacity="0.02" />
+        </linearGradient>
+      </defs>
+      <path d={areaD} fill="url(#spark-grad)" />
+
+      {/* Price line */}
+      <path d={pathD} fill="none" stroke="#f87171" strokeWidth={1.5} />
+
+      {/* Crash start marker */}
+      <line x1={px(0)} y1={0} x2={px(0)} y2={height}
+        stroke="#f87171" strokeWidth={1} strokeDasharray="2,2" strokeOpacity={0.6} />
+
+      {/* Bottom marker */}
+      {track.find(p => p.day === bottomD) && (
+        <circle cx={px(bottomD)} cy={py(track.find(p => p.day === bottomD)!.price)}
+          r={3} fill="#fbbf24" />
+      )}
+
+      {/* Buy signal marker */}
+      {track.find(p => p.day === signalD) && (
+        <g>
+          <circle cx={px(signalD)} cy={py(track.find(p => p.day === signalD)!.price)}
+            r={4} fill="#4ade80" />
+          <text x={px(signalD) + 5} y={py(track.find(p => p.day === signalD)!.price) - 4}
+            fill="#4ade80" fontSize={7} fontFamily="Inter, sans-serif">BUY</text>
+        </g>
+      )}
+    </svg>
+  );
+}
+
+// ── Timeline SVG ──────────────────────────────────────────────────
+function CrisisTimeline({
+  events,
+  allEvents,
+  selected,
+  onSelect,
+}: {
+  events: CrisisEvent[];
+  allEvents: { date: string; title: string; magnitude: number; type: string }[];
+  selected: string | null;
+  onSelect: (id: string) => void;
+}) {
+  const W = 900;
+  const H = 140;
+  const MARGIN = { left: 40, right: 40, top: 30, bottom: 30 };
+
+  const allDates = allEvents.map(e => new Date(e.date).getTime());
+  const minT = Math.min(...allDates);
+  const maxT = Math.max(...allDates);
+  const span = maxT - minT || 1;
+
+  function tx(dateStr: string) {
+    return MARGIN.left + ((new Date(dateStr).getTime() - minT) / span) * (W - MARGIN.left - MARGIN.right);
+  }
+
+  const MID_Y = H / 2;
+
+  return (
+    <div style={{ overflowX: 'auto' }}>
+      <svg viewBox={`0 0 ${W} ${H}`} style={{ width: '100%', minWidth: '640px', display: 'block' }}>
+        {/* Baseline */}
+        <line x1={MARGIN.left} y1={MID_Y} x2={W - MARGIN.right} y2={MID_Y}
+          stroke="var(--border)" strokeWidth={1.5} />
+
+        {/* Year labels */}
+        {['2024', '2025', '2026'].map(yr => {
+          const x = tx(yr + '-01-01');
+          if (x < MARGIN.left || x > W - MARGIN.right) return null;
+          return (
+            <g key={yr}>
+              <line x1={x} y1={MID_Y - 5} x2={x} y2={MID_Y + 5} stroke="var(--border)" strokeWidth={1} />
+              <text x={x} y={MID_Y + 18} textAnchor="middle"
+                fill="var(--text-muted)" fontSize={10} fontFamily="Inter, sans-serif">{yr}</text>
+            </g>
+          );
+        })}
+
+        {/* All events — small dots */}
+        {allEvents.map((ev, i) => {
+          const x = tx(ev.date);
+          const isCrash = ev.magnitude <= -2;
+          const isPositive = ev.magnitude > 0;
+          const color = isCrash ? '#f87171' : isPositive ? '#4ade80' : TYPE_COLORS[ev.type] ?? '#58a6ff';
+          const barH = Math.abs(ev.magnitude) * 12;
+          const y = isPositive ? MID_Y - barH : MID_Y;
+
+          return (
+            <g key={i} style={{ cursor: isCrash ? 'pointer' : 'default' }}
+              onClick={() => {
+                const crisis = events.find(c => c.date === ev.date);
+                if (crisis) onSelect(crisis.id);
+              }}>
+              <rect x={x - 3} y={y} width={6} height={barH}
+                fill={color} fillOpacity={isCrash ? 0.9 : 0.5} rx={1} />
+              {isCrash && (
+                <text x={x} y={y - 5} textAnchor="middle"
+                  fill={color} fontSize={8} fontFamily="Inter, sans-serif"
+                  fontWeight="600">
+                  {Math.abs(ev.magnitude) >= 3 ? '▼▼▼' : '▼▼'}
+                </text>
+              )}
+            </g>
+          );
+        })}
+
+        {/* Selected highlight ring */}
+        {selected && (() => {
+          const crisis = events.find(c => c.id === selected);
+          if (!crisis) return null;
+          const x = tx(crisis.date);
+          return (
+            <circle cx={x} cy={MID_Y} r={10}
+              fill="none" stroke="#f87171" strokeWidth={1.5} strokeOpacity={0.7} />
+          );
+        })()}
+
+        {/* Legend */}
+        <g transform={`translate(${W - MARGIN.right - 160}, ${MARGIN.top - 18})`}>
+          <rect x={0} y={0} width={6} height={18} fill="#f87171" rx={1} fillOpacity={0.9} />
+          <text x={10} y={13} fill="var(--text-muted)" fontSize={9} fontFamily="Inter, sans-serif">Major crash</text>
+          <rect x={80} y={0} width={6} height={18} fill="#4ade80" rx={1} fillOpacity={0.5} />
+          <text x={90} y={13} fill="var(--text-muted)" fontSize={9} fontFamily="Inter, sans-serif">Rally</text>
+        </g>
+      </svg>
+    </div>
+  );
+}
+
+// ── Crisis Card ───────────────────────────────────────────────────
+function CrisisCard({
+  crisis,
+  isSelected,
+  onClick,
+}: {
+  crisis: CrisisEvent;
+  isSelected: boolean;
+  onClick: () => void;
+}) {
+  const severity = Math.abs(crisis.magnitude);
+  const color = severity >= 3 ? '#f87171' : '#fbbf24';
+
+  return (
+    <div
+      className={`crisis-card${isSelected ? ' crisis-card-active' : ''}`}
+      style={{ borderColor: isSelected ? color : 'var(--border)' }}
+      onClick={onClick}
+    >
+      <div className="crisis-card-header">
+        <div className="crisis-card-sev">
+          {'▼'.repeat(severity)}
+        </div>
+        <div className="crisis-card-date">{crisis.date}</div>
+        <span className="crisis-type-badge"
+          style={{ background: TYPE_COLORS[crisis.type] ?? '#58a6ff' }}>
+          {crisis.type}
+        </span>
+      </div>
+
+      <div className="crisis-card-title">{crisis.title}</div>
+
+      <div className="crisis-metrics">
+        <div className="crisis-metric">
+          <span className="crisis-metric-label">Max Drawdown</span>
+          <span className="crisis-metric-val" style={{ color: '#f87171' }}>
+            {crisis.maxDrawdown.toFixed(1)}%
+          </span>
+        </div>
+        <div className="crisis-metric">
+          <span className="crisis-metric-label">Days to Bottom</span>
+          <span className="crisis-metric-val">{crisis.drawdownDays}d</span>
+        </div>
+        <div className="crisis-metric">
+          <span className="crisis-metric-label">Recovery</span>
+          <span className="crisis-metric-val" style={{ color: '#4ade80' }}>
+            {crisis.recoveryDays}d
+          </span>
+        </div>
+        <div className="crisis-metric">
+          <span className="crisis-metric-label">Buy Signal Gain</span>
+          <span className="crisis-metric-val" style={{ color: '#4ade80' }}>
+            +{crisis.buySignalGain}%
+          </span>
+        </div>
+      </div>
+
+      <CrisisSparkline
+        track={crisis.priceTrack}
+        buySignalDay={crisis.buySignalDay}
+        drawdownDays={crisis.drawdownDays}
+      />
+
+      <div className="crisis-sectors">
+        {crisis.sectors.map(s => (
+          <span key={s} className="crisis-sec-tag"
+            style={{ borderColor: SECTOR_COLORS[s] ?? '#444', color: SECTOR_COLORS[s] ?? '#ccc' }}>
+            {s}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Sector Drawdown Comparison bar chart ──────────────────────────
+function SectorDrawdownChart({ crisis }: { crisis: CrisisEvent }) {
+  const ct = getChartTheme();
+  const entries = Object.entries(crisis.sectorDrawdowns)
+    .sort((a, b) => a[1] - b[1]);
+  const labels = entries.map(([s]) => s);
+  const values = entries.map(([, v]) => v);
+  const colors = labels.map(s => (SECTOR_COLORS[s] ?? '#58a6ff') + 'cc');
+
+  return (
+    <div style={{ height: '280px' }}>
+      <Bar
+        data={{
+          labels,
+          datasets: [{
+            label: 'Drawdown %',
+            data: values,
+            backgroundColor: colors,
+            borderColor: labels.map(s => SECTOR_COLORS[s] ?? '#58a6ff'),
+            borderWidth: 1,
+            borderRadius: 3,
+          }],
+        }}
+        options={{
+          indexAxis: 'y',
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: { label: (c: { raw: unknown }) => ` ${(c.raw as number).toFixed(1)}%` },
+            },
+          },
+          scales: {
+            x: {
+              ticks: { color: ct.tick, callback: (v: unknown) => `${v}%` },
+              grid: { color: ct.grid },
+            },
+            y: { ticks: { color: ct.text, font: { size: 10 } }, grid: { display: false } },
+          },
+          animation: { duration: 250 },
+        } as Record<string, unknown>}
+      />
+    </div>
+  );
+}
+
+// ── Cross-crisis comparison ───────────────────────────────────────
+function ComparisonChart({ crises }: { crises: CrisisEvent[] }) {
+  const ct = getChartTheme();
+  const labels = crises.map(c => c.date);
+
+  return (
+    <div className="comparison-grid">
+      {([
+        ['Max Drawdown (%)', crises.map(c => c.maxDrawdown), '#f87171'],
+        ['Days to Bottom', crises.map(c => c.drawdownDays), '#fbbf24'],
+        ['Recovery Days', crises.map(c => c.recoveryDays), '#60a5fa'],
+        ['Buy Signal Gain (%)', crises.map(c => c.buySignalGain), '#4ade80'],
+      ] as [string, number[], string][]).map(([title, values, color]) => (
+        <div key={title} style={{ height: '180px' }}>
+          <div className="comparison-chart-title">{title}</div>
+          <Bar
+            data={{
+              labels,
+              datasets: [{
+                label: title,
+                data: values,
+                backgroundColor: color + '99',
+                borderColor: color,
+                borderWidth: 1,
+                borderRadius: 4,
+              }],
+            }}
+            options={{
+              responsive: true,
+              maintainAspectRatio: false,
+              plugins: { legend: { display: false } },
+              scales: {
+                x: { ticks: { color: ct.tick, font: { size: 9 } }, grid: { color: ct.grid } },
+                y: { ticks: { color: ct.tick, font: { size: 9 } }, grid: { color: ct.grid } },
+              },
+              animation: { duration: 200 },
+            } as Record<string, unknown>}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Buy Signal Scanner Table ──────────────────────────────────────
+function BuySignalTable({ crises }: { crises: CrisisEvent[] }) {
+  return (
+    <div className="table-wrap">
+      <table className="etf-table">
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Event</th>
+            <th>Max Drawdown</th>
+            <th>Bottom Date</th>
+            <th>Signal Day</th>
+            <th>Signal Gain</th>
+            <th>Recovery Date</th>
+            <th>Recovery Days</th>
+          </tr>
+        </thead>
+        <tbody>
+          {crises.map(c => (
+            <tr key={c.id}>
+              <td className="mono">{c.date}</td>
+              <td style={{ maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {c.title}
+              </td>
+              <td className="mono" style={{ color: '#f87171' }}>{c.maxDrawdown.toFixed(1)}%</td>
+              <td className="mono">{c.bottomDate}</td>
+              <td className="mono">+{c.buySignalDay}d</td>
+              <td className="mono" style={{ color: '#4ade80' }}>+{c.buySignalGain}%</td>
+              <td className="mono">{c.recoveryDate}</td>
+              <td className="mono">{c.recoveryDays}d</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Main CrisisTab ────────────────────────────────────────────────
+interface AllEvent {
+  date: string;
+  title: string;
+  magnitude: number;
+  type: string;
+}
+
+interface Props {
+  crisisData: CrisisEvent[] | null;
+  allEvents: AllEvent[] | null;
+}
+
+export default function CrisisTab({ crisisData, allEvents }: Props) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const detailRef = useRef<HTMLDivElement>(null);
+
+  // Auto-select most severe crash on load
+  useEffect(() => {
+    if (crisisData?.length && !selectedId) {
+      const worst = [...crisisData].sort((a, b) => a.maxDrawdown - b.maxDrawdown)[0];
+      setSelectedId(worst.id);
+    }
+  }, [crisisData, selectedId]);
+
+  if (!crisisData || !allEvents) {
+    return (
+      <main className="tab-panel active">
+        <div className="panel"><p style={{ color: 'var(--text-muted)' }}>Loading…</p></div>
+      </main>
+    );
+  }
+
+  const selectedCrisis = crisisData.find(c => c.id === selectedId) ?? null;
+
+  function handleSelect(id: string) {
+    setSelectedId(id);
+    setTimeout(() => detailRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 50);
+  }
+
+  return (
+    <main className="tab-panel active">
+      {/* Timeline ─────────────────────────────────────────────── */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>Crisis Atlas — Event Timeline</h2>
+          <span className="panel-hint">
+            All market events 2024–2026 · Click a crash bar to inspect
+          </span>
+        </div>
+        <CrisisTimeline
+          events={crisisData}
+          allEvents={allEvents}
+          selected={selectedId}
+          onSelect={handleSelect}
+        />
+      </section>
+
+      {/* Crisis Cards Grid ─────────────────────────────────────── */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>Major Crashes</h2>
+          <span className="panel-hint">Magnitude ≥ 2 · Click card for sector breakdown</span>
+        </div>
+        <div className="crisis-cards-grid">
+          {crisisData.map(crisis => (
+            <CrisisCard
+              key={crisis.id}
+              crisis={crisis}
+              isSelected={selectedId === crisis.id}
+              onClick={() => handleSelect(crisis.id)}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* Detail panel for selected crisis ─────────────────────── */}
+      {selectedCrisis && (
+        <section className="panel" ref={detailRef}>
+          <div className="panel-header">
+            <h2>{selectedCrisis.title}</h2>
+            <span className="panel-hint">{selectedCrisis.date} · {selectedCrisis.detail}</span>
+          </div>
+
+          <div className="crisis-detail-grid">
+            <div>
+              <div className="chart-sublabel">Sector Drawdown Impact</div>
+              <SectorDrawdownChart crisis={selectedCrisis} />
+            </div>
+            <div className="crisis-detail-meta">
+              <div className="crisis-detail-stat">
+                <span className="crisis-detail-label">Crash Start</span>
+                <span className="crisis-detail-val">{selectedCrisis.date}</span>
+              </div>
+              <div className="crisis-detail-stat">
+                <span className="crisis-detail-label">Market Bottom</span>
+                <span className="crisis-detail-val" style={{ color: '#f87171' }}>{selectedCrisis.bottomDate}</span>
+              </div>
+              <div className="crisis-detail-stat">
+                <span className="crisis-detail-label">Max Drawdown</span>
+                <span className="crisis-detail-val" style={{ color: '#f87171' }}>
+                  {selectedCrisis.maxDrawdown.toFixed(1)}%
+                </span>
+              </div>
+              <div className="crisis-detail-stat">
+                <span className="crisis-detail-label">Days to Bottom</span>
+                <span className="crisis-detail-val">{selectedCrisis.drawdownDays} days</span>
+              </div>
+              <div className="crisis-detail-stat">
+                <span className="crisis-detail-label">Buy Signal</span>
+                <span className="crisis-detail-val" style={{ color: '#4ade80' }}>
+                  +{selectedCrisis.buySignalDay}d from bottom
+                </span>
+              </div>
+              <div className="crisis-detail-stat">
+                <span className="crisis-detail-label">Signal → Recovery</span>
+                <span className="crisis-detail-val" style={{ color: '#4ade80' }}>
+                  +{selectedCrisis.buySignalGain}%
+                </span>
+              </div>
+              <div className="crisis-detail-stat">
+                <span className="crisis-detail-label">Full Recovery</span>
+                <span className="crisis-detail-val" style={{ color: '#4ade80' }}>{selectedCrisis.recoveryDate}</span>
+              </div>
+              <div className="crisis-detail-stat">
+                <span className="crisis-detail-label">Recovery Duration</span>
+                <span className="crisis-detail-val">{selectedCrisis.recoveryDays} days</span>
+              </div>
+              <div style={{ marginTop: '1rem' }}>
+                <div className="crisis-detail-label" style={{ marginBottom: '0.4rem' }}>Most Affected Sectors</div>
+                <div className="crisis-sectors">
+                  {selectedCrisis.sectors.map(s => (
+                    <span key={s} className="crisis-sec-tag"
+                      style={{ borderColor: SECTOR_COLORS[s] ?? '#444', color: SECTOR_COLORS[s] ?? '#ccc' }}>
+                      {s}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Buy Signal Scanner ─────────────────────────────────────── */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>Bottom Buy Signal Scanner</h2>
+          <span className="panel-hint">
+            Signal: price ≥ 8% below peak → first 2-day bounce · All signals are simulated
+          </span>
+        </div>
+        <BuySignalTable crises={crisisData} />
+      </section>
+
+      {/* Cross-crisis comparison ─────────────────────────────────── */}
+      <section className="panel">
+        <div className="panel-header">
+          <h2>Cross-Crisis Comparison</h2>
+          <span className="panel-hint">Drawdown depth · Speed to bottom · Recovery duration · Buy signal gain</span>
+        </div>
+        <ComparisonChart crises={crisisData} />
+      </section>
+    </main>
+  );
+}

--- a/src/lib/data-engine/crisis.ts
+++ b/src/lib/data-engine/crisis.ts
@@ -1,0 +1,123 @@
+import { MOCK_EVENTS } from './constants';
+import { SeededRandom } from './prng';
+import type { CrisisEvent, CrisisPricePoint } from '@/types';
+
+// Sector-specific crisis beta — how much each sector amplifies a systemic shock
+const SECTOR_CRISIS_BETA: Record<string, number> = {
+  Crypto:         2.4,
+  Technology:     1.5,
+  'Real Estate':  1.2,
+  Energy:         1.3,
+  Healthcare:     0.55,
+  Financials:     1.4,
+  Consumer:       0.85,
+  Industrials:    1.1,
+  Materials:      1.2,
+  Utilities:      0.45,
+  Bonds:          0.30,
+  Commodities:    0.90,
+  International:  1.15,
+  'Broad Market': 1.0,
+};
+
+function addDays(dateStr: string, n: number): string {
+  const d = new Date(dateStr);
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+function buildPriceTrack(
+  rng: SeededRandom,
+  maxDrawdown: number,
+  drawdownDays: number,
+  recoveryDays: number,
+): CrisisPricePoint[] {
+  const PRE_DAYS = 20;
+  const POST_DAYS = 100;
+  const points: CrisisPricePoint[] = [];
+
+  // Pre-event: gentle drift around 100
+  for (let d = -PRE_DAYS; d < 0; d++) {
+    const noise = rng.gauss(0, 0.3);
+    points.push({ day: d, price: Math.round((100 + noise) * 100) / 100 });
+  }
+
+  // Crash phase: smooth drawdown with noise
+  const crashBottom = 100 + maxDrawdown; // e.g. 100 - 34 = 66
+  for (let d = 0; d <= drawdownDays; d++) {
+    const t = d / drawdownDays;
+    // Accelerates into the bottom (cubic)
+    const base = 100 + maxDrawdown * (3 * t * t - 2 * t * t * t);
+    const noise = rng.gauss(0, Math.abs(maxDrawdown) * 0.02);
+    points.push({ day: d, price: Math.round(Math.max(crashBottom * 0.98, base + noise) * 100) / 100 });
+  }
+
+  // Recovery phase: logarithmic recovery with noise
+  for (let d = 1; d <= POST_DAYS - drawdownDays; d++) {
+    const t = Math.min(1, d / recoveryDays);
+    const base = crashBottom + Math.abs(maxDrawdown) * (1 - Math.exp(-3 * t));
+    const noise = rng.gauss(0, Math.abs(maxDrawdown) * 0.015);
+    const capped = Math.min(102, base + noise);
+    points.push({ day: drawdownDays + d, price: Math.round(capped * 100) / 100 });
+  }
+
+  return points;
+}
+
+export function getCrisisData(): CrisisEvent[] {
+  // Use events with magnitude <= -2 as "crisis" events
+  const crashEvents = MOCK_EVENTS.filter(e => e.magnitude <= -2);
+
+  return crashEvents.map(ev => {
+    // Seed from event date so data is deterministic within a day
+    const dateSeed = ev.date.split('-').reduce((s, p) => s + parseInt(p, 10), 0);
+    const rng = new SeededRandom(dateSeed * 17 + Math.abs(ev.magnitude) * 31);
+
+    const severity = Math.abs(ev.magnitude); // 2 or 3
+
+    // Core metrics seeded from event
+    const maxDrawdown = -(severity === 3
+      ? rng.gauss(28, 6)   // magnitude -3: ~22–40% drawdown
+      : rng.gauss(14, 4)); // magnitude -2: ~8–20% drawdown
+    const drawdownDays  = Math.round(rng.gauss(severity === 3 ? 22 : 14, 4));
+    const recoveryDays  = Math.round(rng.gauss(severity === 3 ? 65 : 35, 10));
+    const buySignalDay  = Math.round(rng.gauss(3, 1));   // ~2–5 days after bottom
+    const buySignalGain = Math.round(rng.gauss(severity === 3 ? 18 : 10, 3) * 10) / 10;
+
+    // Per-sector drawdowns
+    const sectorDrawdowns: Record<string, number> = {};
+    for (const [sector, beta] of Object.entries(SECTOR_CRISIS_BETA)) {
+      const base = maxDrawdown * beta;
+      const noise = rng.gauss(0, Math.abs(base) * 0.15);
+      sectorDrawdowns[sector] = Math.round((base + noise) * 10) / 10;
+    }
+
+    // Override affected sectors to be harder hit
+    ev.sectors.forEach(sec => {
+      if (sectorDrawdowns[sec] !== undefined) {
+        sectorDrawdowns[sec] = Math.round(sectorDrawdowns[sec] * 1.3 * 10) / 10;
+      }
+    });
+
+    const priceTrack = buildPriceTrack(rng, maxDrawdown, drawdownDays, recoveryDays);
+
+    return {
+      id:           ev.date + '-' + ev.type,
+      date:         ev.date,
+      bottomDate:   addDays(ev.date, drawdownDays),
+      recoveryDate: addDays(ev.date, drawdownDays + recoveryDays),
+      title:        ev.title,
+      type:         ev.type,
+      sectors:      ev.sectors,
+      magnitude:    ev.magnitude,
+      detail:       ev.detail,
+      maxDrawdown:  Math.round(maxDrawdown * 10) / 10,
+      drawdownDays,
+      recoveryDays,
+      buySignalDay,
+      buySignalGain,
+      sectorDrawdowns,
+      priceTrack,
+    };
+  });
+}

--- a/src/lib/data-engine/index.ts
+++ b/src/lib/data-engine/index.ts
@@ -34,3 +34,5 @@ export { getChipsData, getFlowMatrix } from './chips';
 
 export type { CycleRow } from './cycle';
 export { getCycleData } from './cycle';
+
+export { getCrisisData } from './crisis';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,6 +46,30 @@ export interface DailySeries {
 
 export type Period = '1d' | '5d' | '1m' | '3m' | '6m' | '1y' | 'ytd';
 
+export interface CrisisPricePoint {
+  day: number;   // relative day (0 = event date)
+  price: number; // normalised (100 = pre-crisis baseline)
+}
+
+export interface CrisisEvent {
+  id: string;
+  date: string;
+  bottomDate: string;
+  recoveryDate: string;
+  title: string;
+  type: string;
+  sectors: string[];
+  magnitude: number;
+  detail: string;
+  maxDrawdown: number;      // negative %, e.g. -34.2
+  drawdownDays: number;     // days from event to trough
+  recoveryDays: number;     // days from trough back to baseline
+  buySignalDay: number;     // day offset from bottom when signal triggers
+  buySignalGain: number;    // % gain from signal to recovery
+  sectorDrawdowns: Record<string, number>; // per-sector estimated max drawdown
+  priceTrack: CrisisPricePoint[];          // normalised 120-day price curve
+}
+
 export const TEMPLATES: Record<string, Record<string, number>> = {
   aggressive: {QQQ:25, SMH:20, IBIT:15, XLE:10, XLF:10, XLY:10, EEM:10},
   balanced:   {QQQ:20, GLD:10, AGG:15, VNQ:15, EEM:10, XLE:10, XLV:10, TLT:10},


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Crisis data engine** (`src/lib/data-engine/crisis.ts`): filters `MOCK_EVENTS` to `magnitude <= -2`, generates per-event metrics (maxDrawdown, drawdownDays, recoveryDays, buySignalDay, sectorDrawdowns) with a seeded PRNG for deterministic daily output. A `SECTOR_CRISIS_BETA` map amplifies systemic shocks per sector. `buildPriceTrack()` produces a 120-day normalised price curve: stable pre-event → cubic-accelerating crash → logarithmic recovery.
- **`GET /api/crisis`** route wired to `getCrisisData()`.
- **`CrisisTab`** component with five sub-sections:
  - **CrisisTimeline** — SVG horizontal timeline showing all events; crash bars are clickable
  - **CrisisCard grid** — sparkline with bottom dot + BUY signal marker, sector tags, severity indicator
  - **SectorDrawdownChart** — horizontal bar chart of per-sector max drawdowns (Chart.js)
  - **ComparisonChart** — 2×2 grid comparing maxDrawdown / drawdownDays / recoveryDays / buySignalGain across all crashes
  - **BuySignalTable** — full-width table of bottom-signal opportunities with gain highlights
- **TabNav** updated with `🚨 Crisis Atlas` tab; **page.tsx** fetch waterfall extended to `/api/crisis`.
- CSS classes for all crisis UI components added to `globals.css` with responsive breakpoints.

## Test plan

- [ ] Navigate to `🚨 Crisis Atlas` tab — timeline renders with all events; crash bars highlighted in red
- [ ] Click each crash bar — corresponding card highlights and detail panel scrolls into view
- [ ] Sector Drawdown chart renders with correct bar orientation and colour coding
- [ ] Comparison 2×2 grid shows metrics across all crisis events
- [ ] Buy Signal table shows gain values in green
- [ ] Light/dark theme toggle — all crisis panels adapt correctly
- [ ] `npm run type-check` passes with zero errors
- [ ] `npm run build` completes successfully

https://claude.ai/code/session_01QV5U9ugz9rMMfvrnXzXT8W
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QV5U9ugz9rMMfvrnXzXT8W)_