### PR TITLE
feat: Cross-Asset Correlation tab — heatmap, pair analysis, divergence alerts

### DIFF
--- a/src/app/api/correlation/route.ts
+++ b/src/app/api/correlation/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { getCorrelationData } from '@/lib/data-engine';
+
+export async function GET() {
+  return NextResponse.json(getCorrelationData());
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1409,3 +1409,165 @@ body {
   .crisis-cards-grid   { grid-template-columns: 1fr; }
   .crisis-metrics      { grid-template-columns: repeat(2, 1fr); }
 }
+
+/* ── Correlation ────────────────────────────────────────────────── */
+.corr-main-layout {
+  display: grid;
+  grid-template-columns: 1fr 220px;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.corr-heatmap-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  overflow-x: auto;
+}
+
+.corr-legend {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.corr-legend-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+}
+
+/* ── Sidebar extremes ─────────────────────────────── */
+.corr-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.corr-sidebar-section {
+  background: var(--surface2);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem;
+}
+
+.corr-sidebar-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.corr-extreme-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.3rem 0.4rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s;
+  margin-bottom: 2px;
+}
+.corr-extreme-item:hover,
+.corr-extreme-item.active {
+  background: rgba(255,255,255,0.06);
+}
+
+.corr-extreme-names {
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.corr-extreme-sep {
+  color: var(--text-muted);
+  margin: 0 3px;
+}
+
+.corr-extreme-val {
+  font-size: 0.72rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+  padding: 1px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+/* ── Pair detail ─────────────────────────────────── */
+.corr-pair-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.corr-pair-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.corr-pair-title {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.corr-pair-badges {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.corr-stat-badge {
+  background: var(--surface2);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 72px;
+}
+
+.corr-stat-label {
+  font-size: 0.62rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.corr-stat-val {
+  font-size: 0.88rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+  color: var(--text);
+}
+
+.corr-diverge-alert {
+  background: rgba(247, 147, 26, 0.1);
+  border: 1px solid rgba(247, 147, 26, 0.35);
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8rem;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.corr-diverge-icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+@media (max-width: 900px) {
+  .corr-main-layout { grid-template-columns: 1fr; }
+  .corr-sidebar     { flex-direction: row; }
+  .corr-sidebar-section { flex: 1; }
+}
+
+@media (max-width: 600px) {
+  .corr-sidebar  { flex-direction: column; }
+  .corr-pair-header { flex-direction: column; align-items: flex-start; }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic';
 import TopBar from '@/components/layout/TopBar';
 import TabNav from '@/components/layout/TabNav';
 import Loader from '@/components/layout/Loader';
-import type { Quote, MacroNode, MockEvent, CycleRow, CrisisEvent, Period } from '@/types';
+import type { Quote, MacroNode, MockEvent, CycleRow, CrisisEvent, CorrelationMatrix, Period } from '@/types';
 
 // Dynamic imports to avoid SSR for canvas/chart components
 const MacroTab = dynamic(() => import('@/components/tabs/MacroTab'), {
@@ -28,6 +28,9 @@ const CycleTab = dynamic(() => import('@/components/tabs/CycleTab'), {
 const CrisisTab = dynamic(() => import('@/components/tabs/CrisisTab'), {
   ssr: false,
 });
+const CorrelationTab = dynamic(() => import('@/components/tabs/CorrelationTab'), {
+  ssr: false,
+});
 
 export default function DashboardPage() {
   const [loading, setLoading] = useState(true);
@@ -38,6 +41,7 @@ export default function DashboardPage() {
   const [eventsData, setEventsData] = useState<MockEvent[] | null>(null);
   const [cycleData, setCycleData] = useState<CycleRow[] | null>(null);
   const [crisisData, setCrisisData] = useState<CrisisEvent[] | null>(null);
+  const [correlationData, setCorrelationData] = useState<CorrelationMatrix | null>(null);
   const [updateTime, setUpdateTime] = useState('—');
   // Trend tab selected symbols
   const [selected, setSelected] = useState<string[]>([
@@ -62,13 +66,15 @@ export default function DashboardPage() {
       fetch('/api/events').then(r => r.json()) as Promise<MockEvent[]>,
       fetch('/api/cycle').then(r => r.json()) as Promise<CycleRow[]>,
       fetch('/api/crisis').then(r => r.json()) as Promise<CrisisEvent[]>,
+      fetch('/api/correlation').then(r => r.json()) as Promise<CorrelationMatrix>,
     ])
-      .then(([q, m, e, c, cr]) => {
+      .then(([q, m, e, c, cr, corr]) => {
         setQuotes(q);
         setMacroData(m);
         setEventsData(e);
         setCycleData(c);
         setCrisisData(cr);
+        setCorrelationData(corr);
         setUpdateTime(
           'Updated ' + new Date().toLocaleTimeString('en-US'),
         );
@@ -142,6 +148,9 @@ export default function DashboardPage() {
       )}
       {activeTab === 'crisis' && (
         <CrisisTab crisisData={crisisData} allEvents={eventsData} />
+      )}
+      {activeTab === 'correlation' && (
+        <CorrelationTab correlationData={correlationData} />
       )}
     </>
   );

--- a/src/components/layout/TabNav.tsx
+++ b/src/components/layout/TabNav.tsx
@@ -11,7 +11,8 @@ const TABS = [
   { id: 'backtest', label: '🔬 Backtest' },
   { id: 'flow',     label: '📡 Flow & Chips' },
   { id: 'cycle',    label: '📅 Events & Cycles' },
-  { id: 'crisis',   label: '🚨 Crisis Atlas' },
+  { id: 'crisis',      label: '🚨 Crisis Atlas' },
+  { id: 'correlation', label: '🔗 Correlation' },
 ];
 
 export default function TabNav({ activeTab, onTabChange }: Props) {

--- a/src/components/tabs/CorrelationTab.tsx
+++ b/src/components/tabs/CorrelationTab.tsx
@@ -1,0 +1,409 @@
+'use client';
+import { useState, useMemo } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS, LineElement, PointElement, CategoryScale,
+  LinearScale, Tooltip, Legend, Filler,
+} from 'chart.js';
+import { SECTOR_COLORS } from '@/lib/utils/colors';
+import { getChartTheme } from '@/lib/utils/chartTheme';
+import type { CorrelationMatrix } from '@/types';
+
+ChartJS.register(LineElement, PointElement, CategoryScale, LinearScale, Tooltip, Legend, Filler);
+
+// ── Color helpers ─────────────────────────────────────────────────
+function corrColor(v: number): string {
+  const c = Math.max(-1, Math.min(1, v));
+  // -1 → deep red · 0 → dark neutral · +1 → blue
+  const neutral = [38, 48, 58];
+  const red     = [210, 48, 42];
+  const blue    = [58, 130, 240];
+  const t       = Math.abs(c);
+  const target  = c < 0 ? red : blue;
+  const r = Math.round(neutral[0] + (target[0] - neutral[0]) * t);
+  const g = Math.round(neutral[1] + (target[1] - neutral[1]) * t);
+  const b = Math.round(neutral[2] + (target[2] - neutral[2]) * t);
+  return `rgb(${r},${g},${b})`;
+}
+
+function corrTextColor(v: number): string {
+  return Math.abs(v) > 0.4 ? 'rgba(255,255,255,0.92)' : 'rgba(180,195,210,0.85)';
+}
+
+function fmtCorr(v: number): string {
+  const s = v.toFixed(2);
+  // ".85" / "-.23" style — strip leading zero
+  return s.replace(/^0\./, '.').replace(/^-0\./, '-.');
+}
+
+// ── Heatmap SVG ────────────────────────────────────────────────────
+const CELL   = 33;
+const LABEL  = 46;
+const HEAD   = 82;
+
+interface HeatmapProps {
+  data: CorrelationMatrix;
+  selected: [number, number] | null;
+  onSelect: (pair: [number, number]) => void;
+}
+
+function CorrelationHeatmap({ data, selected, onSelect }: HeatmapProps) {
+  const n  = data.symbols.length;
+  const W  = LABEL + n * CELL + 6;
+  const H  = HEAD  + n * CELL + 6;
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      style={{ width: '100%', maxWidth: 580, display: 'block', overflow: 'visible' }}
+      aria-label="Correlation heatmap"
+    >
+      {/* Column labels — rotated */}
+      {data.symbols.map((sym, j) => (
+        <text
+          key={`ch-${j}`}
+          transform={`translate(${LABEL + j * CELL + CELL / 2}, ${HEAD - 6}) rotate(-55)`}
+          textAnchor="start"
+          fontSize="10"
+          fontWeight="600"
+          fill={SECTOR_COLORS[data.sectors[j]] ?? '#cdd9e5'}
+        >{sym}</text>
+      ))}
+
+      {/* Row labels */}
+      {data.symbols.map((sym, i) => (
+        <text
+          key={`rh-${i}`}
+          x={LABEL - 5}
+          y={HEAD + i * CELL + CELL / 2 + 4}
+          textAnchor="end"
+          fontSize="10"
+          fontWeight="600"
+          fill={SECTOR_COLORS[data.sectors[i]] ?? '#cdd9e5'}
+        >{sym}</text>
+      ))}
+
+      {/* Cells */}
+      {data.matrix.map((row, i) =>
+        row.map((v, j) => {
+          const isDiag = i === j;
+          const isSel  = selected && (
+            (selected[0] === i && selected[1] === j) ||
+            (selected[0] === j && selected[1] === i)
+          );
+          const x = LABEL + j * CELL;
+          const y = HEAD  + i * CELL;
+          return (
+            <g
+              key={`c-${i}-${j}`}
+              onClick={() => !isDiag && onSelect(i < j ? [i, j] : [j, i])}
+              style={{ cursor: isDiag ? 'default' : 'pointer' }}
+            >
+              <rect
+                x={x} y={y} width={CELL} height={CELL}
+                fill={isDiag ? '#1c2128' : corrColor(v)}
+                stroke={isSel ? '#f0c040' : 'rgba(0,0,0,0.25)'}
+                strokeWidth={isSel ? 2 : 0.5}
+              />
+              {!isDiag && (
+                <text
+                  x={x + CELL / 2} y={y + CELL / 2 + 3.5}
+                  textAnchor="middle" fontSize="8.5"
+                  fill={corrTextColor(v)}
+                >{fmtCorr(v)}</text>
+              )}
+              {isDiag && (
+                <line
+                  x1={x + 4} y1={y + CELL - 4}
+                  x2={x + CELL - 4} y2={y + 4}
+                  stroke="rgba(120,130,145,0.4)" strokeWidth="1"
+                />
+              )}
+            </g>
+          );
+        }),
+      )}
+    </svg>
+  );
+}
+
+// ── Color legend ───────────────────────────────────────────────────
+function CorrLegend() {
+  const steps = 40;
+  const W = 220, H = 12;
+  const rects = Array.from({ length: steps }, (_, i) => {
+    const v = -1 + (2 * i) / (steps - 1);
+    return (
+      <rect
+        key={i}
+        x={(i / steps) * W} y={0}
+        width={W / steps + 0.5} height={H}
+        fill={corrColor(v)}
+      />
+    );
+  });
+  return (
+    <div className="corr-legend">
+      <span className="corr-legend-label" style={{ color: '#d03028' }}>−1</span>
+      <svg viewBox={`0 0 ${W} ${H}`} style={{ width: 160, height: 12, borderRadius: 4, overflow: 'hidden' }}>
+        {rects}
+      </svg>
+      <span className="corr-legend-label" style={{ color: '#3a82f0' }}>+1</span>
+    </div>
+  );
+}
+
+// ── Extreme pairs sidebar ──────────────────────────────────────────
+interface ExtremePairsProps {
+  data: CorrelationMatrix;
+  onSelect: (pair: [number, number]) => void;
+  selected: [number, number] | null;
+}
+
+function ExtremePairs({ data, onSelect, selected }: ExtremePairsProps) {
+  const pairs = useMemo(() => {
+    const list: { i: number; j: number; v: number }[] = [];
+    for (let i = 0; i < data.symbols.length; i++) {
+      for (let j = i + 1; j < data.symbols.length; j++) {
+        list.push({ i, j, v: data.matrix[i][j] });
+      }
+    }
+    list.sort((a, b) => b.v - a.v);
+    return {
+      top:    list.slice(0, 5),
+      bottom: list.slice(-5).reverse(),
+    };
+  }, [data]);
+
+  function PairRow({ i, j, v }: { i: number; j: number; v: number }) {
+    const isSel = selected && selected[0] === i && selected[1] === j;
+    return (
+      <div
+        className={`corr-extreme-item${isSel ? ' active' : ''}`}
+        onClick={() => onSelect([i, j])}
+      >
+        <div className="corr-extreme-names">
+          <span style={{ color: SECTOR_COLORS[data.sectors[i]] }}>{data.symbols[i]}</span>
+          <span className="corr-extreme-sep">·</span>
+          <span style={{ color: SECTOR_COLORS[data.sectors[j]] }}>{data.symbols[j]}</span>
+        </div>
+        <span
+          className="corr-extreme-val"
+          style={{ background: corrColor(v), color: corrTextColor(v) }}
+        >{v >= 0 ? '+' : ''}{v.toFixed(2)}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="corr-sidebar">
+      <div className="corr-sidebar-section">
+        <div className="corr-sidebar-title">Most Correlated</div>
+        {pairs.top.map(({ i, j, v }) => (
+          <PairRow key={`t-${i}-${j}`} i={i} j={j} v={v} />
+        ))}
+      </div>
+      <div className="corr-sidebar-section">
+        <div className="corr-sidebar-title">Most Divergent</div>
+        {pairs.bottom.map(({ i, j, v }) => (
+          <PairRow key={`b-${i}-${j}`} i={i} j={j} v={v} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Rolling correlation chart ──────────────────────────────────────
+interface RollingChartProps {
+  data: CorrelationMatrix;
+  pair: [number, number];
+}
+
+function RollingCorrChart({ data, pair }: RollingChartProps) {
+  const ct = getChartTheme();
+  const [i, j] = pair;
+  const symA = data.symbols[i];
+  const symB = data.symbols[j];
+
+  // Find rolling series for this pair
+  const rollingEntry = useMemo(() => {
+    const [a, b] = [Math.min(i, j), Math.max(i, j)];
+    return data.rolling.find(r =>
+      r.symbols[0] === data.symbols[a] && r.symbols[1] === data.symbols[b],
+    ) ?? null;
+  }, [data, i, j]);
+
+  if (!rollingEntry) return null;
+
+  const values  = rollingEntry.values;
+  const current = values[values.length - 1];
+  const avg     = values.reduce((s, v) => s + v, 0) / values.length;
+  const diverge = Math.abs(current - avg);
+
+  // Weekly labels (W-36 … W-0)
+  const labels = values.map((_, k) => {
+    const wk = values.length - 1 - k;
+    return wk === 0 ? 'Now' : `−${wk}w`;
+  });
+
+  const chartData = {
+    labels,
+    datasets: [
+      {
+        label: 'Rolling 30d Corr',
+        data: values,
+        borderColor: '#4a90e2',
+        backgroundColor: 'rgba(74,144,226,0.12)',
+        borderWidth: 2,
+        pointRadius: 0,
+        fill: true,
+        tension: 0.35,
+      },
+      {
+        label: '1yr Avg',
+        data: values.map(() => avg),
+        borderColor: 'rgba(255,193,7,0.6)',
+        borderDash: [4, 4],
+        borderWidth: 1.5,
+        pointRadius: 0,
+        fill: false,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        labels: { color: ct.text, font: { size: 11 }, boxWidth: 14 },
+      },
+      tooltip: {
+        callbacks: {
+          label: (c: { dataset: { label?: string }; parsed: { y: number } }) =>
+            ` ${c.dataset.label}: ${c.parsed.y.toFixed(3)}`,
+        },
+      },
+    },
+    scales: {
+      x: {
+        ticks: {
+          color: ct.tick,
+          maxTicksLimit: 10,
+          callback: (_v: unknown, idx: number) =>
+            idx % 4 === 0 ? labels[idx] : '',
+        },
+        grid: { color: ct.grid },
+      },
+      y: {
+        min: -1, max: 1,
+        ticks: {
+          color: ct.tick,
+          callback: (v: unknown) => Number(v).toFixed(1),
+        },
+        grid: { color: ct.grid },
+      },
+    },
+    animation: { duration: 300 },
+  } as Record<string, unknown>;
+
+  return (
+    <div className="corr-pair-detail">
+      <div className="corr-pair-header">
+        <div className="corr-pair-title">
+          <span style={{ color: SECTOR_COLORS[data.sectors[i]] }}>{symA}</span>
+          {' '}×{' '}
+          <span style={{ color: SECTOR_COLORS[data.sectors[j]] }}>{symB}</span>
+        </div>
+        <div className="corr-pair-badges">
+          <span className="corr-stat-badge">
+            <span className="corr-stat-label">Current</span>
+            <span
+              className="corr-stat-val"
+              style={{ color: current >= 0 ? '#4a90e2' : '#e74c3c' }}
+            >{current >= 0 ? '+' : ''}{current.toFixed(3)}</span>
+          </span>
+          <span className="corr-stat-badge">
+            <span className="corr-stat-label">1yr Avg</span>
+            <span className="corr-stat-val">{avg >= 0 ? '+' : ''}{avg.toFixed(3)}</span>
+          </span>
+          <span className="corr-stat-badge">
+            <span className="corr-stat-label">Divergence</span>
+            <span
+              className="corr-stat-val"
+              style={{ color: diverge > 0.25 ? '#f7931a' : 'var(--text-muted)' }}
+            >{diverge.toFixed(3)}{diverge > 0.25 ? ' ⚠' : ''}</span>
+          </span>
+        </div>
+      </div>
+      <div style={{ height: 200 }}>
+        <Line data={chartData} options={options} />
+      </div>
+      {diverge > 0.25 && (
+        <div className="corr-diverge-alert">
+          <span className="corr-diverge-icon">⚠</span>
+          Current correlation deviates <strong>{(diverge * 100).toFixed(0)} pts</strong> from
+          the 1-year average — potential mean-reversion opportunity.
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main CorrelationTab ────────────────────────────────────────────
+interface Props {
+  correlationData: CorrelationMatrix | null;
+}
+
+export default function CorrelationTab({ correlationData }: Props) {
+  const [selected, setSelected] = useState<[number, number] | null>(null);
+
+  if (!correlationData) {
+    return (
+      <main className="tab-panel active">
+        <div className="panel">
+          <p style={{ color: 'var(--text-muted)' }}>Loading…</p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="tab-panel active">
+      <section className="panel">
+        <div className="panel-header">
+          <h2>Cross-Asset Correlation Matrix</h2>
+          <span className="panel-hint">
+            16 representative ETFs · 252-day rolling Pearson · Click any cell for pair detail
+          </span>
+        </div>
+
+        <div className="corr-main-layout">
+          <div className="corr-heatmap-wrap">
+            <CorrLegend />
+            <CorrelationHeatmap
+              data={correlationData}
+              selected={selected}
+              onSelect={setSelected}
+            />
+          </div>
+          <ExtremePairs
+            data={correlationData}
+            selected={selected}
+            onSelect={setSelected}
+          />
+        </div>
+      </section>
+
+      {selected && (
+        <section className="panel">
+          <div className="panel-header">
+            <h2>Pair Analysis — Rolling 30-Day Correlation</h2>
+            <span className="panel-hint">Weekly sampling · Dashed line = 1-year average</span>
+          </div>
+          <RollingCorrChart data={correlationData} pair={selected} />
+        </section>
+      )}
+    </main>
+  );
+}

--- a/src/lib/data-engine/correlation.ts
+++ b/src/lib/data-engine/correlation.ts
@@ -1,0 +1,123 @@
+import { ETF_UNIVERSE, SECTOR_DRIFT } from './constants';
+import { SeededRandom, seedFor } from './prng';
+import type { CorrelationMatrix } from '@/types';
+
+// Representative ETFs — one or two per sector, 16 total
+const CORR_SYMBOLS = [
+  'SPY',  // Broad Market
+  'QQQ',  // Technology
+  'SMH',  // Technology (semi)
+  'XLF',  // Financials
+  'XLV',  // Healthcare
+  'XLE',  // Energy
+  'XLY',  // Consumer
+  'XLU',  // Utilities
+  'TLT',  // Bonds (long)
+  'AGG',  // Bonds (agg)
+  'HYG',  // Bonds (HY)
+  'GLD',  // Commodities (gold)
+  'USO',  // Commodities (oil)
+  'VNQ',  // Real Estate
+  'EEM',  // International (EM)
+  'IBIT', // Crypto
+];
+
+// Market beta per sector — drives cross-asset correlation structure
+const SECTOR_BETA: Record<string, number> = {
+  'Broad Market':  1.00,
+  'Technology':    1.10,
+  'Financials':    0.90,
+  'Healthcare':    0.65,
+  'Energy':        0.80,
+  'Consumer':      0.78,
+  'Industrials':   0.85,
+  'Materials':     0.82,
+  'Real Estate':   0.55,
+  'Utilities':     0.35,
+  'Bonds':        -0.15,
+  'Commodities':   0.18,
+  'International': 0.80,
+  'Crypto':        1.20,
+};
+
+const MARKET_VOL = 0.012;
+const TOTAL_DAYS = 304;  // 252 full window + 52-week rolling buffer
+const ROLLING_WINDOW = 30;
+const ROLLING_STEP   = 7;
+const N_ROLLING      = 37; // ~9 months of weekly points
+
+function generateMarketReturns(n: number): number[] {
+  const seed = Math.floor(Date.now() / 86400000) * 98765 + 43210;
+  const rng  = new SeededRandom(seed);
+  return Array.from({ length: n }, () => rng.gauss(0, MARKET_VOL));
+}
+
+function generateFactorReturns(
+  symbol: string,
+  marketReturns: number[],
+): number[] {
+  const info = ETF_UNIVERSE[symbol];
+  if (!info) return marketReturns.map(() => 0);
+
+  const beta    = SECTOR_BETA[info.sector] ?? 0.8;
+  const drift   = SECTOR_DRIFT[info.sector] ?? 0;
+  const idioVar = Math.max(0, info.vol ** 2 - (beta * MARKET_VOL) ** 2);
+  const idioVol = Math.sqrt(idioVar);
+
+  const rng     = new SeededRandom(seedFor(symbol));
+  return marketReturns.map(m => beta * m + rng.gauss(drift, idioVol));
+}
+
+function pearson(a: number[], b: number[]): number {
+  const n = a.length;
+  if (n < 4) return 0;
+  let sa = 0, sb = 0;
+  for (let i = 0; i < n; i++) { sa += a[i]; sb += b[i]; }
+  const ma = sa / n, mb = sb / n;
+  let num = 0, va = 0, vb = 0;
+  for (let i = 0; i < n; i++) {
+    const da = a[i] - ma, db = b[i] - mb;
+    num += da * db; va += da * da; vb += db * db;
+  }
+  const denom = Math.sqrt(va * vb);
+  return denom < 1e-14 ? 0 : Math.round((num / denom) * 1000) / 1000;
+}
+
+export function getCorrelationData(): CorrelationMatrix {
+  const symbols = CORR_SYMBOLS;
+  const n       = symbols.length;
+  const market  = generateMarketReturns(TOTAL_DAYS);
+  const allRet  = symbols.map(s => generateFactorReturns(s, market));
+
+  // Full correlation over the last 252 trading days
+  const matrix: number[][] = Array.from({ length: n }, (_, i) =>
+    Array.from({ length: n }, (__, j) => {
+      if (i === j) return 1;
+      return pearson(allRet[i].slice(-252), allRet[j].slice(-252));
+    }),
+  );
+
+  // Rolling N_ROLLING weekly points for every pair
+  const rolling: CorrelationMatrix['rolling'] = [];
+  const rollStart = TOTAL_DAYS - N_ROLLING * ROLLING_STEP - ROLLING_WINDOW;
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const values = Array.from({ length: N_ROLLING }, (_, k) => {
+        const pos = rollStart + k * ROLLING_STEP;
+        return pearson(
+          allRet[i].slice(pos, pos + ROLLING_WINDOW),
+          allRet[j].slice(pos, pos + ROLLING_WINDOW),
+        );
+      });
+      rolling.push({ symbols: [symbols[i], symbols[j]], values });
+    }
+  }
+
+  return {
+    symbols,
+    names:   symbols.map(s => ETF_UNIVERSE[s]?.name   ?? s),
+    sectors: symbols.map(s => ETF_UNIVERSE[s]?.sector ?? ''),
+    matrix,
+    rolling,
+  };
+}

--- a/src/lib/data-engine/index.ts
+++ b/src/lib/data-engine/index.ts
@@ -36,3 +36,5 @@ export type { CycleRow } from './cycle';
 export { getCycleData } from './cycle';
 
 export { getCrisisData } from './crisis';
+
+export { getCorrelationData } from './correlation';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -70,6 +70,17 @@ export interface CrisisEvent {
   priceTrack: CrisisPricePoint[];          // normalised 120-day price curve
 }
 
+export interface CorrelationMatrix {
+  symbols: string[];
+  names: string[];
+  sectors: string[];
+  matrix: number[][];
+  rolling: {
+    symbols: [string, string];
+    values: number[];
+  }[];
+}
+
 export const TEMPLATES: Record<string, Record<string, number>> = {
   aggressive: {QQQ:25, SMH:20, IBIT:15, XLE:10, XLF:10, XLY:10, EEM:10},
   balanced:   {QQQ:20, GLD:10, AGG:15, VNQ:15, EEM:10, XLE:10, XLV:10, TLT:10},


### PR DESCRIPTION
## Summary

- **Single-factor return model** (`correlation.ts`): a shared date-seeded market factor + per-ETF idiosyncratic noise scaled to maintain target volatility. A `SECTOR_BETA` map (Bonds=−0.15, Utilities=0.35, Tech=1.10, Crypto=1.20…) drives realistic cross-asset correlation structure — equities cluster together, bonds anti-correlate, crypto loosely follows equities.
- **`GET /api/correlation`**: returns 16×16 Pearson matrix (252-day window) + per-pair rolling 30-day correlation series (37 weekly points, 120 pairs).
- **`CorrelationTab`** with three sub-sections:
  - **CorrelationHeatmap** — SVG 16×16 grid with diverging red→gray→blue color scale, inline correlation values, sector-colored axis labels, click-to-select any pair
  - **ExtremePairs sidebar** — top 5 most-correlated and top 5 most-divergent pairs with value badges
  - **RollingCorrChart** — Chart.js line chart for the selected pair showing current 30-day correlation vs 1-year average; orange divergence alert fires when Δ > 0.25
- **`CorrelationMatrix`** type added to `src/types/index.ts`
- `TabNav` gains `🔗 Correlation` tab; `page.tsx` initial fetch waterfall extended to `/api/correlation`

## Test plan

- [ ] Navigate to `🔗 Correlation` — heatmap renders with color-coded cells
- [ ] Equity-equity cells (e.g., SPY × QQQ) show strong positive (blue) correlation
- [ ] Bond cells (TLT, AGG) show negative/near-zero correlation with equities (red tint)
- [ ] Click a cell — pair detail section appears below with rolling chart
- [ ] Sidebar extremes list highlights selected pair
- [ ] Divergence alert shows for pairs where current corr drifts >0.25 from average
- [ ] Light/dark theme toggle — all panels adapt correctly
- [ ] `npm run type-check` passes; `npm run build` succeeds

https://claude.ai/code/session_01QV5U9ugz9rMMfvrnXzXT8W

---
_Generated by [Claude Code](https://claude.ai/code/session_01QV5U9ugz9rMMfvrnXzXT8W)_