### PR TITLE
feat(p2): information architecture — market ticker bar, grouped nav, Cmd+K quick search

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -130,27 +130,20 @@ body {
 }
 
 /* ── Tab Navigation ─────────────────────────────────────────────── */
-.tab-nav {
-  display: flex;
-  gap: 0;
-  background: var(--surface);
-  border-bottom: 1px solid var(--border);
-  padding: 0 1rem;
-  overflow-x: auto;
-}
-
 .tab-btn {
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   font-weight: 500;
-  padding: 0.7rem 1.1rem;
+  padding: 0.65rem 0.9rem;
   cursor: pointer;
   transition: color 0.15s, border-color 0.15s;
   white-space: nowrap;
   font-family: inherit;
+  display: flex;
+  align-items: center;
 }
 .tab-btn:hover { color: var(--text); }
 .tab-btn.active {
@@ -1570,4 +1563,284 @@ body {
 @media (max-width: 600px) {
   .corr-sidebar  { flex-direction: column; }
   .corr-pair-header { flex-direction: column; align-items: flex-start; }
+}
+
+/* ── Market Ticker Bar ─────────────────────────────────────────── */
+.ticker-bar {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  height: 36px;
+  overflow: hidden;
+  position: sticky;
+  top: 56px; /* below TopBar */
+  z-index: 90;
+}
+
+.ticker-inner {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 1rem;
+  gap: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.ticker-inner::-webkit-scrollbar { display: none; }
+
+.ticker-item {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0 0.85rem;
+  height: 100%;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-right: 1px solid var(--border);
+  transition: background 0.15s;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.ticker-item:first-child { border-left: 1px solid var(--border); }
+.ticker-item:hover { background: var(--surface2); }
+
+.ticker-sym {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: 0.04em;
+}
+
+.ticker-price {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+}
+
+.ticker-chg {
+  font-size: 0.72rem;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+}
+
+.ticker-hint {
+  margin-left: auto;
+  padding-left: 1rem;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ── Tab Nav — grouped ─────────────────────────────────────────── */
+.tab-nav {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 92px; /* below TopBar + TickerBar */
+  z-index: 89;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.tab-nav::-webkit-scrollbar { display: none; }
+
+.tab-group {
+  display: flex;
+  align-items: stretch;
+  position: relative;
+}
+
+.tab-group-label {
+  display: flex;
+  align-items: center;
+  padding: 0 0.6rem 0 0.9rem;
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-muted);
+  white-space: nowrap;
+  border-right: 1px solid var(--border);
+  opacity: 0.7;
+}
+
+.tab-sep {
+  width: 1px;
+  background: var(--border);
+  margin: 6px 0;
+}
+
+/* Keyboard shortcut badge — hidden until hover */
+.tab-kbd {
+  display: none;
+  font-size: 0.6rem;
+  padding: 1px 4px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--surface2);
+  color: var(--text-muted);
+  font-family: inherit;
+  margin-left: 4px;
+  vertical-align: middle;
+  line-height: 1.4;
+  pointer-events: none;
+}
+.tab-btn:hover .tab-kbd { display: inline; }
+
+/* ── Quick Search (Cmd+K) ──────────────────────────────────────── */
+.qs-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(3px);
+  z-index: 999;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 120px;
+  animation: qs-fade-in 0.12s ease;
+}
+
+@keyframes qs-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.qs-modal {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  width: 100%;
+  max-width: 520px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  animation: qs-slide-in 0.14s ease;
+}
+
+@keyframes qs-slide-in {
+  from { transform: translateY(-8px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+
+.qs-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.qs-icon {
+  font-size: 1.1rem;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.qs-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: 0.95rem;
+  color: var(--text);
+  font-family: inherit;
+}
+.qs-input::placeholder { color: var(--text-muted); }
+
+.qs-esc {
+  font-size: 0.65rem;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-muted);
+  background: var(--surface2);
+  font-family: inherit;
+  flex-shrink: 0;
+}
+
+.qs-results {
+  max-height: 340px;
+  overflow-y: auto;
+}
+
+.qs-result-item {
+  display: grid;
+  grid-template-columns: 56px 1fr auto auto;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1rem;
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.12s;
+  border-bottom: 1px solid rgba(var(--border-rgb, 48, 54, 61), 0.5);
+}
+.qs-result-item:hover { background: var(--surface2); }
+.qs-result-item:last-child { border-bottom: none; }
+
+.qs-sym {
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.qs-name {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.qs-sector {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.qs-pct {
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+  text-align: right;
+}
+
+.qs-empty {
+  padding: 1.5rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.qs-footer {
+  display: flex;
+  gap: 1.25rem;
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.68rem;
+  color: var(--text-muted);
+}
+.qs-footer kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--surface2);
+  font-size: 0.65rem;
+  font-family: inherit;
+  margin-right: 3px;
+}
+
+/* Light theme adjustments */
+[data-theme="light"] .qs-overlay { background: rgba(0, 0, 0, 0.3); }
+[data-theme="light"] .qs-modal   { box-shadow: 0 24px 60px rgba(0, 0, 0, 0.2); }
+
+@media (max-width: 600px) {
+  .qs-overlay      { padding-top: 60px; align-items: flex-start; }
+  .qs-modal        { max-width: 100%; border-radius: 0; }
+  .tab-group-label { display: none; }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,8 @@ import dynamic from 'next/dynamic';
 import TopBar from '@/components/layout/TopBar';
 import TabNav from '@/components/layout/TabNav';
 import Loader from '@/components/layout/Loader';
+import MarketTickerBar from '@/components/layout/MarketTickerBar';
+import QuickSearch from '@/components/layout/QuickSearch';
 import type { Quote, MacroNode, MockEvent, CycleRow, CrisisEvent, CorrelationMatrix, Period } from '@/types';
 
 // Dynamic imports to avoid SSR for canvas/chart components
@@ -118,7 +120,13 @@ export default function DashboardPage() {
         onPeriodChange={setPeriod}
         updateTime={updateTime}
       />
+      <MarketTickerBar
+        quotes={quotes}
+        period={period}
+        onSelectSymbol={handleSelectSymbolForTrend}
+      />
       <TabNav activeTab={activeTab} onTabChange={setActiveTab} />
+      <QuickSearch quotes={quotes} onSelect={handleSelectSymbolForTrend} />
       <Loader show={loading} />
       {activeTab === 'macro' && (
         <MacroTab macroData={macroData} period={period} />

--- a/src/components/layout/MarketTickerBar.tsx
+++ b/src/components/layout/MarketTickerBar.tsx
@@ -1,0 +1,58 @@
+'use client';
+import { useMemo } from 'react';
+import type { Quote } from '@/types';
+import { changeTextColor, fmtPct } from '@/lib/utils/colors';
+
+const TICKER_SYMBOLS = ['SPY', 'QQQ', 'TLT', 'GLD', 'IBIT', 'XLE', 'EEM', 'VNQ'];
+
+interface Props {
+  quotes: Quote[];
+  period: string;
+  onSelectSymbol: (sym: string) => void;
+}
+
+export default function MarketTickerBar({ quotes, period, onSelectSymbol }: Props) {
+  const tickers = useMemo(() => {
+    const map = new Map(quotes.map(q => [q.symbol, q]));
+    return TICKER_SYMBOLS.map(sym => map.get(sym)).filter(Boolean) as Quote[];
+  }, [quotes]);
+
+  if (!tickers.length) return null;
+
+  function getPct(q: Quote): number {
+    switch (period) {
+      case '5d':  return q.change_5d;
+      case '1m':  return q.change_1m;
+      case '3m':  return q.change_3m;
+      case '6m':  return q.change_6m;
+      case '1y':  return q.change_1y;
+      case 'ytd': return q.change_ytd;
+      default:    return q.change_1d;
+    }
+  }
+
+  return (
+    <div className="ticker-bar" role="region" aria-label="Market ticker">
+      <div className="ticker-inner">
+        {tickers.map(q => {
+          const pct = getPct(q);
+          return (
+            <button
+              key={q.symbol}
+              className="ticker-item"
+              onClick={() => onSelectSymbol(q.symbol)}
+              title={q.name}
+            >
+              <span className="ticker-sym">{q.symbol}</span>
+              <span className="ticker-price">${q.price.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+              <span className="ticker-chg" style={{ color: changeTextColor(pct) }}>
+                {fmtPct(pct)}
+              </span>
+            </button>
+          );
+        })}
+        <span className="ticker-hint">Click to chart · period: {period}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/QuickSearch.tsx
+++ b/src/components/layout/QuickSearch.tsx
@@ -1,0 +1,94 @@
+'use client';
+import { useState, useEffect, useRef, useMemo } from 'react';
+import type { Quote } from '@/types';
+import { SECTOR_COLORS, changeTextColor, fmtPct } from '@/lib/utils/colors';
+
+interface Props {
+  quotes: Quote[];
+  onSelect: (sym: string) => void;
+}
+
+export default function QuickSearch({ quotes, onSelect }: Props) {
+  const [open, setOpen]   = useState(false);
+  const [query, setQuery] = useState('');
+  const inputRef          = useRef<HTMLInputElement>(null);
+
+  // Cmd+K / Ctrl+K to open
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        setOpen(prev => !prev);
+      }
+      if (e.key === 'Escape') setOpen(false);
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setTimeout(() => inputRef.current?.focus(), 30);
+    }
+  }, [open]);
+
+  const results = useMemo(() => {
+    if (!query.trim()) return quotes.slice(0, 12);
+    const q = query.toLowerCase();
+    return quotes.filter(
+      r => r.symbol.toLowerCase().includes(q) || r.name.toLowerCase().includes(q),
+    ).slice(0, 12);
+  }, [quotes, query]);
+
+  function pick(sym: string) {
+    onSelect(sym);
+    setOpen(false);
+  }
+
+  if (!open) return null;
+
+  return (
+    <div className="qs-overlay" onClick={() => setOpen(false)}>
+      <div className="qs-modal" onClick={e => e.stopPropagation()} role="dialog" aria-modal aria-label="Symbol search">
+        <div className="qs-header">
+          <span className="qs-icon">⌕</span>
+          <input
+            ref={inputRef}
+            className="qs-input"
+            placeholder="Search symbols or names…"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter' && results[0]) pick(results[0].symbol);
+            }}
+          />
+          <kbd className="qs-esc">Esc</kbd>
+        </div>
+        <div className="qs-results">
+          {results.map(r => (
+            <button key={r.symbol} className="qs-result-item" onClick={() => pick(r.symbol)}>
+              <span
+                className="qs-sym"
+                style={{ color: SECTOR_COLORS[r.sector] ?? '#cdd9e5' }}
+              >{r.symbol}</span>
+              <span className="qs-name">{r.name}</span>
+              <span className="qs-sector">{r.sector}</span>
+              <span className="qs-pct" style={{ color: changeTextColor(r.change_1d) }}>
+                {fmtPct(r.change_1d)}
+              </span>
+            </button>
+          ))}
+          {!results.length && (
+            <div className="qs-empty">No symbols match "{query}"</div>
+          )}
+        </div>
+        <div className="qs-footer">
+          <span><kbd>↵</kbd> to chart first result</span>
+          <span><kbd>Esc</kbd> to close</span>
+          <span><kbd>⌘K</kbd> to toggle</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/TabNav.tsx
+++ b/src/components/layout/TabNav.tsx
@@ -1,28 +1,71 @@
 'use client';
+import { useEffect } from 'react';
+
 interface Props {
   activeTab: string;
   onTabChange: (tab: string) => void;
 }
 
-const TABS = [
-  { id: 'macro',    label: '🌐 Macro Flow' },
-  { id: 'overview', label: '📊 Overview' },
-  { id: 'trends',   label: '📈 Trend Analysis' },
-  { id: 'backtest', label: '🔬 Backtest' },
-  { id: 'flow',     label: '📡 Flow & Chips' },
-  { id: 'cycle',    label: '📅 Events & Cycles' },
-  { id: 'crisis',      label: '🚨 Crisis Atlas' },
-  { id: 'correlation', label: '🔗 Correlation' },
+const TAB_GROUPS = [
+  {
+    label: 'Markets',
+    tabs: [
+      { id: 'macro',    label: '🌐 Macro Flow',      key: '1' },
+      { id: 'overview', label: '📊 Overview',         key: '2' },
+      { id: 'trends',   label: '📈 Trend Analysis',   key: '3' },
+    ],
+  },
+  {
+    label: 'Portfolio',
+    tabs: [
+      { id: 'backtest', label: '🔬 Backtest',          key: '4' },
+      { id: 'flow',     label: '📡 Flow & Chips',      key: '5' },
+    ],
+  },
+  {
+    label: 'Research',
+    tabs: [
+      { id: 'cycle',       label: '📅 Events & Cycles', key: '6' },
+      { id: 'crisis',      label: '🚨 Crisis Atlas',    key: '7' },
+      { id: 'correlation', label: '🔗 Correlation',     key: '8' },
+    ],
+  },
 ];
 
+// Flat list used for keyboard shortcut lookup
+const ALL_TABS = TAB_GROUPS.flatMap(g => g.tabs);
+
 export default function TabNav({ activeTab, onTabChange }: Props) {
+  // Alt+1–8 keyboard shortcuts
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (!e.altKey) return;
+      const tab = ALL_TABS.find(t => t.key === e.key);
+      if (tab) { e.preventDefault(); onTabChange(tab.id); }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onTabChange]);
+
   return (
-    <nav className="tab-nav">
-      {TABS.map(t => (
-        <button key={t.id} className={`tab-btn${activeTab === t.id ? ' active' : ''}`}
-          onClick={() => onTabChange(t.id)}>
-          {t.label}
-        </button>
+    <nav className="tab-nav" aria-label="Main navigation">
+      {TAB_GROUPS.map((group, gi) => (
+        <div key={group.label} className="tab-group">
+          <span className="tab-group-label">{group.label}</span>
+          {group.tabs.map(t => (
+            <button
+              key={t.id}
+              className={`tab-btn${activeTab === t.id ? ' active' : ''}`}
+              onClick={() => onTabChange(t.id)}
+              title={`Alt+${t.key}`}
+              aria-current={activeTab === t.id ? 'page' : undefined}
+            >
+              {t.label}
+              <kbd className="tab-kbd">Alt+{t.key}</kbd>
+            </button>
+          ))}
+          {gi < TAB_GROUPS.length - 1 && <div className="tab-sep" aria-hidden />}
+        </div>
       ))}
     </nav>
   );


### PR DESCRIPTION
## Summary

Three focused improvements to the dashboard's information architecture:

### Market Ticker Bar
- Persistent 36px strip between TopBar and TabNav — always visible regardless of active tab
- Shows live price + period-aware change % for: **SPY · QQQ · TLT · GLD · IBIT · XLE · EEM · VNQ**
- Clicking any symbol opens the Trend Analysis tab with that symbol pre-selected
- Sticky below TopBar; horizontal-scrollable on mobile with hidden scrollbar

### Grouped TabNav
- Three logical sections: **Markets** (Macro Flow, Overview, Trend Analysis) · **Portfolio** (Backtest, Flow & Chips) · **Research** (Events & Cycles, Crisis Atlas, Correlation)
- Section labels as compact chips between groups
- **Alt+1–8 keyboard shortcuts** registered globally via `useEffect`; hint badge (`Alt+N`) appears only on tab hover — no visual noise at rest
- Sticky below TickerBar; scrolls horizontally on small screens

### Quick Search (Cmd+K / Ctrl+K)
- Spotlight-style overlay modal; toggle with `Cmd+K` or `Ctrl+K`, close with `Escape`
- Filters all 31 ETF symbols and names in real time (no extra API fetch — uses existing quotes state)
- Result rows show: symbol (sector-colored) · full name · sector · 1d change %
- `Enter` selects the first result and opens TrendTab; click any row does the same
- Smooth fade + slide-in animation; backdrop blur

## Test plan

- [ ] Market ticker bar appears between TopBar and TabNav with 8 live prices
- [ ] Clicking a ticker symbol switches to Trend Analysis tab with that symbol
- [ ] Ticker change % matches the currently selected period (1d/5d/1m…)
- [ ] Tab groups render with **Markets / Portfolio / Research** labels
- [ ] `Alt+1` through `Alt+8` switch tabs correctly
- [ ] Hovering a tab shows the `Alt+N` kbd hint
- [ ] `Cmd+K` opens Quick Search overlay; typing filters symbols in real time
- [ ] `Enter` in Quick Search opens TrendTab for the first result
- [ ] `Escape` closes Quick Search
- [ ] Light/dark theme — all new components adapt correctly
- [ ] Mobile (< 600px) — TickerBar scrolls, section labels hide, modal is full-width

https://claude.ai/code/session_01QV5U9ugz9rMMfvrnXzXT8W

---
_Generated by [Claude Code](https://claude.ai/code/session_01QV5U9ugz9rMMfvrnXzXT8W)_