### PR TITLE
feat: real data integration + visual overhaul + adaptive polling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "chart.js": "^4.4.7",
+        "echarts": "^6.0.0",
+        "echarts-for-react": "^3.0.6",
+        "lightweight-charts": "^5.2.0",
         "next": "15.5.18",
         "react": "^19.0.0",
         "react-chartjs-2": "^5.2.0",
@@ -2525,6 +2528,36 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/echarts": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
+      "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.0.0"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.6.tgz",
+      "integrity": "sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.355",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.355.tgz",
@@ -3146,11 +3179,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fancy-canvas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
+      "integrity": "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4278,6 +4316,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightweight-charts": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.2.0.tgz",
+      "integrity": "sha512-ey3Vas8UhV06ni+LT9TA1nEe4y8So4Mi6CL/oarNHFMyTktz/xy8e8+oh04Q//eO3t6etvFXgayz2fClyFQb5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fancy-canvas": "2.1.0"
       }
     },
     "node_modules/lilconfig": {
@@ -5589,6 +5636,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
+      "integrity": "sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==",
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6518,6 +6571,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zrender": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
+      "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "next": "15.5.18",
         "react": "^19.0.0",
         "react-chartjs-2": "^5.2.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "yahoo-finance2": "^3.14.0"
       },
       "devDependencies": {
         "@types/node": "^22",
@@ -37,6 +38,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@deno/shim-deno": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno/-/shim-deno-0.18.2.tgz",
+      "integrity": "sha512-oQ0CVmOio63wlhwQF75zA4ioolPvOwAoK0yuzcS5bDC1JUvH3y1GS8xPh8EOpcoDQRU4FTG8OQfxhpR+c6DrzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deno/shim-deno-test": "^0.5.0",
+        "which": "^4.0.0"
+      }
+    },
+    "node_modules/@deno/shim-deno-test": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno-test/-/shim-deno-test-0.5.0.tgz",
+      "integrity": "sha512-4nMhecpGlPi0cSzT67L+Tm+GOJqvuk8gqHBziqcUQOarnuIax1z96/gJHCSIz2Z0zhxE6Rzwb3IZXPtFh51j+w==",
+      "license": "MIT"
+    },
+    "node_modules/@deno/shim-deno/node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@deno/shim-deno/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2376,7 +2417,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3167,6 +3207,16 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-mock-cache": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/fetch-mock-cache/-/fetch-mock-cache-2.3.1.tgz",
+      "integrity": "sha512-hDk+Nbt0Y8Aq7KTEU6ASQAcpB34UjhkpD3QjzD6yvEKP4xVElAqXrjQ7maL+LYMGafx51Zq6qUfDM57PNu/qMw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "filenamify-url": "2.1.2"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3178,6 +3228,48 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify-url": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-2.1.2.tgz",
+      "integrity": "sha512-3rMbAr7vDNMOGsj1aMniQFl749QjgM+lMJ/77ZRSPTIgxvolZwoQbn8dXLs7xfd+hAdli+oTnSWZNkJJLWQFEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "filenamify": "^4.3.0",
+        "humanize-url": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fill-range": {
@@ -3545,6 +3637,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/humanize-url": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-2.1.1.tgz",
+      "integrity": "sha512-V4nxsPGNE7mPjr1qDp471YfW8nhBiTRWrG/4usZlpvFU8I7gsV7Jvrrzv/snbLm5dWO3dr1ennu2YqnhTWFmYA==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-url": "^4.5.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ignore": {
@@ -4083,6 +4187,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4287,7 +4397,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -4467,6 +4576,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/object-assign": {
@@ -4966,15 +5084,32 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -5101,6 +5236,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -5614,6 +5755,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-outer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -5847,6 +6009,24 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5858,6 +6038,66 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tough-cookie-file-store": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie-file-store/-/tough-cookie-file-store-2.0.3.tgz",
+      "integrity": "sha512-sMpZVcmFf6EYFHFFl+SYH4W1/OnXBYMGDsv2IlbQ2caHyFElW/UR/gpj/KYU1JwmP4dE9xqwv2+vWcmlXHojSw==",
+      "license": "MIT",
+      "dependencies": {
+        "tough-cookie": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie-file-store/node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trim-repeated/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6030,6 +6270,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -6104,6 +6353,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -6226,6 +6485,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yahoo-finance2": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/yahoo-finance2/-/yahoo-finance2-3.14.0.tgz",
+      "integrity": "sha512-gsT/tqgeizKtMxbIIWFiFyuhM/6MZE4yEyNLmPekr88AX14JL2HWw0/QNMOR081jVtzTjihqDW0zV7IayH1Wcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deno/shim-deno": "~0.18.0",
+        "fetch-mock-cache": "npm:fetch-mock-cache@^2.1.3",
+        "json-schema": "^0.4.0",
+        "tough-cookie": "npm:tough-cookie@^5.1.1",
+        "tough-cookie-file-store": "npm:tough-cookie-file-store@^2.0.3"
+      },
+      "bin": {
+        "yahoo-finance": "esm/bin/yahoo-finance.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   },
   "dependencies": {
     "chart.js": "^4.4.7",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
+    "lightweight-charts": "^5.2.0",
     "next": "15.5.18",
     "react": "^19.0.0",
     "react-chartjs-2": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "next": "15.5.18",
     "react": "^19.0.0",
     "react-chartjs-2": "^5.2.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "yahoo-finance2": "^3.14.0"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/src/app/api/backtest/route.ts
+++ b/src/app/api/backtest/route.ts
@@ -28,5 +28,5 @@ export async function GET(request: Request) {
     normalised[sym] = w / total;
   }
 
-  return NextResponse.json(runBacktest(normalised, period));
+  return NextResponse.json(await runBacktest(normalised, period));
 }

--- a/src/app/api/chips/route.ts
+++ b/src/app/api/chips/route.ts
@@ -4,5 +4,5 @@ import { getChipsData } from '@/lib/data-engine';
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const period = searchParams.get('period') ?? '1m';
-  return NextResponse.json(getChipsData(period));
+  return NextResponse.json(await getChipsData(period));
 }

--- a/src/app/api/cycle/route.ts
+++ b/src/app/api/cycle/route.ts
@@ -2,5 +2,5 @@ import { NextResponse } from 'next/server';
 import { getCycleData } from '@/lib/data-engine';
 
 export async function GET() {
-  return NextResponse.json(getCycleData());
+  return NextResponse.json(await getCycleData());
 }

--- a/src/app/api/flow-matrix/route.ts
+++ b/src/app/api/flow-matrix/route.ts
@@ -4,5 +4,5 @@ import { getFlowMatrix } from '@/lib/data-engine';
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const period = searchParams.get('period') ?? '1m';
-  return NextResponse.json(getFlowMatrix(period));
+  return NextResponse.json(await getFlowMatrix(period));
 }

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -11,6 +11,6 @@ export async function GET(request: Request) {
   }
 
   const days = PERIOD_DAYS[period as keyof typeof PERIOD_DAYS] ?? 380;
-  const series = generateSeries(symbol, days);
+  const series = await generateSeries(symbol, days);
   return NextResponse.json({ symbol, period, series });
 }

--- a/src/app/api/macro/route.ts
+++ b/src/app/api/macro/route.ts
@@ -4,5 +4,5 @@ import { getMacroData } from '@/lib/data-engine';
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const period = searchParams.get('period') ?? '1d';
-  return NextResponse.json(getMacroData(period));
+  return NextResponse.json(await getMacroData(period));
 }

--- a/src/app/api/quotes/route.ts
+++ b/src/app/api/quotes/route.ts
@@ -2,5 +2,5 @@ import { NextResponse } from 'next/server';
 import { getAllQuotes } from '@/lib/data-engine';
 
 export async function GET() {
-  return NextResponse.json(getAllQuotes());
+  return NextResponse.json(await getAllQuotes());
 }

--- a/src/app/api/sectors/route.ts
+++ b/src/app/api/sectors/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: Request) {
     etfs: { symbol: string; change: number }[];
   }> = {};
 
-  for (const q of getAllQuotes()) {
+  for (const q of await getAllQuotes()) {
     const sec = q.sector as string;
     if (!(sec in sectors)) {
       sectors[sec] = { sector: sec, change: 0, mcap: 0, etfs: [] };

--- a/src/app/api/strategy-backtest/route.ts
+++ b/src/app/api/strategy-backtest/route.ts
@@ -5,5 +5,5 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const period = searchParams.get('period') ?? '1y';
   const topN = parseInt(searchParams.get('top_n') ?? '3', 10);
-  return NextResponse.json(runStrategyBacktest(period, topN));
+  return NextResponse.json(await runStrategyBacktest(period, topN));
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,6 +55,12 @@
   --topbar-start: #dce8fb;
 }
 
+[data-theme="light"] .topbar {
+  background: #ffffff;
+  border-bottom: none;
+  box-shadow: 0 1px 0 rgba(59,130,246,0.14), 0 3px 12px rgba(59,130,246,0.07);
+}
+
 html { scroll-behavior: smooth; }
 
 body {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,8 +77,9 @@ body {
 }
 [data-theme="light"] body {
   background:
-    radial-gradient(ellipse 100% 35% at 50% -8%, rgba(59,130,246,0.07) 0%, transparent 60%),
-    var(--bg);
+    linear-gradient(to bottom, #ffffff 0%, #ffffff 72px, var(--bg) 220px),
+    radial-gradient(ellipse 100% 35% at 50% 10%, rgba(59,130,246,0.06) 0%, transparent 60%);
+  background-attachment: fixed;
 }
 
 /* ── Top Bar ────────────────────────────────────────────────────── */
@@ -87,6 +88,7 @@ body {
   align-items: center;
   gap: 1rem;
   padding: 0.65rem 1.25rem;
+  padding-top: max(0.65rem, env(safe-area-inset-top));
   background: linear-gradient(180deg, var(--topbar-start) 0%, var(--bg) 100%);
   border-bottom: 1px solid var(--border);
   position: sticky;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1667,6 +1667,13 @@ body {
   flex-shrink: 0;
 }
 
+/* Major market index items — subtle blue accent */
+.ticker-item.ticker-index { border-right-color: rgba(99,179,237,0.20); }
+.ticker-sym-index { color: #93c5fd; font-size: 0.78rem; }
+
+/* Separator after the last index item */
+.ticker-item.ticker-index:nth-child(5) { border-right: 2px solid rgba(99,179,237,0.35); }
+
 /* ── Tab Nav — grouped ─────────────────────────────────────────── */
 .tab-nav {
   display: flex;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,37 +6,49 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  --bg:        #0d1117;
-  --surface:   #161b22;
-  --surface2:  #1c2333;
-  --border:    #30363d;
-  --text:      #e6edf3;
-  --text-muted:#8b949e;
-  --accent:    #58a6ff;
-  --accent2:   #388bfd;
-  --pos:       #3fb950;
-  --neg:       #f85149;
-  --radius:    10px;
-  --radius-sm: 6px;
-  --shadow:    0 4px 16px rgba(0,0,0,0.4);
-  --chart-grid:rgba(255,255,255,0.05);
-  --chart-tick:#94a3b8;
+  --bg:           #070d19;
+  --surface:      #0d1627;
+  --surface2:     #132035;
+  --surface-glass:rgba(13,22,39,0.72);
+  --border:       rgba(99,179,237,0.10);
+  --border-hover: rgba(99,179,237,0.28);
+  --glow:         rgba(59,130,246,0.12);
+  --text:         #e2e8f0;
+  --text-muted:   #94a3b8;
+  --accent:       #3b82f6;
+  --accent2:      #2563eb;
+  --accent-end:   #8b5cf6;
+  --pos:          #22c55e;
+  --neg:          #ef4444;
+  --radius:       12px;
+  --radius-sm:    8px;
+  --shadow:       0 8px 32px rgba(0,0,0,0.55), 0 2px 8px rgba(0,0,0,0.3);
+  --chart-grid:   rgba(99,179,237,0.06);
+  --chart-tick:   #4d6080;
+  --flash-pos:    rgba(34,197,94,0.20);
+  --flash-neg:    rgba(239,68,68,0.20);
 }
 
 [data-theme="light"] {
-  --bg:        #f6f8fa;
-  --surface:   #ffffff;
-  --surface2:  #eef0f3;
-  --border:    #d0d7de;
-  --text:      #1f2328;
-  --text-muted:#636c76;
-  --accent:    #0969da;
-  --accent2:   #0550ae;
-  --pos:       #1a7f37;
-  --neg:       #cf222e;
-  --shadow:    0 4px 16px rgba(0,0,0,0.12);
-  --chart-grid:rgba(0,0,0,0.06);
-  --chart-tick:#57606a;
+  --bg:           #f0f4fc;
+  --surface:      #ffffff;
+  --surface2:     #eef2fb;
+  --surface-glass:rgba(255,255,255,0.80);
+  --border:       rgba(59,130,246,0.14);
+  --border-hover: rgba(59,130,246,0.35);
+  --glow:         rgba(59,130,246,0.08);
+  --text:         #1e2a3a;
+  --text-muted:   #5a6e8a;
+  --accent:       #2563eb;
+  --accent2:      #1d4ed8;
+  --accent-end:   #7c3aed;
+  --pos:          #16a34a;
+  --neg:          #dc2626;
+  --shadow:       0 4px 20px rgba(0,0,0,0.10);
+  --chart-grid:   rgba(59,130,246,0.08);
+  --chart-tick:   #7a8fa8;
+  --flash-pos:    rgba(22,163,74,0.18);
+  --flash-neg:    rgba(220,38,38,0.15);
 }
 
 html { scroll-behavior: smooth; }
@@ -56,12 +68,14 @@ body {
   align-items: center;
   gap: 1rem;
   padding: 0.65rem 1.25rem;
-  background: var(--surface);
+  background: linear-gradient(180deg, #0a1220 0%, var(--bg) 100%);
   border-bottom: 1px solid var(--border);
   position: sticky;
   top: 0;
   z-index: 100;
   flex-wrap: wrap;
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
 }
 
 .topbar-brand {
@@ -72,9 +86,12 @@ body {
 }
 .brand-icon { font-size: 1.3rem; }
 .brand-name {
-  font-weight: 700;
+  font-weight: 800;
   font-size: 1rem;
-  color: var(--text);
+  background: linear-gradient(90deg, var(--accent), var(--accent-end));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
   white-space: nowrap;
 }
 .brand-sub {
@@ -106,8 +123,9 @@ body {
 }
 .period-btn:hover { background: var(--surface2); color: var(--text); }
 .period-btn.active {
-  background: var(--accent2);
+  background: linear-gradient(135deg, var(--accent), var(--accent-end));
   color: #fff;
+  box-shadow: 0 0 10px rgba(59,130,246,0.30);
 }
 
 .topbar-meta {
@@ -149,6 +167,8 @@ body {
 .tab-btn.active {
   color: var(--accent);
   border-bottom-color: var(--accent);
+  border-bottom-width: 2px;
+  border-bottom-style: solid;
 }
 
 /* ── Tab Panels ─────────────────────────────────────────────────── */
@@ -169,13 +189,18 @@ body {
 }
 
 .stat-card {
-  background: var(--surface);
+  background: linear-gradient(135deg, var(--surface), rgba(13,22,39,0.6));
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 1rem 1.1rem;
-  transition: border-color 0.2s;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  transition: border-color 0.2s, box-shadow 0.2s;
 }
-.stat-card:hover { border-color: var(--accent2); }
+.stat-card:hover {
+  border-color: var(--border-hover);
+  box-shadow: 0 0 20px var(--glow), var(--shadow);
+}
 
 .stat-label {
   font-size: 0.72rem;
@@ -203,11 +228,18 @@ body {
 
 /* ── Panels ─────────────────────────────────────────────────────── */
 .panel {
-  background: var(--surface);
+  background: linear-gradient(135deg, var(--surface), rgba(13,22,39,0.7));
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 1.25rem;
   margin-bottom: 1.25rem;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+.panel:hover {
+  border-color: var(--border-hover);
+  box-shadow: 0 0 24px var(--glow), var(--shadow);
 }
 
 .panel-header {
@@ -219,8 +251,11 @@ body {
 }
 .panel-header h2 {
   font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--text);
+  font-weight: 700;
+  background: linear-gradient(90deg, var(--text), var(--text-muted));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 .panel-hint {
   font-size: 0.72rem;
@@ -1567,7 +1602,7 @@ body {
 
 /* ── Market Ticker Bar ─────────────────────────────────────────── */
 .ticker-bar {
-  background: var(--surface);
+  background: linear-gradient(180deg, var(--surface), rgba(13,22,39,0.95));
   border-bottom: 1px solid var(--border);
   height: 36px;
   overflow: hidden;
@@ -1637,7 +1672,7 @@ body {
   display: flex;
   align-items: stretch;
   gap: 0;
-  background: var(--surface);
+  background: linear-gradient(180deg, var(--surface), rgba(13,22,39,0.97));
   border-bottom: 1px solid var(--border);
   position: sticky;
   top: 92px; /* below TopBar + TickerBar */
@@ -1843,4 +1878,58 @@ body {
   .qs-overlay      { padding-top: 60px; align-items: flex-start; }
   .qs-modal        { max-width: 100%; border-radius: 0; }
   .tab-group-label { display: none; }
+}
+
+/* ── Quote flash animations ─────────────────────────────────────── */
+@keyframes flash-pos {
+  0%,100% { background: transparent; }
+  40%      { background: var(--flash-pos); }
+}
+@keyframes flash-neg {
+  0%,100% { background: transparent; }
+  40%      { background: var(--flash-neg); }
+}
+.flash-pos { animation: flash-pos 0.7s ease; }
+.flash-neg { animation: flash-neg 0.7s ease; }
+
+/* ── Market status badge ────────────────────────────────────────── */
+.market-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 3px 10px;
+  border-radius: 20px;
+  border: 1px solid;
+  text-transform: uppercase;
+}
+.market-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.market-open {
+  color: var(--pos);
+  border-color: rgba(34,197,94,0.35);
+  background: rgba(34,197,94,0.08);
+}
+.market-open .market-dot { background: var(--pos); box-shadow: 0 0 5px var(--pos); animation: pulse-dot 1.5s infinite; }
+.market-pre, .market-post {
+  color: #fbbf24;
+  border-color: rgba(251,191,36,0.35);
+  background: rgba(251,191,36,0.08);
+}
+.market-pre .market-dot, .market-post .market-dot { background: #fbbf24; }
+.market-closed {
+  color: var(--text-muted);
+  border-color: var(--border);
+  background: var(--surface2);
+}
+.market-closed .market-dot { background: var(--text-muted); }
+@keyframes pulse-dot {
+  0%,100% { opacity: 1; }
+  50%      { opacity: 0.45; }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,13 +6,13 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  --bg:           #070d19;
-  --surface:      #0d1627;
-  --surface2:     #132035;
-  --surface-glass:rgba(13,22,39,0.72);
-  --border:       rgba(99,179,237,0.10);
-  --border-hover: rgba(99,179,237,0.28);
-  --glow:         rgba(59,130,246,0.12);
+  --bg:           #060c18;
+  --surface:      #0e1c31;
+  --surface2:     #152540;
+  --surface-glass:rgba(14,28,49,0.75);
+  --border:       rgba(99,179,237,0.13);
+  --border-hover: rgba(99,179,237,0.32);
+  --glow:         rgba(59,130,246,0.15);
   --text:         #e2e8f0;
   --text-muted:   #94a3b8;
   --accent:       #3b82f6;
@@ -22,44 +22,55 @@
   --neg:          #ef4444;
   --radius:       12px;
   --radius-sm:    8px;
-  --shadow:       0 8px 32px rgba(0,0,0,0.55), 0 2px 8px rgba(0,0,0,0.3);
+  --shadow:       0 4px 24px rgba(0,0,0,0.60), 0 1px 0 rgba(99,179,237,0.06) inset;
+  --shadow-card:  0 2px 16px rgba(0,0,0,0.50), 0 0 0 1px rgba(99,179,237,0.06);
   --chart-grid:   rgba(99,179,237,0.06);
   --chart-tick:   #4d6080;
   --flash-pos:    rgba(34,197,94,0.20);
   --flash-neg:    rgba(239,68,68,0.20);
+  --topbar-start: #07111f;
 }
 
 [data-theme="light"] {
-  --bg:           #f0f4fc;
+  --bg:           #eef3fc;
   --surface:      #ffffff;
-  --surface2:     #eef2fb;
-  --surface-glass:rgba(255,255,255,0.80);
-  --border:       rgba(59,130,246,0.14);
-  --border-hover: rgba(59,130,246,0.35);
+  --surface2:     #f0f5ff;
+  --surface-glass:rgba(255,255,255,0.85);
+  --border:       rgba(59,130,246,0.16);
+  --border-hover: rgba(59,130,246,0.38);
   --glow:         rgba(59,130,246,0.08);
-  --text:         #1e2a3a;
+  --text:         #1a2640;
   --text-muted:   #5a6e8a;
   --accent:       #2563eb;
   --accent2:      #1d4ed8;
   --accent-end:   #7c3aed;
   --pos:          #16a34a;
   --neg:          #dc2626;
-  --shadow:       0 4px 20px rgba(0,0,0,0.10);
+  --shadow:       0 2px 16px rgba(59,130,246,0.10), 0 1px 4px rgba(0,0,0,0.06);
+  --shadow-card:  0 2px 12px rgba(59,130,246,0.08), 0 1px 3px rgba(0,0,0,0.05);
   --chart-grid:   rgba(59,130,246,0.08);
   --chart-tick:   #7a8fa8;
   --flash-pos:    rgba(22,163,74,0.18);
   --flash-neg:    rgba(220,38,38,0.15);
+  --topbar-start: #dce8fb;
 }
 
 html { scroll-behavior: smooth; }
 
 body {
   font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-  background: var(--bg);
+  background:
+    radial-gradient(ellipse 75% 45% at 8% 0%,   rgba(59,130,246,0.11) 0%, transparent 55%),
+    radial-gradient(ellipse 55% 40% at 92% 100%, rgba(139,92,246,0.09) 0%, transparent 55%),
+    var(--bg);
+  background-attachment: fixed;
   color: var(--text);
   font-size: 14px;
   line-height: 1.5;
   min-height: 100vh;
+}
+[data-theme="light"] body {
+  background: var(--bg);
 }
 
 /* ── Top Bar ────────────────────────────────────────────────────── */
@@ -68,7 +79,7 @@ body {
   align-items: center;
   gap: 1rem;
   padding: 0.65rem 1.25rem;
-  background: linear-gradient(180deg, #0a1220 0%, var(--bg) 100%);
+  background: linear-gradient(180deg, var(--topbar-start) 0%, var(--bg) 100%);
   border-bottom: 1px solid var(--border);
   position: sticky;
   top: 0;
@@ -189,17 +200,28 @@ body {
 }
 
 .stat-card {
-  background: linear-gradient(135deg, var(--surface), rgba(13,22,39,0.6));
+  position: relative;
+  overflow: hidden;
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 1rem 1.1rem;
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  transition: border-color 0.2s, box-shadow 0.2s;
+  box-shadow: var(--shadow-card);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.15s;
+}
+.stat-card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-end), transparent);
 }
 .stat-card:hover {
   border-color: var(--border-hover);
-  box-shadow: 0 0 20px var(--glow), var(--shadow);
+  box-shadow: 0 0 24px var(--glow), var(--shadow-card);
+  transform: translateY(-1px);
 }
 
 .stat-label {
@@ -228,18 +250,28 @@ body {
 
 /* ── Panels ─────────────────────────────────────────────────────── */
 .panel {
-  background: linear-gradient(135deg, var(--surface), rgba(13,22,39,0.7));
+  position: relative;
+  overflow: hidden;
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 1.25rem;
   margin-bottom: 1.25rem;
+  box-shadow: var(--shadow-card);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   transition: border-color 0.2s, box-shadow 0.2s;
 }
+.panel::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-end), transparent 70%);
+}
 .panel:hover {
   border-color: var(--border-hover);
-  box-shadow: 0 0 24px var(--glow), var(--shadow);
+  box-shadow: 0 0 28px var(--glow), var(--shadow-card);
 }
 
 .panel-header {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,9 +10,9 @@
   --surface:      #0e1c31;
   --surface2:     #152540;
   --surface-glass:rgba(14,28,49,0.75);
-  --border:       rgba(99,179,237,0.13);
-  --border-hover: rgba(99,179,237,0.32);
-  --glow:         rgba(59,130,246,0.15);
+  --border:       rgba(99,179,237,0.14);
+  --border-hover: rgba(99,179,237,0.36);
+  --glow:         rgba(59,130,246,0.18);
   --text:         #e2e8f0;
   --text-muted:   #94a3b8;
   --accent:       #3b82f6;
@@ -20,35 +20,35 @@
   --accent-end:   #8b5cf6;
   --pos:          #22c55e;
   --neg:          #ef4444;
-  --radius:       12px;
+  --radius:       14px;
   --radius-sm:    8px;
-  --shadow:       0 4px 24px rgba(0,0,0,0.60), 0 1px 0 rgba(99,179,237,0.06) inset;
-  --shadow-card:  0 2px 16px rgba(0,0,0,0.50), 0 0 0 1px rgba(99,179,237,0.06);
+  --shadow:       0 8px 32px rgba(0,0,0,0.65), 0 1px 0 rgba(99,179,237,0.07) inset;
+  --shadow-card:  0 4px 20px rgba(0,0,0,0.45), 0 1px 0 rgba(99,179,237,0.07) inset;
   --chart-grid:   rgba(99,179,237,0.06);
   --chart-tick:   #4d6080;
-  --flash-pos:    rgba(34,197,94,0.20);
-  --flash-neg:    rgba(239,68,68,0.20);
+  --flash-pos:    rgba(34,197,94,0.22);
+  --flash-neg:    rgba(239,68,68,0.22);
   --topbar-start: #07111f;
 }
 
 [data-theme="light"] {
   --bg:           #eef3fc;
   --surface:      #ffffff;
-  --surface2:     #f0f5ff;
-  --surface-glass:rgba(255,255,255,0.85);
-  --border:       rgba(59,130,246,0.16);
-  --border-hover: rgba(59,130,246,0.38);
-  --glow:         rgba(59,130,246,0.08);
-  --text:         #1a2640;
-  --text-muted:   #5a6e8a;
+  --surface2:     #f4f7ff;
+  --surface-glass:rgba(255,255,255,0.90);
+  --border:       rgba(59,130,246,0.15);
+  --border-hover: rgba(59,130,246,0.40);
+  --glow:         rgba(59,130,246,0.06);
+  --text:         #111827;
+  --text-muted:   #6b7f9a;
   --accent:       #2563eb;
   --accent2:      #1d4ed8;
   --accent-end:   #7c3aed;
   --pos:          #16a34a;
   --neg:          #dc2626;
-  --shadow:       0 4px 24px rgba(59,130,246,0.14), 0 1px 6px rgba(0,0,0,0.07);
-  --shadow-card:  0 4px 20px rgba(59,130,246,0.13), 0 1px 5px rgba(0,0,0,0.07), 0 0 0 1px rgba(59,130,246,0.07);
-  --chart-grid:   rgba(59,130,246,0.08);
+  --shadow:       none;
+  --shadow-card:  none;
+  --chart-grid:   rgba(59,130,246,0.07);
   --chart-tick:   #7a8fa8;
   --flash-pos:    rgba(22,163,74,0.18);
   --flash-neg:    rgba(220,38,38,0.15);
@@ -102,13 +102,14 @@ body {
 .topbar-brand {
   display: flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: 0.5rem;
   margin-right: auto;
 }
-.brand-icon { font-size: 1.3rem; }
+.brand-icon { font-size: 1.25rem; line-height: 1; }
 .brand-name {
   font-weight: 800;
-  font-size: 1rem;
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
   background: linear-gradient(90deg, var(--accent), var(--accent-end));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -116,37 +117,43 @@ body {
   white-space: nowrap;
 }
 .brand-sub {
-  font-size: 0.72rem;
+  font-size: 0.68rem;
   color: var(--text-muted);
   white-space: nowrap;
+  font-weight: 400;
 }
 
 .topbar-period {
   display: flex;
-  gap: 4px;
-  background: var(--bg);
-  border-radius: 8px;
+  gap: 2px;
+  background: rgba(0,0,0,0.18);
+  border-radius: 9px;
   padding: 3px;
   border: 1px solid var(--border);
+}
+[data-theme="light"] .topbar-period {
+  background: var(--surface2);
 }
 
 .period-btn {
   background: transparent;
   border: none;
   color: var(--text-muted);
-  font-size: 0.78rem;
-  font-weight: 500;
-  padding: 4px 9px;
-  border-radius: 5px;
+  font-size: 0.77rem;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 6px;
   cursor: pointer;
-  transition: background 0.15s, color 0.15s;
+  transition: background 0.12s, color 0.12s;
   font-family: inherit;
+  letter-spacing: 0.01em;
 }
-.period-btn:hover { background: var(--surface2); color: var(--text); }
+.period-btn:hover { background: rgba(255,255,255,0.08); color: var(--text); }
+[data-theme="light"] .period-btn:hover { background: var(--border); color: var(--text); }
 .period-btn.active {
   background: linear-gradient(135deg, var(--accent), var(--accent-end));
   color: #fff;
-  box-shadow: 0 0 10px rgba(59,130,246,0.30);
+  box-shadow: 0 1px 8px rgba(59,130,246,0.40);
 }
 
 .topbar-meta {
@@ -176,21 +183,24 @@ body {
   color: var(--text-muted);
   font-size: 0.82rem;
   font-weight: 500;
-  padding: 0.65rem 0.9rem;
+  padding: 0.7rem 1rem;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
   white-space: nowrap;
   font-family: inherit;
   display: flex;
   align-items: center;
+  gap: 0.3rem;
+  border-radius: 0;
 }
-.tab-btn:hover { color: var(--text); }
+.tab-btn:hover { color: var(--text); background: rgba(99,179,237,0.04); }
 .tab-btn.active {
   color: var(--accent);
   border-bottom-color: var(--accent);
-  border-bottom-width: 2px;
-  border-bottom-style: solid;
+  font-weight: 600;
 }
+[data-theme="light"] .tab-btn:hover { background: rgba(59,130,246,0.05); }
+[data-theme="light"] .tab-btn.active { color: var(--accent2); border-bottom-color: var(--accent2); }
 
 /* ── Tab Panels ─────────────────────────────────────────────────── */
 .tab-panel {
@@ -215,47 +225,53 @@ body {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 1rem 1.1rem;
+  padding: 1.1rem 1.2rem;
   box-shadow: var(--shadow-card);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  transition: border-color 0.2s, box-shadow 0.2s, transform 0.15s;
+  transition: border-color 0.18s, box-shadow 0.18s, transform 0.15s;
 }
 .stat-card::before {
   content: '';
   position: absolute;
   top: 0; left: 0; right: 0;
-  height: 2px;
-  background: linear-gradient(90deg, var(--accent), var(--accent-end), transparent);
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-end), transparent 80%);
+  border-radius: var(--radius) var(--radius) 0 0;
 }
 .stat-card:hover {
   border-color: var(--border-hover);
-  box-shadow: 0 0 24px var(--glow), var(--shadow-card);
-  transform: translateY(-1px);
+  box-shadow: 0 0 0 3px var(--glow), var(--shadow-card);
+  transform: translateY(-2px);
 }
 
 .stat-label {
-  font-size: 0.72rem;
+  font-size: 0.68rem;
   color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 0.4rem;
+  letter-spacing: 0.07em;
+  font-weight: 600;
+  margin-bottom: 0.45rem;
 }
 .stat-symbol {
-  font-size: 1.3rem;
-  font-weight: 700;
+  font-size: 1.6rem;
+  font-weight: 800;
   color: var(--text);
-  margin-bottom: 0.25rem;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.2rem;
+  line-height: 1.1;
 }
 .stat-change {
-  font-size: 1rem;
-  font-weight: 600;
-  margin-bottom: 0.2rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
   font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+  letter-spacing: -0.01em;
 }
 .stat-sector {
   font-size: 0.72rem;
   color: var(--text-muted);
+  font-weight: 500;
 }
 
 /* ── Panels ─────────────────────────────────────────────────────── */
@@ -265,44 +281,48 @@ body {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 1.25rem;
+  padding: 1.35rem 1.4rem;
   margin-bottom: 1.25rem;
   box-shadow: var(--shadow-card);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
-  transition: border-color 0.2s, box-shadow 0.2s;
+  transition: border-color 0.18s, box-shadow 0.18s;
 }
 .panel::before {
   content: '';
   position: absolute;
   top: 0; left: 0; right: 0;
-  height: 2px;
-  background: linear-gradient(90deg, var(--accent), var(--accent-end), transparent 70%);
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-end), transparent 65%);
+  border-radius: var(--radius) var(--radius) 0 0;
 }
 .panel:hover {
   border-color: var(--border-hover);
-  box-shadow: 0 0 28px var(--glow), var(--shadow-card);
+  box-shadow: 0 0 0 3px var(--glow), var(--shadow-card);
 }
 
 .panel-header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 0.75rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.1rem;
+  padding-bottom: 0.85rem;
+  border-bottom: 1px solid var(--border);
   flex-wrap: wrap;
 }
 .panel-header h2 {
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   font-weight: 700;
-  background: linear-gradient(90deg, var(--text), var(--text-muted));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
 .panel-hint {
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   color: var(--text-muted);
   margin-left: auto;
+  font-weight: 400;
+  opacity: 0.8;
 }
 
 /* ── Heatmap ────────────────────────────────────────────────────── */
@@ -1706,20 +1726,24 @@ body {
 
 /* ── Market Ticker Bar ─────────────────────────────────────────── */
 .ticker-bar {
-  background: linear-gradient(180deg, var(--surface), rgba(13,22,39,0.95));
+  background: var(--surface);
   border-bottom: 1px solid var(--border);
-  height: 36px;
+  height: 38px;
   overflow: hidden;
   position: sticky;
-  top: 56px; /* below TopBar */
+  top: 56px;
   z-index: 90;
+}
+[data-theme="light"] .ticker-bar {
+  background: #f8faff;
+  border-top: 1px solid rgba(59,130,246,0.08);
 }
 
 .ticker-inner {
   display: flex;
   align-items: center;
   height: 100%;
-  padding: 0 1rem;
+  padding: 0 0.5rem;
   gap: 0;
   overflow-x: auto;
   scrollbar-width: none;
@@ -1729,61 +1753,64 @@ body {
 .ticker-item {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0 0.85rem;
+  gap: 0.3rem;
+  padding: 0 0.75rem;
   height: 100%;
   border: none;
   background: transparent;
   cursor: pointer;
   border-right: 1px solid var(--border);
-  transition: background 0.15s;
+  transition: background 0.12s;
   white-space: nowrap;
   flex-shrink: 0;
+  font-family: inherit;
 }
-.ticker-item:first-child { border-left: 1px solid var(--border); }
 .ticker-item:hover { background: var(--surface2); }
 
 .ticker-sym {
-  font-size: 0.75rem;
+  font-size: 0.73rem;
   font-weight: 700;
   color: var(--text);
   letter-spacing: 0.04em;
 }
 
 .ticker-price {
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   color: var(--text-muted);
   font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
 }
 
 .ticker-chg {
-  font-size: 0.72rem;
-  font-weight: 600;
+  font-size: 0.71rem;
+  font-weight: 700;
   font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
 }
 
 .ticker-hint {
   margin-left: auto;
-  padding-left: 1rem;
-  font-size: 0.65rem;
+  padding-left: 0.75rem;
+  font-size: 0.62rem;
   color: var(--text-muted);
   white-space: nowrap;
   flex-shrink: 0;
+  opacity: 0.6;
 }
 
-/* Major market index items — subtle blue accent */
-.ticker-item.ticker-index { border-right-color: rgba(99,179,237,0.20); }
-.ticker-sym-index { color: #93c5fd; font-size: 0.78rem; }
+/* Major market index items */
+.ticker-item.ticker-index { background: rgba(59,130,246,0.04); }
+.ticker-item.ticker-index:hover { background: rgba(59,130,246,0.10); }
+.ticker-sym-index { color: #60a5fa; font-size: 0.75rem; }
+[data-theme="light"] .ticker-sym-index { color: #2563eb; }
 
-/* Separator after the last index item */
-.ticker-item.ticker-index:nth-child(5) { border-right: 2px solid rgba(99,179,237,0.35); }
+/* Separator after last index item */
+.ticker-item.ticker-index:nth-child(5) { border-right: 2px solid rgba(99,179,237,0.30); margin-right: 2px; }
 
 /* ── Tab Nav — grouped ─────────────────────────────────────────── */
 .tab-nav {
   display: flex;
   align-items: stretch;
   gap: 0;
-  background: linear-gradient(180deg, var(--surface), rgba(13,22,39,0.97));
+  background: var(--surface);
   border-bottom: 1px solid var(--border);
   position: sticky;
   top: 92px; /* below TopBar + TickerBar */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,8 +46,8 @@
   --accent-end:   #7c3aed;
   --pos:          #16a34a;
   --neg:          #dc2626;
-  --shadow:       0 2px 16px rgba(59,130,246,0.10), 0 1px 4px rgba(0,0,0,0.06);
-  --shadow-card:  0 2px 12px rgba(59,130,246,0.08), 0 1px 3px rgba(0,0,0,0.05);
+  --shadow:       0 4px 24px rgba(59,130,246,0.14), 0 1px 6px rgba(0,0,0,0.07);
+  --shadow-card:  0 4px 20px rgba(59,130,246,0.13), 0 1px 5px rgba(0,0,0,0.07), 0 0 0 1px rgba(59,130,246,0.07);
   --chart-grid:   rgba(59,130,246,0.08);
   --chart-tick:   #7a8fa8;
   --flash-pos:    rgba(22,163,74,0.18);
@@ -70,7 +70,9 @@ body {
   min-height: 100vh;
 }
 [data-theme="light"] body {
-  background: var(--bg);
+  background:
+    radial-gradient(ellipse 100% 35% at 50% -8%, rgba(59,130,246,0.07) 0%, transparent 60%),
+    var(--bg);
 }
 
 /* ── Top Bar ────────────────────────────────────────────────────── */
@@ -766,6 +768,68 @@ body {
   border-radius: var(--radius-sm);
   border-left: 3px solid var(--accent2);
 }
+
+/* ── Chart Controls (TrendTab) ─────────────────────────────────── */
+.chart-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+.chart-mode-btns, .chart-indicator-btns {
+  display: flex;
+  gap: 4px;
+}
+.chart-mode-btns { margin-right: 0.25rem; }
+.chart-mode-btn {
+  padding: 5px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+}
+.chart-mode-btn:hover { color: var(--text); border-color: var(--accent); }
+.chart-mode-btn.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+  box-shadow: 0 0 12px rgba(59,130,246,0.35);
+}
+.chart-ind-btn {
+  padding: 4px 11px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+}
+.chart-ind-btn:hover { color: var(--text); border-color: var(--accent2); }
+.chart-ind-btn.active {
+  border-color: var(--accent2);
+  color: var(--accent);
+  background: rgba(59,130,246,0.08);
+}
+.candle-legend {
+  display: flex;
+  gap: 1rem;
+  margin-top: 0.6rem;
+  font-size: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+  color: var(--text-muted);
+}
+.legend-candle-up   { color: #22c55e; font-weight: 600; }
+.legend-candle-down { color: #ef4444; font-weight: 600; }
 
 /* ── Hidden utility ─────────────────────────────────────────────── */
 .hidden { display: none !important; }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,19 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import './globals.css';
 
 export const metadata: Metadata = {
   title: 'Fund Flow Dashboard | Global Capital Flow',
   description: 'Global capital flow analysis platform',
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  viewportFit: 'cover',
+  themeColor: [
+    { media: '(prefers-color-scheme: dark)',  color: '#060c18' },
+    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
+  ],
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -18,6 +28,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           (function(){
             var t = localStorage.getItem('theme') || 'dark';
             document.documentElement.setAttribute('data-theme', t);
+            var m = document.querySelector('meta[name="theme-color"]:not([media])') || document.createElement('meta');
+            m.setAttribute('name', 'theme-color');
+            m.setAttribute('content', t === 'light' ? '#ffffff' : '#060c18');
+            if (!m.parentNode) document.head.appendChild(m);
           })();
         `}} />
         {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import TopBar from '@/components/layout/TopBar';
 import TabNav from '@/components/layout/TabNav';
@@ -7,6 +7,7 @@ import Loader from '@/components/layout/Loader';
 import MarketTickerBar from '@/components/layout/MarketTickerBar';
 import QuickSearch from '@/components/layout/QuickSearch';
 import type { Quote, MacroNode, MockEvent, CycleRow, CrisisEvent, CorrelationMatrix, Period } from '@/types';
+import { getMarketStatus, getPollInterval, type MarketStatus } from '@/lib/utils/marketHours';
 
 // Dynamic imports to avoid SSR for canvas/chart components
 const MacroTab = dynamic(() => import('@/components/tabs/MacroTab'), {
@@ -45,6 +46,9 @@ export default function DashboardPage() {
   const [crisisData, setCrisisData] = useState<CrisisEvent[] | null>(null);
   const [correlationData, setCorrelationData] = useState<CorrelationMatrix | null>(null);
   const [updateTime, setUpdateTime] = useState('—');
+  const [marketStatus, setMarketStatus] = useState<MarketStatus>('closed');
+  const [flashMap, setFlashMap] = useState<Record<string, 'up' | 'down' | null>>({});
+  const prevPricesRef = useRef<Record<string, number>>({});
   // Trend tab selected symbols
   const [selected, setSelected] = useState<string[]>([
     'QQQ',
@@ -93,16 +97,37 @@ export default function DashboardPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [period]);
 
-  // 60s auto-refresh of quotes
+  // Adaptive quote refresh based on market hours
   useEffect(() => {
-    const id = setInterval(async () => {
-      const q = (await fetch('/api/quotes').then(r =>
-        r.json(),
-      )) as Quote[];
+    const prevPrices = prevPricesRef.current;
+    let timerId: ReturnType<typeof setTimeout>;
+
+    async function refresh() {
+      const q = (await fetch('/api/quotes').then(r => r.json())) as Quote[];
       setQuotes(q);
       setUpdateTime('Updated ' + new Date().toLocaleTimeString('en-US'));
-    }, 60_000);
-    return () => clearInterval(id);
+
+      // Detect price changes for flash animation
+      const newFlash: Record<string, 'up' | 'down' | null> = {};
+      q.forEach(quote => {
+        const prev = prevPrices[quote.symbol];
+        if (prev !== undefined && prev !== quote.price) {
+          newFlash[quote.symbol] = quote.price > prev ? 'up' : 'down';
+        }
+        prevPrices[quote.symbol] = quote.price;
+      });
+      setFlashMap(newFlash);
+      setTimeout(() => setFlashMap({}), 800);
+
+      const status = getMarketStatus();
+      setMarketStatus(status);
+      timerId = setTimeout(refresh, getPollInterval(status));
+    }
+
+    const status = getMarketStatus();
+    setMarketStatus(status);
+    timerId = setTimeout(refresh, getPollInterval(status));
+    return () => clearTimeout(timerId);
   }, []);
 
   function handleSelectSymbolForTrend(sym: string) {
@@ -119,11 +144,13 @@ export default function DashboardPage() {
         period={period}
         onPeriodChange={setPeriod}
         updateTime={updateTime}
+        marketStatus={marketStatus}
       />
       <MarketTickerBar
         quotes={quotes}
         period={period}
         onSelectSymbol={handleSelectSymbolForTrend}
+        flashMap={flashMap}
       />
       <TabNav activeTab={activeTab} onTabChange={setActiveTab} />
       <QuickSearch quotes={quotes} onSelect={handleSelectSymbolForTrend} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -130,11 +130,18 @@ export default function DashboardPage() {
     return () => clearTimeout(timerId);
   }, []);
 
+  // Add to multi-symbol comparison in Trends tab
   function handleSelectSymbolForTrend(sym: string) {
     setSelected(prev => {
       if (prev.includes(sym)) return prev;
       return prev.length >= 6 ? [...prev.slice(1), sym] : [...prev, sym];
     });
+    setActiveTab('trends');
+  }
+
+  // Navigate to Trends tab with only this single symbol (solo chart view)
+  function handleViewChart(sym: string) {
+    setSelected([sym]);
     setActiveTab('trends');
   }
 
@@ -149,7 +156,7 @@ export default function DashboardPage() {
       <MarketTickerBar
         quotes={quotes}
         period={period}
-        onSelectSymbol={handleSelectSymbolForTrend}
+        onSelectSymbol={handleViewChart}
         flashMap={flashMap}
       />
       <TabNav activeTab={activeTab} onTabChange={setActiveTab} />

--- a/src/components/layout/MarketTickerBar.tsx
+++ b/src/components/layout/MarketTickerBar.tsx
@@ -9,9 +9,10 @@ interface Props {
   quotes: Quote[];
   period: string;
   onSelectSymbol: (sym: string) => void;
+  flashMap?: Record<string, 'up' | 'down' | null>;
 }
 
-export default function MarketTickerBar({ quotes, period, onSelectSymbol }: Props) {
+export default function MarketTickerBar({ quotes, period, onSelectSymbol, flashMap }: Props) {
   const tickers = useMemo(() => {
     const map = new Map(quotes.map(q => [q.symbol, q]));
     return TICKER_SYMBOLS.map(sym => map.get(sym)).filter(Boolean) as Quote[];
@@ -39,7 +40,7 @@ export default function MarketTickerBar({ quotes, period, onSelectSymbol }: Prop
           return (
             <button
               key={q.symbol}
-              className="ticker-item"
+              className={`ticker-item${flashMap?.[q.symbol] === 'up' ? ' flash-pos' : flashMap?.[q.symbol] === 'down' ? ' flash-neg' : ''}`}
               onClick={() => onSelectSymbol(q.symbol)}
               title={q.name}
             >

--- a/src/components/layout/MarketTickerBar.tsx
+++ b/src/components/layout/MarketTickerBar.tsx
@@ -3,7 +3,9 @@ import { useMemo } from 'react';
 import type { Quote } from '@/types';
 import { changeTextColor, fmtPct } from '@/lib/utils/colors';
 
-const TICKER_SYMBOLS = ['SPY', 'QQQ', 'TLT', 'GLD', 'IBIT', 'XLE', 'EEM', 'VNQ'];
+// Major broad-market indices shown first with accent styling
+const INDEX_SYMBOLS  = ['VOO', 'SPY', 'QQQ', 'DIA', 'IWM'];
+const TICKER_SYMBOLS = [...INDEX_SYMBOLS, 'TLT', 'GLD', 'IBIT', 'XLE', 'EEM', 'VNQ'];
 
 interface Props {
   quotes: Quote[];
@@ -35,24 +37,31 @@ export default function MarketTickerBar({ quotes, period, onSelectSymbol, flashM
   return (
     <div className="ticker-bar" role="region" aria-label="Market ticker">
       <div className="ticker-inner">
-        {tickers.map(q => {
+        {tickers.map((q, idx) => {
           const pct = getPct(q);
+          const isIndex = INDEX_SYMBOLS.includes(q.symbol);
+          const flash = flashMap?.[q.symbol];
           return (
             <button
               key={q.symbol}
-              className={`ticker-item${flashMap?.[q.symbol] === 'up' ? ' flash-pos' : flashMap?.[q.symbol] === 'down' ? ' flash-neg' : ''}`}
+              className={`ticker-item${isIndex ? ' ticker-index' : ''}${flash === 'up' ? ' flash-pos' : flash === 'down' ? ' flash-neg' : ''}`}
               onClick={() => onSelectSymbol(q.symbol)}
-              title={q.name}
+              title={`${q.name} — click to view chart`}
             >
-              <span className="ticker-sym">{q.symbol}</span>
-              <span className="ticker-price">${q.price.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+              {isIndex && idx > 0 && idx === INDEX_SYMBOLS.indexOf(q.symbol) && (
+                <span className="ticker-sep" />
+              )}
+              <span className={`ticker-sym${isIndex ? ' ticker-sym-index' : ''}`}>{q.symbol}</span>
+              <span className="ticker-price">
+                ${q.price.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+              </span>
               <span className="ticker-chg" style={{ color: changeTextColor(pct) }}>
                 {fmtPct(pct)}
               </span>
             </button>
           );
         })}
-        <span className="ticker-hint">Click to chart · period: {period}</span>
+        <span className="ticker-hint">Click any symbol to view chart</span>
       </div>
     </div>
   );

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { useState, useEffect } from 'react';
 import type { Period } from '@/types';
+import type { MarketStatus } from '@/lib/utils/marketHours';
+import { MARKET_STATUS_LABEL } from '@/lib/utils/marketHours';
 
 const PERIODS: Period[] = ['1d', '5d', '1m', '3m', '6m', '1y', 'ytd'];
 
@@ -8,9 +10,10 @@ interface Props {
   period: Period;
   onPeriodChange: (p: Period) => void;
   updateTime: string;
+  marketStatus: MarketStatus;
 }
 
-export default function TopBar({ period, onPeriodChange, updateTime }: Props) {
+export default function TopBar({ period, onPeriodChange, updateTime, marketStatus }: Props) {
   const [theme, setTheme] = useState<'dark' | 'light'>('dark');
 
   useEffect(() => {
@@ -57,7 +60,10 @@ export default function TopBar({ period, onPeriodChange, updateTime }: Props) {
         >
           {theme === 'dark' ? '☀️' : '🌙'}
         </button>
-        <span className="data-badge">⚙ Mock Data</span>
+        <span className={`market-status-badge market-${marketStatus}`}>
+          <span className="market-dot" />
+          {MARKET_STATUS_LABEL[marketStatus]}
+        </span>
         <span className="update-time">{updateTime}</span>
       </div>
     </header>

--- a/src/components/tabs/BacktestTab.tsx
+++ b/src/components/tabs/BacktestTab.tsx
@@ -1,30 +1,10 @@
 'use client';
 import { useState } from 'react';
-import { Line } from 'react-chartjs-2';
-import {
-  Chart as ChartJS,
-  LineElement,
-  PointElement,
-  CategoryScale,
-  LinearScale,
-  Tooltip,
-  Legend,
-  Filler,
-} from 'chart.js';
+import ReactECharts from 'echarts-for-react/lib/core';
+import { echarts, getEChartsTheme } from '@/lib/utils/echarts';
 import { SECTOR_COLORS, fmtPct } from '@/lib/utils/colors';
-import { getChartTheme } from '@/lib/utils/chartTheme';
 import { TEMPLATES } from '@/types';
 import type { Quote } from '@/types';
-
-ChartJS.register(
-  LineElement,
-  PointElement,
-  CategoryScale,
-  LinearScale,
-  Tooltip,
-  Legend,
-  Filler,
-);
 
 interface IndexedPoint {
   date: string;
@@ -122,40 +102,6 @@ export default function BacktestTab({ quotes }: Props) {
       setBtLoading(false);
     }
   }
-
-  const ct = getChartTheme();
-  const lineOpts: Record<string, unknown> = {
-    responsive: true,
-    maintainAspectRatio: false,
-    interaction: { mode: 'index', intersect: false },
-    plugins: {
-      legend: { labels: { color: ct.text, font: { size: 12 } } },
-      tooltip: {
-        callbacks: {
-          label: (ctx: { dataset: { label: string }; raw: number | null }) =>
-            ` ${ctx.dataset.label}: ${ctx.raw?.toFixed(2)}`,
-        },
-      },
-    },
-    scales: {
-      x: {
-        ticks: { color: ct.tick, maxTicksLimit: 12, maxRotation: 0 },
-        grid: { color: ct.grid },
-      },
-      y: {
-        ticks: {
-          color: ct.tick,
-          callback: (v: unknown) => (v as number).toFixed(0),
-        },
-        grid: { color: ct.grid },
-        title: {
-          display: true,
-          text: 'Indexed Return (base = 100)',
-          color: ct.tick,
-        },
-      },
-    },
-  };
 
   const STRATS = [
     { key: 'momentum' as const, label: `Momentum Rotation (Top${topN})`, color: '#4ade80' },
@@ -263,24 +209,55 @@ export default function BacktestTab({ quotes }: Props) {
                 </div>
               ))}
             </div>
-            <div className="chart-wrap tall" style={{ marginTop: '1.25rem' }}>
-              <Line
-                data={{
-                  labels: stratData.spy.map(p => p.date),
-                  datasets: STRATS.map(s => ({
-                    label: s.label,
-                    data: stratData[s.key].map(p => p.value),
-                    borderColor: s.color,
-                    backgroundColor: s.color + '18',
-                    borderWidth: s.key === 'spy' ? 1.5 : 2.5,
-                    borderDash: s.key === 'spy' ? [5, 5] : [],
-                    fill: s.key === 'momentum',
-                    pointRadius: 0,
-                    tension: 0.3,
-                    spanGaps: true,
-                  })),
-                }}
-                options={lineOpts}
+            <div style={{ marginTop: '1.25rem' }}>
+              <ReactECharts
+                echarts={echarts}
+                option={(() => {
+                  const th = getEChartsTheme();
+                  return {
+                    backgroundColor: 'transparent',
+                    tooltip: {
+                      trigger: 'axis',
+                      backgroundColor: th.tooltipBg,
+                      borderColor: th.tooltipBorder,
+                      textStyle: { color: th.tooltipText },
+                    },
+                    legend: {
+                      data: STRATS.map(s => s.label),
+                      textStyle: { color: th.textColor },
+                      top: 0,
+                    },
+                    grid: { left: 8, right: 8, top: 32, bottom: 8, containLabel: true },
+                    xAxis: {
+                      type: 'category',
+                      data: stratData.spy.map(p => p.date),
+                      axisLine: { lineStyle: { color: th.gridColor } },
+                      axisTick: { show: false },
+                      axisLabel: { color: th.textColor, interval: Math.floor(stratData.spy.length / 10) },
+                    },
+                    yAxis: {
+                      type: 'value',
+                      axisLabel: { color: th.textColor },
+                      splitLine: { lineStyle: { color: th.gridColor } },
+                    },
+                    series: STRATS.map(s => ({
+                      name: s.label,
+                      type: 'line',
+                      data: stratData[s.key].map(p => p.value),
+                      lineStyle: {
+                        color: s.color,
+                        width: s.key === 'spy' ? 1.5 : 2.5,
+                        type: s.key === 'spy' ? 'dashed' : 'solid',
+                      },
+                      itemStyle: { color: s.color },
+                      areaStyle: s.key === 'momentum' ? { color: s.color + '18' } : undefined,
+                      symbol: 'none',
+                      smooth: true,
+                    })),
+                  };
+                })()}
+                style={{ height: '360px' }}
+                notMerge
               />
             </div>
             <div className="strat-note">
@@ -436,34 +413,61 @@ export default function BacktestTab({ quotes }: Props) {
                 </div>
               ))}
             </div>
-            <div className="chart-wrap tall" style={{ marginTop: '1.5rem' }}>
-              <Line
-                data={{
-                  labels: btData.portfolio.map(p => p.date),
-                  datasets: [
-                    {
-                      label: 'My Portfolio',
-                      data: btData.portfolio.map(p => p.value),
-                      borderColor: '#4a90e2',
-                      backgroundColor: '#4a90e222',
-                      borderWidth: 2.5,
-                      fill: true,
-                      pointRadius: 0,
-                      tension: 0.3,
+            <div style={{ marginTop: '1.5rem' }}>
+              <ReactECharts
+                echarts={echarts}
+                option={(() => {
+                  const th = getEChartsTheme();
+                  return {
+                    backgroundColor: 'transparent',
+                    tooltip: {
+                      trigger: 'axis',
+                      backgroundColor: th.tooltipBg,
+                      borderColor: th.tooltipBorder,
+                      textStyle: { color: th.tooltipText },
                     },
-                    {
-                      label: 'SPY (S&P 500)',
-                      data: btData.benchmark.map(b => b.value),
-                      borderColor: '#94a3b8',
-                      backgroundColor: 'transparent',
-                      borderWidth: 1.5,
-                      borderDash: [5, 5],
-                      pointRadius: 0,
-                      tension: 0.3,
+                    legend: {
+                      data: ['My Portfolio', 'SPY (S&P 500)'],
+                      textStyle: { color: th.textColor },
+                      top: 0,
                     },
-                  ],
-                }}
-                options={lineOpts}
+                    grid: { left: 8, right: 8, top: 32, bottom: 8, containLabel: true },
+                    xAxis: {
+                      type: 'category',
+                      data: btData!.portfolio.map(p => p.date),
+                      axisLine: { lineStyle: { color: th.gridColor } },
+                      axisTick: { show: false },
+                      axisLabel: { color: th.textColor, interval: Math.floor(btData!.portfolio.length / 10) },
+                    },
+                    yAxis: {
+                      type: 'value',
+                      axisLabel: { color: th.textColor },
+                      splitLine: { lineStyle: { color: th.gridColor } },
+                    },
+                    series: [
+                      {
+                        name: 'My Portfolio',
+                        type: 'line',
+                        data: btData!.portfolio.map(p => p.value),
+                        lineStyle: { color: '#4a90e2', width: 2.5 },
+                        itemStyle: { color: '#4a90e2' },
+                        areaStyle: { color: '#4a90e222' },
+                        symbol: 'none',
+                        smooth: true,
+                      },
+                      {
+                        name: 'SPY (S&P 500)',
+                        type: 'line',
+                        data: btData!.benchmark.map(b => b.value),
+                        lineStyle: { color: '#94a3b8', width: 1.5, type: 'dashed' },
+                        itemStyle: { color: '#94a3b8' },
+                        symbol: 'none',
+                      },
+                    ],
+                  };
+                })()}
+                style={{ height: '360px' }}
+                notMerge
               />
             </div>
             <div className="bt-composition">

--- a/src/components/tabs/CorrelationTab.tsx
+++ b/src/components/tabs/CorrelationTab.tsx
@@ -1,15 +1,9 @@
 'use client';
 import { useState, useMemo } from 'react';
-import { Line } from 'react-chartjs-2';
-import {
-  Chart as ChartJS, LineElement, PointElement, CategoryScale,
-  LinearScale, Tooltip, Legend, Filler,
-} from 'chart.js';
+import ReactECharts from 'echarts-for-react/lib/core';
+import { echarts, getEChartsTheme } from '@/lib/utils/echarts';
 import { SECTOR_COLORS } from '@/lib/utils/colors';
-import { getChartTheme } from '@/lib/utils/chartTheme';
 import type { CorrelationMatrix } from '@/types';
-
-ChartJS.register(LineElement, PointElement, CategoryScale, LinearScale, Tooltip, Legend, Filler);
 
 // ── Color helpers ─────────────────────────────────────────────────
 function corrColor(v: number): string {
@@ -220,12 +214,10 @@ interface RollingChartProps {
 }
 
 function RollingCorrChart({ data, pair }: RollingChartProps) {
-  const ct = getChartTheme();
   const [i, j] = pair;
   const symA = data.symbols[i];
   const symB = data.symbols[j];
 
-  // Find rolling series for this pair
   const rollingEntry = useMemo(() => {
     const [a, b] = [Math.min(i, j), Math.max(i, j)];
     return data.rolling.find(r =>
@@ -240,72 +232,64 @@ function RollingCorrChart({ data, pair }: RollingChartProps) {
   const avg     = values.reduce((s, v) => s + v, 0) / values.length;
   const diverge = Math.abs(current - avg);
 
-  // Weekly labels (W-36 … W-0)
   const labels = values.map((_, k) => {
     const wk = values.length - 1 - k;
     return wk === 0 ? 'Now' : `−${wk}w`;
   });
 
-  const chartData = {
-    labels,
-    datasets: [
+  const th = getEChartsTheme();
+  const chartOption = {
+    backgroundColor: 'transparent',
+    tooltip: {
+      trigger: 'axis',
+      backgroundColor: th.tooltipBg,
+      borderColor: th.tooltipBorder,
+      textStyle: { color: th.tooltipText },
+      formatter: (params: unknown) => {
+        const p = params as Array<{ seriesName: string; value: number }>;
+        return p.map(x => `${x.seriesName}: ${x.value.toFixed(3)}`).join('<br/>');
+      },
+    },
+    legend: { data: ['Rolling 30d Corr', '1yr Avg'], textStyle: { color: th.textColor, fontSize: 11 }, top: 0 },
+    grid: { left: 8, right: 8, top: 28, bottom: 8, containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: labels,
+      axisLine: { show: false },
+      axisTick: { show: false },
+      axisLabel: {
+        color: th.textColor,
+        interval: (idx: number) => idx % 4 === 0,
+      },
+      splitLine: { show: false },
+    },
+    yAxis: {
+      type: 'value',
+      min: -1, max: 1,
+      axisLabel: { color: th.textColor, formatter: (v: number) => v.toFixed(1) },
+      splitLine: { lineStyle: { color: th.gridColor } },
+    },
+    series: [
       {
-        label: 'Rolling 30d Corr',
+        name: 'Rolling 30d Corr',
+        type: 'line',
         data: values,
-        borderColor: '#4a90e2',
-        backgroundColor: 'rgba(74,144,226,0.12)',
-        borderWidth: 2,
-        pointRadius: 0,
-        fill: true,
-        tension: 0.35,
+        lineStyle: { color: '#4a90e2', width: 2 },
+        itemStyle: { color: '#4a90e2' },
+        areaStyle: { color: 'rgba(74,144,226,0.12)' },
+        symbol: 'none',
+        smooth: true,
       },
       {
-        label: '1yr Avg',
+        name: '1yr Avg',
+        type: 'line',
         data: values.map(() => avg),
-        borderColor: 'rgba(255,193,7,0.6)',
-        borderDash: [4, 4],
-        borderWidth: 1.5,
-        pointRadius: 0,
-        fill: false,
+        lineStyle: { color: 'rgba(255,193,7,0.7)', width: 1.5, type: 'dashed' },
+        itemStyle: { color: 'rgba(255,193,7,0.7)' },
+        symbol: 'none',
       },
     ],
   };
-
-  const options = {
-    responsive: true,
-    maintainAspectRatio: false,
-    plugins: {
-      legend: {
-        labels: { color: ct.text, font: { size: 11 }, boxWidth: 14 },
-      },
-      tooltip: {
-        callbacks: {
-          label: (c: { dataset: { label?: string }; parsed: { y: number } }) =>
-            ` ${c.dataset.label}: ${c.parsed.y.toFixed(3)}`,
-        },
-      },
-    },
-    scales: {
-      x: {
-        ticks: {
-          color: ct.tick,
-          maxTicksLimit: 10,
-          callback: (_v: unknown, idx: number) =>
-            idx % 4 === 0 ? labels[idx] : '',
-        },
-        grid: { color: ct.grid },
-      },
-      y: {
-        min: -1, max: 1,
-        ticks: {
-          color: ct.tick,
-          callback: (v: unknown) => Number(v).toFixed(1),
-        },
-        grid: { color: ct.grid },
-      },
-    },
-    animation: { duration: 300 },
-  } as Record<string, unknown>;
 
   return (
     <div className="corr-pair-detail">
@@ -318,10 +302,9 @@ function RollingCorrChart({ data, pair }: RollingChartProps) {
         <div className="corr-pair-badges">
           <span className="corr-stat-badge">
             <span className="corr-stat-label">Current</span>
-            <span
-              className="corr-stat-val"
-              style={{ color: current >= 0 ? '#4a90e2' : '#e74c3c' }}
-            >{current >= 0 ? '+' : ''}{current.toFixed(3)}</span>
+            <span className="corr-stat-val" style={{ color: current >= 0 ? '#4a90e2' : '#e74c3c' }}>
+              {current >= 0 ? '+' : ''}{current.toFixed(3)}
+            </span>
           </span>
           <span className="corr-stat-badge">
             <span className="corr-stat-label">1yr Avg</span>
@@ -329,16 +312,13 @@ function RollingCorrChart({ data, pair }: RollingChartProps) {
           </span>
           <span className="corr-stat-badge">
             <span className="corr-stat-label">Divergence</span>
-            <span
-              className="corr-stat-val"
-              style={{ color: diverge > 0.25 ? '#f7931a' : 'var(--text-muted)' }}
-            >{diverge.toFixed(3)}{diverge > 0.25 ? ' ⚠' : ''}</span>
+            <span className="corr-stat-val" style={{ color: diverge > 0.25 ? '#f7931a' : 'var(--text-muted)' }}>
+              {diverge.toFixed(3)}{diverge > 0.25 ? ' ⚠' : ''}
+            </span>
           </span>
         </div>
       </div>
-      <div style={{ height: 200 }}>
-        <Line data={chartData} options={options} />
-      </div>
+      <ReactECharts echarts={echarts} option={chartOption} style={{ height: 200 }} notMerge />
       {diverge > 0.25 && (
         <div className="corr-diverge-alert">
           <span className="corr-diverge-icon">⚠</span>

--- a/src/components/tabs/CrisisTab.tsx
+++ b/src/components/tabs/CrisisTab.tsx
@@ -1,14 +1,9 @@
 'use client';
 import { useState, useRef, useEffect } from 'react';
-import { Bar } from 'react-chartjs-2';
-import {
-  Chart as ChartJS, BarElement, CategoryScale, LinearScale, Tooltip, Legend,
-} from 'chart.js';
+import ReactECharts from 'echarts-for-react/lib/core';
+import { echarts, getEChartsTheme } from '@/lib/utils/echarts';
 import { SECTOR_COLORS } from '@/lib/utils/colors';
-import { getChartTheme } from '@/lib/utils/chartTheme';
 import type { CrisisEvent, CrisisPricePoint } from '@/types';
-
-ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend);
 
 const TYPE_COLORS: Record<string, string> = {
   fed:          '#4a90e2',
@@ -267,54 +262,56 @@ function CrisisCard({
 
 // ── Sector Drawdown Comparison bar chart ──────────────────────────
 function SectorDrawdownChart({ crisis }: { crisis: CrisisEvent }) {
-  const ct = getChartTheme();
-  const entries = Object.entries(crisis.sectorDrawdowns)
-    .sort((a, b) => a[1] - b[1]);
+  const th = getEChartsTheme();
+  const entries = Object.entries(crisis.sectorDrawdowns).sort((a, b) => a[1] - b[1]);
   const labels = entries.map(([s]) => s);
   const values = entries.map(([, v]) => v);
-  const colors = labels.map(s => (SECTOR_COLORS[s] ?? '#58a6ff') + 'cc');
+
+  const option = {
+    backgroundColor: 'transparent',
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' },
+      backgroundColor: th.tooltipBg,
+      borderColor: th.tooltipBorder,
+      textStyle: { color: th.tooltipText },
+      formatter: (params: unknown) => {
+        const p = params as Array<{ name: string; value: number }>;
+        return `${p[0].name}: ${p[0].value.toFixed(1)}%`;
+      },
+    },
+    grid: { left: 8, right: 16, top: 4, bottom: 4, containLabel: true },
+    xAxis: {
+      type: 'value',
+      axisLabel: { color: th.textColor, formatter: (v: number) => `${v}%` },
+      splitLine: { lineStyle: { color: th.gridColor } },
+      axisLine: { show: false },
+    },
+    yAxis: {
+      type: 'category',
+      data: labels,
+      axisLabel: { color: th.textColor, fontSize: 10 },
+      axisLine: { show: false },
+      axisTick: { show: false },
+    },
+    series: [{
+      type: 'bar',
+      data: values.map((v, i) => ({
+        value: v,
+        itemStyle: { color: (SECTOR_COLORS[labels[i]] ?? '#58a6ff') + 'cc', borderRadius: [0, 3, 3, 0] },
+      })),
+      barMaxWidth: 22,
+    }],
+  };
 
   return (
-    <div style={{ height: '280px' }}>
-      <Bar
-        data={{
-          labels,
-          datasets: [{
-            label: 'Drawdown %',
-            data: values,
-            backgroundColor: colors,
-            borderColor: labels.map(s => SECTOR_COLORS[s] ?? '#58a6ff'),
-            borderWidth: 1,
-            borderRadius: 3,
-          }],
-        }}
-        options={{
-          indexAxis: 'y',
-          responsive: true,
-          maintainAspectRatio: false,
-          plugins: {
-            legend: { display: false },
-            tooltip: {
-              callbacks: { label: (c: { raw: unknown }) => ` ${(c.raw as number).toFixed(1)}%` },
-            },
-          },
-          scales: {
-            x: {
-              ticks: { color: ct.tick, callback: (v: unknown) => `${v}%` },
-              grid: { color: ct.grid },
-            },
-            y: { ticks: { color: ct.text, font: { size: 10 } }, grid: { display: false } },
-          },
-          animation: { duration: 250 },
-        } as Record<string, unknown>}
-      />
-    </div>
+    <ReactECharts echarts={echarts} option={option} style={{ height: '280px' }} notMerge />
   );
 }
 
 // ── Cross-crisis comparison ───────────────────────────────────────
 function ComparisonChart({ crises }: { crises: CrisisEvent[] }) {
-  const ct = getChartTheme();
+  const th = getEChartsTheme();
   const labels = crises.map(c => c.date);
 
   return (
@@ -325,30 +322,43 @@ function ComparisonChart({ crises }: { crises: CrisisEvent[] }) {
         ['Recovery Days', crises.map(c => c.recoveryDays), '#60a5fa'],
         ['Buy Signal Gain (%)', crises.map(c => c.buySignalGain), '#4ade80'],
       ] as [string, number[], string][]).map(([title, values, color]) => (
-        <div key={title} style={{ height: '180px' }}>
+        <div key={title}>
           <div className="comparison-chart-title">{title}</div>
-          <Bar
-            data={{
-              labels,
-              datasets: [{
-                label: title,
-                data: values,
-                backgroundColor: color + '99',
-                borderColor: color,
-                borderWidth: 1,
-                borderRadius: 4,
+          <ReactECharts
+            echarts={echarts}
+            option={{
+              backgroundColor: 'transparent',
+              tooltip: {
+                trigger: 'axis',
+                backgroundColor: th.tooltipBg,
+                borderColor: th.tooltipBorder,
+                textStyle: { color: th.tooltipText, fontSize: 11 },
+              },
+              grid: { left: 4, right: 4, top: 4, bottom: 4, containLabel: true },
+              xAxis: {
+                type: 'category',
+                data: labels,
+                axisLabel: { color: th.textColor, fontSize: 9 },
+                splitLine: { show: false },
+                axisLine: { show: false },
+                axisTick: { show: false },
+              },
+              yAxis: {
+                type: 'value',
+                axisLabel: { color: th.textColor, fontSize: 9 },
+                splitLine: { lineStyle: { color: th.gridColor } },
+              },
+              series: [{
+                type: 'bar',
+                data: (values as number[]).map(v => ({
+                  value: v,
+                  itemStyle: { color: color + '99', borderColor: color, borderWidth: 1, borderRadius: 4 },
+                })),
+                barMaxWidth: 20,
               }],
             }}
-            options={{
-              responsive: true,
-              maintainAspectRatio: false,
-              plugins: { legend: { display: false } },
-              scales: {
-                x: { ticks: { color: ct.tick, font: { size: 9 } }, grid: { color: ct.grid } },
-                y: { ticks: { color: ct.tick, font: { size: 9 } }, grid: { color: ct.grid } },
-              },
-              animation: { duration: 200 },
-            } as Record<string, unknown>}
+            style={{ height: '180px' }}
+            notMerge
           />
         </div>
       ))}

--- a/src/components/tabs/FlowChipsTab.tsx
+++ b/src/components/tabs/FlowChipsTab.tsx
@@ -88,13 +88,6 @@ export default function FlowChipsTab({ quotes, period }: Props) {
       axisLabel: { color: th.textColor },
       splitLine: { lineStyle: { color: th.gridColor } },
     },
-    markLine: {
-      silent: true,
-      data: [
-        { xAxis: (n + 1) / 2, lineStyle: { color: 'rgba(139,148,158,0.3)', type: 'dashed' } },
-        { yAxis: 1, lineStyle: { color: 'rgba(139,148,158,0.3)', type: 'dashed' } },
-      ],
-    },
     series: [{
       type: 'scatter',
       data: flowData.sectors.map((sec, i) => [
@@ -125,6 +118,14 @@ export default function FlowChipsTab({ quotes, period }: Props) {
         fontSize: 9,
         color: '#e2e8f0',
         position: 'inside',
+      },
+      markLine: {
+        silent: true,
+        symbol: 'none',
+        data: [
+          { xAxis: (n + 1) / 2, lineStyle: { color: 'rgba(139,148,158,0.3)', type: 'dashed' as const } },
+          { yAxis: 1, lineStyle: { color: 'rgba(139,148,158,0.3)', type: 'dashed' as const } },
+        ],
       },
     }],
   };

--- a/src/components/tabs/FlowChipsTab.tsx
+++ b/src/components/tabs/FlowChipsTab.tsx
@@ -1,36 +1,10 @@
 'use client';
 import { useState, useEffect } from 'react';
-import { Bubble, Bar, Line } from 'react-chartjs-2';
-import {
-  Chart as ChartJS,
-  ArcElement,
-  BarElement,
-  BubbleController,
-  LineElement,
-  PointElement,
-  CategoryScale,
-  LinearScale,
-  Tooltip,
-  Legend,
-  Filler,
-} from 'chart.js';
-import { SECTOR_COLORS, changeColor } from '@/lib/utils/colors';
-import { getChartTheme } from '@/lib/utils/chartTheme';
+import ReactECharts from 'echarts-for-react/lib/core';
+import { echarts, getEChartsTheme } from '@/lib/utils/echarts';
+import { changeColor } from '@/lib/utils/colors';
 import { SankeyChart } from '@/components/charts';
 import type { Quote, ChipRow, FlowMatrix } from '@/types';
-
-ChartJS.register(
-  ArcElement,
-  BarElement,
-  BubbleController,
-  LineElement,
-  PointElement,
-  CategoryScale,
-  LinearScale,
-  Tooltip,
-  Legend,
-  Filler,
-);
 
 interface Props {
   quotes: Quote[];
@@ -76,82 +50,128 @@ export default function FlowChipsTab({ quotes, period }: Props) {
     );
   }
 
-  const ct = getChartTheme();
+  const th = getEChartsTheme();
 
   const n = flowData.sectors.length;
 
-  const bubbleDatasets = flowData.sectors.map((sec, i) => ({
-    label: sec,
-    data: [
-      {
-        x: n - i,
-        y: flowData.volume_ratios[i],
-        r: Math.max(6, Math.sqrt(flowData.mcaps[i] || 1) * 1.8),
+  // ECharts scatter replaces the Bubble chart
+  const scatterOption = {
+    backgroundColor: 'transparent',
+    tooltip: {
+      trigger: 'item',
+      backgroundColor: th.tooltipBg,
+      borderColor: th.tooltipBorder,
+      textStyle: { color: th.tooltipText },
+      formatter: (params: unknown) => {
+        const p = params as { data: [number, number, number, string, number] };
+        const [x, y, , sec, score] = p.data;
+        return `${sec}<br/>Momentum rank: ${x}<br/>Volume ratio: ${y.toFixed(2)}x<br/>Flow Score: ${score > 0 ? '+' : ''}${score}`;
       },
-    ],
-    backgroundColor: changeColor(flowData.flow_scores[i], 0.7),
-    borderColor:     changeColor(flowData.flow_scores[i], 1),
-    borderWidth: 1.5,
-  }));
-
-  const quadrantPlugin = {
-    id: 'quadrantLines',
-    afterDraw(chart: ChartJS) {
-      const c = chart as unknown as {
-        ctx: CanvasRenderingContext2D;
-        chartArea: { left: number; right: number; top: number; bottom: number };
-        scales: {
-          x: { getPixelForValue: (v: number) => number };
-          y: { getPixelForValue: (v: number) => number };
-        };
-      };
-      const { ctx, chartArea: { left, right, top, bottom }, scales: { x, y } } = c;
-      const mx = x.getPixelForValue((n + 1) / 2);
-      const my = y.getPixelForValue(1);
-      ctx.save();
-      ctx.strokeStyle = 'rgba(139,148,158,0.25)';
-      ctx.setLineDash([5, 4]);
-      ctx.lineWidth = 1;
-      ctx.beginPath(); ctx.moveTo(mx, top);   ctx.lineTo(mx, bottom); ctx.stroke();
-      ctx.beginPath(); ctx.moveTo(left, my);  ctx.lineTo(right, my);  ctx.stroke();
-      ctx.restore();
     },
+    grid: { left: 8, right: 8, top: 24, bottom: 32, containLabel: true },
+    xAxis: {
+      type: 'value',
+      name: 'Momentum Rank →',
+      nameTextStyle: { color: th.textColor, fontSize: 10 },
+      min: 0, max: n + 1,
+      axisLabel: { color: th.textColor },
+      splitLine: { lineStyle: { color: th.gridColor } },
+      axisLine: {
+        onZero: false,
+        lineStyle: { color: 'rgba(139,148,158,0.25)', type: 'dashed' as const },
+      },
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Volume Ratio',
+      nameTextStyle: { color: th.textColor, fontSize: 10 },
+      axisLabel: { color: th.textColor },
+      splitLine: { lineStyle: { color: th.gridColor } },
+    },
+    markLine: {
+      silent: true,
+      data: [
+        { xAxis: (n + 1) / 2, lineStyle: { color: 'rgba(139,148,158,0.3)', type: 'dashed' } },
+        { yAxis: 1, lineStyle: { color: 'rgba(139,148,158,0.3)', type: 'dashed' } },
+      ],
+    },
+    series: [{
+      type: 'scatter',
+      data: flowData.sectors.map((sec, i) => [
+        n - i,
+        flowData.volume_ratios[i],
+        Math.max(10, Math.sqrt(flowData.mcaps[i] || 1) * 1.8),
+        sec,
+        flowData.flow_scores[i],
+      ]),
+      symbolSize: (val: unknown) => (val as number[])[2],
+      itemStyle: {
+        color: (params: unknown) => {
+          const p = params as { data: number[] };
+          return changeColor(p.data[4], 0.7);
+        },
+        borderColor: (params: unknown) => {
+          const p = params as { data: number[] };
+          return changeColor(p.data[4], 1);
+        },
+        borderWidth: 1.5,
+      },
+      label: {
+        show: true,
+        formatter: (params: unknown) => {
+          const p = params as { data: [number, number, number, string] };
+          return p.data[3].substring(0, 4);
+        },
+        fontSize: 9,
+        color: '#e2e8f0',
+        position: 'inside',
+      },
+    }],
   };
 
   const flowSorted = flowData.sectors
     .map((s, i) => ({ s, v: flowData.flow_scores[i] }))
     .sort((a, b) => a.v - b.v);
 
-  const scoreBarData = {
-    labels: flowSorted.map(d => d.s),
-    datasets: [
-      {
-        data:            flowSorted.map(d => d.v),
-        backgroundColor: flowSorted.map(d => changeColor(d.v, 0.75)),
-        borderColor:     flowSorted.map(d => changeColor(d.v, 1)),
-        borderWidth: 1,
+  // Flow Score bar option (ECharts horizontal bar)
+  const flowBarOption = {
+    backgroundColor: 'transparent',
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' },
+      backgroundColor: th.tooltipBg,
+      borderColor: th.tooltipBorder,
+      textStyle: { color: th.tooltipText },
+      formatter: (params: unknown) => {
+        const p = params as Array<{ name: string; value: number }>;
+        return `${p[0].name}: Flow Score: ${p[0].value > 0 ? '+' : ''}${p[0].value}`;
       },
-    ],
-  };
-
-  const barOpts: Record<string, unknown> = {
-    indexAxis: 'y',
-    responsive: true,
-    maintainAspectRatio: false,
-    plugins: {
-      legend: { display: false },
-      tooltip: {
-        callbacks: {
-          label: (c: { raw: number }) =>
-            ` Flow Score: ${c.raw > 0 ? '+' : ''}${c.raw}`,
+    },
+    grid: { left: 8, right: 16, top: 8, bottom: 8, containLabel: true },
+    xAxis: {
+      type: 'value',
+      axisLine: { show: false },
+      axisTick: { show: false },
+      splitLine: { lineStyle: { color: th.gridColor } },
+      axisLabel: { color: th.textColor },
+    },
+    yAxis: {
+      type: 'category',
+      data: flowSorted.map(d => d.s),
+      axisLine: { show: false },
+      axisTick: { show: false },
+      axisLabel: { color: th.textColor, fontSize: 11 },
+    },
+    series: [{
+      type: 'bar',
+      data: flowSorted.map(d => ({
+        value: d.v,
+        itemStyle: {
+          color: changeColor(d.v, 0.75),
         },
-      },
-    },
-    scales: {
-      x: { ticks: { color: ct.tick }, grid: { color: ct.grid } },
-      y: { ticks: { color: ct.text, font: { size: 11 } }, grid: { color: ct.grid } },
-    },
-    animation: { duration: 300 },
+      })),
+      barMaxWidth: 28,
+    }],
   };
 
   // Chip chart data
@@ -160,6 +180,128 @@ export default function FlowChipsTab({ quotes, period }: Props) {
   const isTW = chipMode === 'tw';
   const chipLabels = isTW ? ['外資', '投信', '自營商'] : ['Institutional', 'Smart Money', 'Retail'];
   const secEtf = quotes.find(q => q.sector === chipRow?.sector && q.symbol !== 'SPY');
+
+  // Stacked bar option for daily net buy
+  const stackedBarOption = chipRow ? {
+    backgroundColor: 'transparent',
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' },
+      backgroundColor: th.tooltipBg,
+      borderColor: th.tooltipBorder,
+      textStyle: { color: th.tooltipText },
+    },
+    legend: {
+      data: chipLabels,
+      textStyle: { color: th.textColor },
+      top: 0,
+    },
+    grid: { left: 8, right: 8, top: 28, bottom: 8, containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: chipRow.dates,
+      axisLine: { show: false },
+      axisTick: { show: false },
+      axisLabel: { color: th.textColor, interval: Math.floor(chipRow.dates.length / 8), rotate: 30 },
+    },
+    yAxis: {
+      type: 'value',
+      name: '$M',
+      nameTextStyle: { color: th.textColor },
+      axisLabel: { color: th.textColor },
+      splitLine: { lineStyle: { color: th.gridColor } },
+    },
+    series: [
+      {
+        name: chipLabels[0],
+        type: 'bar',
+        stack: 's',
+        data: chipRow.institutional,
+        itemStyle: { color: 'rgba(74,144,226,0.75)' },
+      },
+      {
+        name: chipLabels[1],
+        type: 'bar',
+        stack: 's',
+        data: chipRow.smart_money,
+        itemStyle: { color: 'rgba(142,68,173,0.65)' },
+      },
+      {
+        name: chipLabels[2],
+        type: 'bar',
+        stack: 's',
+        data: chipRow.retail,
+        itemStyle: { color: 'rgba(231,76,60,0.55)' },
+      },
+    ],
+  } : null;
+
+  // Cumulative line option
+  const cumulativeLineOption = chipRow ? {
+    backgroundColor: 'transparent',
+    tooltip: {
+      trigger: 'axis',
+      backgroundColor: th.tooltipBg,
+      borderColor: th.tooltipBorder,
+      textStyle: { color: th.tooltipText },
+    },
+    legend: {
+      data: [
+        isTW ? 'Cumulative Foreign Buy' : 'Cumulative Institutional Buy',
+        ...(secEtf ? [`${secEtf.symbol} 現價`] : []),
+      ],
+      textStyle: { color: th.textColor },
+      top: 0,
+    },
+    grid: { left: 8, right: 60, top: 28, bottom: 8, containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: chipRow.dates,
+      axisLine: { show: false },
+      axisTick: { show: false },
+      axisLabel: { color: th.textColor, interval: Math.floor(chipRow.dates.length / 8), rotate: 30 },
+    },
+    yAxis: [
+      {
+        type: 'value',
+        name: 'Cumul. $M',
+        nameTextStyle: { color: '#4a90e2' },
+        axisLabel: { color: '#4a90e2' },
+        splitLine: { lineStyle: { color: th.gridColor } },
+        position: 'left',
+      },
+      ...(secEtf ? [{
+        type: 'value',
+        name: 'ETF Price',
+        nameTextStyle: { color: '#f7931a' },
+        axisLabel: { color: '#f7931a' },
+        splitLine: { show: false },
+        position: 'right',
+      }] : []),
+    ],
+    series: [
+      {
+        name: isTW ? 'Cumulative Foreign Buy' : 'Cumulative Institutional Buy',
+        type: 'line',
+        data: chipRow.cumulative,
+        lineStyle: { color: '#4a90e2', width: 2 },
+        itemStyle: { color: '#4a90e2' },
+        areaStyle: { color: 'rgba(74,144,226,0.12)' },
+        symbol: 'none',
+        smooth: true,
+        yAxisIndex: 0,
+      },
+      ...(secEtf ? [{
+        name: `${secEtf.symbol} 現價`,
+        type: 'line',
+        data: chipRow.dates.map(() => secEtf.price),
+        lineStyle: { color: '#f7931a', width: 1.5, type: 'dashed' as const },
+        itemStyle: { color: '#f7931a' },
+        symbol: 'none',
+        yAxisIndex: 1,
+      }] : []),
+    ],
+  } : null;
 
   return (
     <main className="tab-panel active">
@@ -185,41 +327,12 @@ export default function FlowChipsTab({ quotes, period }: Props) {
         <div className="flow-top-grid">
           <div>
             <div className="chart-sublabel">Rotation Quadrant</div>
-            <div className="chart-wrap" style={{ height: '340px' }}>
-              <Bubble
-                data={{ datasets: bubbleDatasets }}
-                options={{
-                  responsive: true,
-                  maintainAspectRatio: false,
-                  plugins: {
-                    legend: { display: false },
-                    tooltip: {
-                      callbacks: {
-                        label: (ctx: import('chart.js').TooltipItem<'bubble'>) => {
-                          const d = ctx.raw as { x: number; y: number; r: number };
-                          const sec = ctx.dataset.label ?? '';
-                          const score = flowData.flow_scores[flowData.sectors.indexOf(sec)];
-                          return `${sec} | Momentum rank:${d.x} | Volume ratio:${d.y.toFixed(2)}x | Flow Score:${score > 0 ? '+' : ''}${score}`;
-                        },
-                      },
-                    },
-                  },
-                  scales: {
-                    x: {
-                      title: { display: true, text: 'Momentum Rank → (right = inflow)', color: ct.tick },
-                      ticks: { color: ct.tick },
-                      grid: { color: ct.grid },
-                      min: 0, max: n + 1,
-                    },
-                    y: {
-                      title: { display: true, text: 'Volume Ratio (vs 30d avg)', color: ct.tick },
-                      ticks: { color: ct.tick },
-                      grid: { color: ct.grid },
-                    },
-                  },
-                  animation: { duration: 400 },
-                }}
-                plugins={[quadrantPlugin as unknown as import('chart.js').Plugin]}
+            <div style={{ height: '340px' }}>
+              <ReactECharts
+                echarts={echarts}
+                option={scatterOption}
+                style={{ height: '100%' }}
+                notMerge
               />
             </div>
             <div className="quadrant-legend">
@@ -232,7 +345,12 @@ export default function FlowChipsTab({ quotes, period }: Props) {
           <div>
             <div className="chart-sublabel">Sector Flow Score</div>
             <div className="chart-wrap" style={{ height: '340px' }}>
-              <Bar data={scoreBarData} options={barOpts} />
+              <ReactECharts
+                echarts={echarts}
+                option={flowBarOption}
+                style={{ height: '100%' }}
+                notMerge
+              />
             </div>
           </div>
         </div>
@@ -283,92 +401,27 @@ export default function FlowChipsTab({ quotes, period }: Props) {
           </div>
         </div>
 
-        {chipRow && (
+        {chipRow && stackedBarOption && cumulativeLineOption && (
           <div className="chip-charts-grid">
             <div>
               <div className="chart-sublabel">Daily Net Buy ($M)</div>
               <div className="chart-wrap" style={{ height: '260px' }}>
-                <Bar
-                  data={{
-                    labels: chipRow.dates,
-                    datasets: [
-                      {
-                        label: chipLabels[0],
-                        data: chipRow.institutional,
-                        backgroundColor: 'rgba(74,144,226,0.75)',
-                        stack: 's',
-                      },
-                      {
-                        label: chipLabels[1],
-                        data: chipRow.smart_money,
-                        backgroundColor: 'rgba(142,68,173,0.65)',
-                        stack: 's',
-                      },
-                      {
-                        label: chipLabels[2],
-                        data: chipRow.retail,
-                        backgroundColor: 'rgba(231,76,60,0.55)',
-                        stack: 's',
-                      },
-                    ],
-                  }}
-                  options={{
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    plugins: {
-                      legend: { labels: { color: ct.tick, boxWidth: 12 } },
-                    },
-                    scales: {
-                      x: { ticks: { color: ct.tick, maxTicksLimit: 8, maxRotation: 30 }, grid: { color: ct.grid }, stacked: true },
-                      y: { ticks: { color: ct.tick }, grid: { color: ct.grid }, stacked: true, title: { display: true, text: '$M', color: ct.tick } },
-                    },
-                    animation: { duration: 300 },
-                  } as Record<string, unknown>}
+                <ReactECharts
+                  echarts={echarts}
+                  option={stackedBarOption}
+                  style={{ height: '100%' }}
+                  notMerge
                 />
               </div>
             </div>
             <div>
               <div className="chart-sublabel">Cumulative Institutional vs ETF Price</div>
               <div className="chart-wrap" style={{ height: '260px' }}>
-                <Line
-                  data={{
-                    labels: chipRow.dates,
-                    datasets: [
-                      {
-                        label: isTW ? 'Cumulative Foreign Buy' : 'Cumulative Institutional Buy',
-                        data: chipRow.cumulative,
-                        borderColor: '#4a90e2',
-                        backgroundColor: 'rgba(74,144,226,0.12)',
-                        fill: true,
-                        tension: 0.3,
-                        yAxisID: 'y',
-                        pointRadius: 0,
-                      },
-                      ...(secEtf ? [{
-                        label: `${secEtf.symbol} 現價`,
-                        data: chipRow.dates.map(() => secEtf.price),
-                        borderColor: '#f7931a',
-                        borderDash: [4, 3],
-                        pointRadius: 0,
-                        yAxisID: 'y2',
-                        backgroundColor: 'transparent',
-                        tension: 0.3,
-                      }] : []),
-                    ],
-                  }}
-                  options={{
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    plugins: {
-                      legend: { labels: { color: ct.tick, boxWidth: 12 } },
-                    },
-                    scales: {
-                      x: { ticks: { color: ct.tick, maxTicksLimit: 8, maxRotation: 30 }, grid: { color: ct.grid } },
-                      y: { ticks: { color: '#4a90e2' }, grid: { color: ct.grid }, position: 'left', title: { display: true, text: 'Cumul. $M', color: '#4a90e2' } },
-                      y2: { ticks: { color: '#f7931a' }, grid: { display: false }, position: 'right', title: { display: true, text: 'ETF Price', color: '#f7931a' } },
-                    },
-                    animation: { duration: 300 },
-                  } as Record<string, unknown>}
+                <ReactECharts
+                  echarts={echarts}
+                  option={cumulativeLineOption}
+                  style={{ height: '100%' }}
+                  notMerge
                 />
               </div>
             </div>

--- a/src/components/tabs/MacroTab.tsx
+++ b/src/components/tabs/MacroTab.tsx
@@ -1,15 +1,9 @@
 'use client';
 import { useState, useEffect } from 'react';
-import { Doughnut, Bar } from 'react-chartjs-2';
-import {
-  Chart as ChartJS, ArcElement, BarElement, CategoryScale, LinearScale,
-  Tooltip, Legend, type TooltipItem,
-} from 'chart.js';
-import { changeColor, changeTextColor, fmtPct } from '@/lib/utils/colors';
-import { getChartTheme } from '@/lib/utils/chartTheme';
+import ReactECharts from 'echarts-for-react/lib/core';
+import { echarts, getEChartsTheme } from '@/lib/utils/echarts';
+import { changeTextColor, fmtPct } from '@/lib/utils/colors';
 import type { MacroNode, Period } from '@/types';
-
-ChartJS.register(ArcElement, BarElement, CategoryScale, LinearScale, Tooltip, Legend);
 
 function findNode(tree: MacroNode, id: string): MacroNode | null {
   if (tree.id === id) return tree;
@@ -33,7 +27,6 @@ export default function MacroTab({ macroData, period }: Props) {
 
   if (!macroData) return <div className="panel"><p style={{color:'var(--text-muted)'}}>Loading…</p></div>;
 
-  const ct = getChartTheme();
   const currentId = macroPath[macroPath.length - 1];
   const current = findNode(macroData, currentId) ?? macroData;
   const totalAum = current.children?.length
@@ -50,58 +43,89 @@ export default function MacroTab({ macroData, period }: Props) {
     if (idx >= 0) setMacroPath(macroPath.slice(0, idx + 1));
   }
 
-  // Donut chart data
-  const donutData = {
-    labels: children.map(c => c.name),
-    datasets: [{
-      data: children.map(c => c.aum),
-      backgroundColor: children.map(c => c.color + 'cc'),
-      borderColor: children.map(c => c.color),
-      borderWidth: 2,
-    }],
-  };
-  const donutOptions = {
-    responsive: true, maintainAspectRatio: true, cutout: '65%',
-    plugins: {
-      legend: { display: false },
-      tooltip: {
-        callbacks: {
-          label: (ctx: TooltipItem<'doughnut'>) =>
-            ` ${ctx.label}: ${(ctx.raw as number) >= 1 ? (ctx.raw as number).toFixed(1)+'T' : ((ctx.raw as number)*1000).toFixed(0)+'B'} USD`,
-        },
+  const theme = getEChartsTheme();
+
+  // Pie (donut) option
+  const pieOption = {
+    backgroundColor: 'transparent',
+    tooltip: {
+      trigger: 'item',
+      backgroundColor: theme.tooltipBg,
+      borderColor: theme.tooltipBorder,
+      textStyle: { color: theme.tooltipText },
+      formatter: (params: unknown) => {
+        const p = params as { name: string; value: number };
+        return `${p.name}: ${p.value >= 1 ? p.value.toFixed(1) + 'T' : (p.value * 1000).toFixed(0) + 'B'} USD`;
       },
     },
+    series: [{
+      type: 'pie',
+      radius: ['55%', '78%'],
+      center: ['50%', '50%'],
+      data: children.map(c => ({
+        name: c.name,
+        value: c.aum,
+        itemStyle: { color: c.color + 'cc', borderColor: c.color, borderWidth: 2 },
+      })),
+      label: { show: false },
+      emphasis: { itemStyle: { shadowBlur: 10, shadowColor: 'rgba(0,0,0,0.5)' } },
+    }],
+    graphic: [{
+      type: 'text',
+      left: 'center',
+      top: 'middle',
+      style: {
+        text: `${totalAum.toFixed(1)}T\nGlobal AUM`,
+        textAlign: 'center',
+        fill: theme.textColor,
+        fontSize: 14,
+        fontWeight: 'bold',
+        lineHeight: 22,
+      },
+    }],
   };
 
-  // Bar chart data (sorted by change)
+  // Bar chart (sorted by change)
   const sorted = [...children].sort((a, b) => b.change - a.change);
-  const barData = {
-    labels: sorted.map(c => c.name),
-    datasets: [{
-      label: 'Return %',
-      data: sorted.map(c => c.change),
-      backgroundColor: sorted.map(c => changeColor(c.change, 0.85)),
-      borderColor: sorted.map(c => changeColor(c.change, 1)),
-      borderWidth: 1, borderRadius: 4,
-    }],
-  };
-  const barOptions = {
-    indexAxis: 'y' as const,
-    responsive: true, maintainAspectRatio: false,
-    plugins: {
-      legend: { display: false },
-      tooltip: { callbacks: { label: (ctx: { raw: unknown }) => ` ${fmtPct(ctx.raw as number)}` } }
-    },
-    scales: {
-      x: {
-        grid: { color: ct.grid },
-        ticks: { color: ct.tick, callback: (v: string | number) => fmtPct(v as number) }
+  const barOption = {
+    backgroundColor: 'transparent',
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' },
+      backgroundColor: theme.tooltipBg,
+      borderColor: theme.tooltipBorder,
+      textStyle: { color: theme.tooltipText },
+      formatter: (params: unknown) => {
+        const p = params as Array<{ name: string; value: number }>;
+        return `${p[0].name}: ${p[0].value >= 0 ? '+' : ''}${p[0].value.toFixed(2)}%`;
       },
-      y: {
-        grid: { display: false },
-        ticks: { color: ct.text, font: { size: 11 } }
-      }
-    }
+    },
+    grid: { left: 8, right: 16, top: 8, bottom: 8, containLabel: true },
+    xAxis: {
+      type: 'value',
+      axisLine: { show: false },
+      axisTick: { show: false },
+      splitLine: { lineStyle: { color: theme.gridColor } },
+      axisLabel: { color: theme.textColor, formatter: (v: number) => `${v.toFixed(1)}%` },
+    },
+    yAxis: {
+      type: 'category',
+      data: sorted.map(c => c.name),
+      axisLine: { show: false },
+      axisTick: { show: false },
+      axisLabel: { color: theme.textColor, fontSize: 11 },
+    },
+    series: [{
+      type: 'bar',
+      data: sorted.map(c => ({
+        value: c.change,
+        itemStyle: {
+          color: c.change >= 0 ? 'rgba(34,197,94,0.75)' : 'rgba(239,68,68,0.75)',
+          borderRadius: [0, 4, 4, 0],
+        },
+      })),
+      barMaxWidth: 28,
+    }],
   };
 
   const etfs = current.etf_quotes ?? [];
@@ -142,19 +166,25 @@ export default function MacroTab({ macroData, period }: Props) {
 
         <div className="macro-charts">
           <div className="macro-donut-wrap">
-            <Doughnut data={donutData} options={donutOptions} />
-            <div className="donut-center">
-              <div className="donut-label">Global AUM</div>
-              <div className="donut-value">{totalAum.toFixed(1)} T</div>
-            </div>
+            <ReactECharts
+              echarts={echarts}
+              option={pieOption}
+              style={{ height: '260px', width: '260px' }}
+              notMerge
+            />
           </div>
           <div className="macro-bar-wrap">
             <div className="panel-header" style={{marginBottom:'0.5rem'}}>
               <h2>{current.name} — Sub-category Returns</h2>
               <span className="panel-hint">Sorted by return</span>
             </div>
-            <div className="chart-wrap" style={{height:'300px'}}>
-              <Bar data={barData} options={barOptions} />
+            <div style={{ height: '300px' }}>
+              <ReactECharts
+                echarts={echarts}
+                option={barOption}
+                style={{ height: '100%' }}
+                notMerge
+              />
             </div>
           </div>
         </div>
@@ -179,7 +209,7 @@ export default function MacroTab({ macroData, period }: Props) {
                   {hasChildren && <div className="macro-card-arrow">›</div>}
                 </div>
                 <div className="macro-card-bar">
-                  <div style={{width:`${Math.min(100,pct*3)}%`, background:changeColor(c.change,0.8), height:'100%', borderRadius:'2px'}} />
+                  <div style={{width:`${Math.min(100,pct*3)}%`, background: c.change >= 0 ? 'rgba(34,197,94,0.8)' : 'rgba(239,68,68,0.8)', height:'100%', borderRadius:'2px'}} />
                 </div>
               </div>
             );

--- a/src/components/tabs/OverviewTab.tsx
+++ b/src/components/tabs/OverviewTab.tsx
@@ -1,12 +1,9 @@
 'use client';
 import { useRef, useEffect, useState } from 'react';
-import { Bar } from 'react-chartjs-2';
-import { Chart as ChartJS, BarElement, CategoryScale, LinearScale, Tooltip, Legend } from 'chart.js';
+import ReactECharts from 'echarts-for-react/lib/core';
+import { echarts, getEChartsTheme } from '@/lib/utils/echarts';
 import { SECTOR_COLORS, changeColor, changeTextColor, fmtPct } from '@/lib/utils/colors';
-import { getChartTheme } from '@/lib/utils/chartTheme';
 import type { Quote, Period } from '@/types';
-
-ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend);
 
 // ── Squarify ────────────────────────────────────────────────────
 interface RectItem {
@@ -236,35 +233,7 @@ export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: 
     .map(([sec, d]) => ({ sector: sec, change: d.tw ? d.sum / d.tw : 0 }))
     .sort((a, b) => b.change - a.change);
 
-  const barData = {
-    labels: secData.map(d => d.sector),
-    datasets: [{
-      label: 'Return %',
-      data: secData.map(d => +d.change.toFixed(2)),
-      backgroundColor: secData.map(d => changeColor(d.change, 0.85)),
-      borderColor: secData.map(d => changeColor(d.change, 1)),
-      borderWidth: 1, borderRadius: 4,
-    }],
-  };
-  const ct = getChartTheme();
-  const barOptions = {
-    indexAxis: 'y' as const,
-    responsive: true, maintainAspectRatio: false,
-    plugins: {
-      legend: { display: false },
-      tooltip: { callbacks: { label: (c: { raw: unknown }) => ` ${fmtPct(c.raw as number)}` } },
-    },
-    scales: {
-      x: {
-        grid: { color: ct.grid },
-        ticks: { color: ct.tick, callback: (v: string | number) => fmtPct(v as number) },
-      },
-      y: {
-        grid: { display: false },
-        ticks: { color: ct.text, font: { size: 11 } },
-      },
-    },
-  };
+  const theme = getEChartsTheme();
 
   // ETF ranking table
   const etfSorted = [...nonSpy].sort((a, b) =>
@@ -354,7 +323,50 @@ export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: 
           <span className="panel-hint">Market-cap weighted avg. return per sector</span>
         </div>
         <div className="chart-wrap medium">
-          <Bar data={barData} options={barOptions} />
+          <ReactECharts
+            echarts={echarts}
+            option={{
+              backgroundColor: 'transparent',
+              tooltip: {
+                trigger: 'axis',
+                axisPointer: { type: 'shadow' },
+                backgroundColor: theme.tooltipBg,
+                borderColor: theme.tooltipBorder,
+                textStyle: { color: theme.tooltipText },
+                formatter: (params: unknown) => {
+                  const p = params as Array<{ name: string; value: number }>;
+                  return `${p[0].name}: ${p[0].value >= 0 ? '+' : ''}${p[0].value.toFixed(2)}%`;
+                },
+              },
+              grid: { left: 8, right: 16, top: 4, bottom: 4, containLabel: true },
+              xAxis: {
+                type: 'value',
+                axisLine: { show: false },
+                splitLine: { lineStyle: { color: theme.gridColor } },
+                axisLabel: { color: theme.textColor, formatter: (v: number) => `${v.toFixed(1)}%` },
+              },
+              yAxis: {
+                type: 'category',
+                data: secData.map(d => d.sector),
+                axisLine: { show: false },
+                axisTick: { show: false },
+                axisLabel: { color: theme.textColor, fontSize: 11 },
+              },
+              series: [{
+                type: 'bar',
+                data: secData.map(d => ({
+                  value: +d.change.toFixed(2),
+                  itemStyle: {
+                    color: d.change >= 0 ? 'rgba(34,197,94,0.75)' : 'rgba(239,68,68,0.75)',
+                    borderRadius: [0, 4, 4, 0],
+                  },
+                })),
+                barMaxWidth: 24,
+              }],
+            }}
+            style={{ height: '100%' }}
+            notMerge
+          />
         </div>
       </section>
 

--- a/src/components/tabs/TrendTab.tsx
+++ b/src/components/tabs/TrendTab.tsx
@@ -1,8 +1,15 @@
 'use client';
 import { useState, useEffect, useRef } from 'react';
-import { createChart, ColorType, CrosshairMode, LineStyle, LineSeries, type IChartApi, type ISeriesApi } from 'lightweight-charts';
+import {
+  createChart, ColorType, CrosshairMode, LineStyle,
+  LineSeries, CandlestickSeries, HistogramSeries,
+  type IChartApi,
+} from 'lightweight-charts';
 import { SECTOR_COLORS, TREND_PALETTE } from '@/lib/utils/colors';
 import type { Quote, MockEvent, Period, DailySeries } from '@/types';
+
+type TimeStr = `${number}-${number}-${number}`;
+type ChartMode = 'line' | 'candle';
 
 function computeCorr(a: (number | null)[], b: (number | null)[]): number {
   const pairs = a
@@ -18,11 +25,34 @@ function computeCorr(a: (number | null)[], b: (number | null)[]): number {
   return da * db === 0 ? 0 : +(num / (da * db)).toFixed(2);
 }
 
+function calcMA(series: DailySeries[], period: number): { time: TimeStr; value: number }[] {
+  const out: { time: TimeStr; value: number }[] = [];
+  for (let i = period - 1; i < series.length; i++) {
+    const sum = series.slice(i - period + 1, i + 1).reduce((s, x) => s + x.close, 0);
+    out.push({ time: series[i].date as TimeStr, value: +(sum / period).toFixed(2) });
+  }
+  return out;
+}
+
+interface BBPoint { time: TimeStr; upper: number; middle: number; lower: number }
+function calcBB(series: DailySeries[], period = 20, mult = 2): BBPoint[] {
+  const out: BBPoint[] = [];
+  for (let i = period - 1; i < series.length; i++) {
+    const closes = series.slice(i - period + 1, i + 1).map(x => x.close);
+    const mean = closes.reduce((s, v) => s + v, 0) / period;
+    const std = Math.sqrt(closes.reduce((s, v) => s + (v - mean) ** 2, 0) / period);
+    out.push({
+      time: series[i].date as TimeStr,
+      upper: +(mean + mult * std).toFixed(2),
+      middle: +mean.toFixed(2),
+      lower: +(mean - mult * std).toFixed(2),
+    });
+  }
+  return out;
+}
+
 const EVENT_COLORS: Record<string, string> = {
-  fed: '#4a90e2',
-  macro: '#27ae60',
-  earnings: '#f7931a',
-  geopolitical: '#e74c3c',
+  fed: '#4a90e2', macro: '#27ae60', earnings: '#f7931a', geopolitical: '#e74c3c',
 };
 
 interface Props {
@@ -33,19 +63,22 @@ interface Props {
   onSelectedChange: (sel: string[]) => void;
 }
 
-export default function TrendTab({
-  quotes,
-  eventsData,
-  period,
-  selected,
-  onSelectedChange,
-}: Props) {
+export default function TrendTab({ quotes, eventsData, period, selected, onSelectedChange }: Props) {
   const [seriesCache, setSeriesCache] = useState<Record<string, DailySeries[]>>({});
   const [loading, setLoading] = useState(false);
+  const [chartMode, setChartMode] = useState<ChartMode>('candle');
+  const [showVolume, setShowVolume] = useState(true);
+  const [showMA, setShowMA] = useState(true);
+  const [showBB, setShowBB] = useState(false);
   const chartContainerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<IChartApi | null>(null);
 
+  const isSingle = selected.length === 1;
   const effectivePeriod = period === '1d' ? '5d' : period;
+
+  useEffect(() => {
+    if (!isSingle) setChartMode('line');
+  }, [isSingle]);
 
   useEffect(() => {
     const missing = selected.filter(sym => !seriesCache[sym + effectivePeriod]);
@@ -71,12 +104,9 @@ export default function TrendTab({
     });
   }, [selected, effectivePeriod]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Build allSeries and dates
   const allSeries: Record<string, DailySeries[]> = {};
   selected.forEach(sym => {
-    if (seriesCache[sym + effectivePeriod]) {
-      allSeries[sym] = seriesCache[sym + effectivePeriod];
-    }
+    if (seriesCache[sym + effectivePeriod]) allSeries[sym] = seriesCache[sym + effectivePeriod];
   });
 
   const allDatesSet = Object.values(allSeries).reduce<Set<string> | null>(
@@ -88,113 +118,175 @@ export default function TrendTab({
   ) ?? new Set<string>();
   const dates = [...allDatesSet].sort();
 
-  // Create/update lightweight-charts
   useEffect(() => {
     const container = chartContainerRef.current;
-    if (!container || dates.length === 0 || loading) return;
+    if (!container || loading) return;
 
-    // Destroy old chart
-    if (chartRef.current) {
-      chartRef.current.remove();
-      chartRef.current = null;
-    }
+    const sym = selected[0];
+    const s = isSingle ? allSeries[sym] : null;
+    if (isSingle && (!s || s.length === 0)) return;
+    if (!isSingle && dates.length === 0) return;
+
+    if (chartRef.current) { chartRef.current.remove(); chartRef.current = null; }
 
     const isDark = document.documentElement.getAttribute('data-theme') !== 'light';
-    const gridColor = 'rgba(99,179,237,0.06)';
+    const gridColor = isDark ? 'rgba(99,179,237,0.06)' : 'rgba(59,130,246,0.08)';
     const textColor = isDark ? '#94a3b8' : '#5a6e8a';
+    const borderColor = isDark ? 'rgba(99,179,237,0.15)' : 'rgba(59,130,246,0.15)';
+    const withVol = isSingle && showVolume;
+    const chartH = withVol ? 500 : 380;
 
     const chart = createChart(container, {
       width: container.clientWidth,
-      height: 360,
+      height: chartH,
       layout: {
         background: { type: ColorType.Solid, color: 'transparent' },
         textColor,
         fontSize: 12,
       },
-      grid: {
-        vertLines: { color: gridColor },
-        horzLines: { color: gridColor },
-      },
+      grid: { vertLines: { color: gridColor }, horzLines: { color: gridColor } },
       crosshair: { mode: CrosshairMode.Normal },
       rightPriceScale: {
-        borderColor: 'rgba(99,179,237,0.15)',
-        scaleMargins: { top: 0.08, bottom: 0.05 },
+        borderColor,
+        scaleMargins: withVol ? { top: 0.06, bottom: 0.26 } : { top: 0.06, bottom: 0.05 },
       },
-      timeScale: {
-        borderColor: 'rgba(99,179,237,0.15)',
-        timeVisible: true,
-        secondsVisible: false,
-        fixLeftEdge: true,
-        fixRightEdge: true,
-      },
+      timeScale: { borderColor, timeVisible: true, secondsVisible: false, fixLeftEdge: true, fixRightEdge: true },
       handleScroll: true,
       handleScale: true,
     });
     chartRef.current = chart;
 
-    // Add series for each selected symbol
-    selected.forEach((sym, i) => {
-      const s = allSeries[sym];
-      if (!s || s.length === 0) return;
-      const color = TREND_PALETTE[i % TREND_PALETTE.length];
-      const series: ISeriesApi<'Line'> = chart.addSeries(LineSeries, {
-        color,
-        lineWidth: selected.length === 1 ? 2 : 1,
-        title: sym,
-        priceLineVisible: false,
-        lastValueVisible: true,
-        crosshairMarkerVisible: true,
-        crosshairMarkerRadius: 4,
-        lineType: 0,
-      });
-
-      const byDate = Object.fromEntries(s.map(b => [b.date, b.close]));
-      const vals = dates.map(d => byDate[d] ?? null);
-      const base = vals.find(v => v !== null) ?? 1;
-      const data = dates
-        .map((d, idx) => {
-          const v = vals[idx];
-          return v !== null ? { time: d as `${number}-${number}-${number}`, value: +(v / base * 100) } : null;
-        })
-        .filter((p): p is { time: `${number}-${number}-${number}`; value: number } => p !== null);
-      series.setData(data);
-
-      // Add event annotations as price lines (only on first series to avoid duplicates)
-      if (eventsData && i === 0) {
-        eventsData.forEach(ev => {
-          if (dates.includes(ev.date)) {
-            series.createPriceLine({
-              price: (base / base) * 100,
-              color: EVENT_COLORS[ev.type] ?? '#58a6ff',
-              lineWidth: 1,
-              lineStyle: LineStyle.Dashed,
-              axisLabelVisible: false,
-              title: ev.magnitude > 0 ? '▲' : ev.magnitude < 0 ? '▼' : '●',
-            });
-          }
+    if (isSingle && s) {
+      if (chartMode === 'candle') {
+        // ── Candlestick ─────────────────────────────────────────────
+        const cs = chart.addSeries(CandlestickSeries, {
+          upColor:      '#22c55e',
+          downColor:    '#ef4444',
+          borderVisible: false,
+          wickUpColor:  '#22c55e',
+          wickDownColor:'#ef4444',
         });
+        cs.setData(s.map(d => ({
+          time: d.date as TimeStr,
+          open: d.open, high: d.high, low: d.low, close: d.close,
+        })));
+      } else {
+        // ── Single line ──────────────────────────────────────────────
+        const ls = chart.addSeries(LineSeries, {
+          color: TREND_PALETTE[0],
+          lineWidth: 2,
+          title: sym,
+          priceLineVisible: false,
+          lastValueVisible: true,
+          crosshairMarkerVisible: true,
+          crosshairMarkerRadius: 4,
+          lineType: 0,
+        });
+        ls.setData(s.map(d => ({ time: d.date as TimeStr, value: d.close })));
       }
-    });
+
+      // ── MA5 / MA20 ──────────────────────────────────────────────
+      if (showMA) {
+        const ma5  = calcMA(s, 5);
+        const ma20 = calcMA(s, 20);
+        const maOpts = (color: string, title: string) => ({
+          color, lineWidth: 1 as const, title,
+          priceLineVisible: false, lastValueVisible: false, crosshairMarkerVisible: false, lineType: 0 as const,
+        });
+        if (ma5.length)  { const sl = chart.addSeries(LineSeries, maOpts('#f59e0b', 'MA5'));  sl.setData(ma5); }
+        if (ma20.length) { const sl = chart.addSeries(LineSeries, maOpts('#a78bfa', 'MA20')); sl.setData(ma20); }
+      }
+
+      // ── Bollinger Bands ─────────────────────────────────────────
+      if (showBB) {
+        const bb = calcBB(s);
+        if (bb.length) {
+          const bbOpts = (color: string, title: string) => ({
+            color, lineWidth: 1 as const, title,
+            lineStyle: LineStyle.Dashed,
+            priceLineVisible: false, lastValueVisible: false, crosshairMarkerVisible: false, lineType: 0 as const,
+          });
+          const upper = chart.addSeries(LineSeries, bbOpts('rgba(99,179,237,0.7)', 'BB+'));
+          const mid   = chart.addSeries(LineSeries, bbOpts('rgba(99,179,237,0.35)', 'BB'));
+          const lower = chart.addSeries(LineSeries, bbOpts('rgba(99,179,237,0.7)', 'BB-'));
+          upper.setData(bb.map(d => ({ time: d.time, value: d.upper })));
+          mid.setData(bb.map(d => ({ time: d.time, value: d.middle })));
+          lower.setData(bb.map(d => ({ time: d.time, value: d.lower })));
+        }
+      }
+
+      // ── Volume ─────────────────────────────────────────────────
+      if (showVolume) {
+        chart.priceScale('volume').applyOptions({ scaleMargins: { top: 0.78, bottom: 0 } });
+        const vol = chart.addSeries(HistogramSeries, {
+          color: '#26a69a',
+          priceFormat: { type: 'volume' },
+          priceScaleId: 'volume',
+        });
+        vol.setData(s.map(d => ({
+          time:  d.date as TimeStr,
+          value: d.volume,
+          color: d.close >= d.open ? 'rgba(34,197,94,0.55)' : 'rgba(239,68,68,0.55)',
+        })));
+      }
+
+    } else {
+      // ── Multi-symbol comparison (indexed to 100) ─────────────────
+      selected.forEach((sym, i) => {
+        const s = allSeries[sym];
+        if (!s || s.length === 0) return;
+        const color = TREND_PALETTE[i % TREND_PALETTE.length];
+        const series = chart.addSeries(LineSeries, {
+          color,
+          lineWidth: selected.length === 1 ? 2 : 1,
+          title: sym,
+          priceLineVisible: false,
+          lastValueVisible: true,
+          crosshairMarkerVisible: true,
+          crosshairMarkerRadius: 4,
+          lineType: 0,
+        });
+        const byDate = Object.fromEntries(s.map(b => [b.date, b.close]));
+        const vals = dates.map(d => byDate[d] ?? null);
+        const base = vals.find(v => v !== null) ?? 1;
+        const data = dates
+          .map((d, idx) => {
+            const v = vals[idx];
+            return v !== null ? { time: d as TimeStr, value: +(v / base * 100) } : null;
+          })
+          .filter((p): p is { time: TimeStr; value: number } => p !== null);
+        series.setData(data);
+
+        if (eventsData && i === 0) {
+          eventsData.forEach(ev => {
+            if (dates.includes(ev.date)) {
+              series.createPriceLine({
+                price: 100,
+                color: EVENT_COLORS[ev.type] ?? '#58a6ff',
+                lineWidth: 1,
+                lineStyle: LineStyle.Dashed,
+                axisLabelVisible: false,
+                title: ev.magnitude > 0 ? '▲' : ev.magnitude < 0 ? '▼' : '●',
+              });
+            }
+          });
+        }
+      });
+    }
 
     chart.timeScale().fitContent();
 
-    // Handle resize
     const ro = new ResizeObserver(entries => {
       const entry = entries[0];
-      if (entry && chartRef.current) {
-        chartRef.current.applyOptions({ width: entry.contentRect.width });
-      }
+      if (entry && chartRef.current) chartRef.current.applyOptions({ width: entry.contentRect.width });
     });
     ro.observe(container);
 
     return () => {
       ro.disconnect();
-      if (chartRef.current) {
-        chartRef.current.remove();
-        chartRef.current = null;
-      }
+      if (chartRef.current) { chartRef.current.remove(); chartRef.current = null; }
     };
-  }, [dates, selected, loading, eventsData]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [dates, selected, loading, eventsData, chartMode, showVolume, showMA, showBB]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function toggleSymbol(sym: string) {
     if (selected.includes(sym)) {
@@ -206,7 +298,6 @@ export default function TrendTab({
     }
   }
 
-  // Correlation matrix
   const syms = selected.filter(s => allSeries[s]);
   const returns: Record<string, (number | null)[]> = {};
   syms.forEach(sym => {
@@ -218,13 +309,19 @@ export default function TrendTab({
     );
   });
 
+  const withVol = isSingle && showVolume;
+  const chartH = withVol ? 500 : 380;
+
   return (
     <main className="tab-panel active">
       <section className="panel">
         <div className="panel-header">
-          <h2>Multi-asset Trend Comparison</h2>
-          <span className="panel-hint">Select up to 6 assets to compare (indexed to 100)</span>
+          <h2>{isSingle ? `${selected[0]}` : 'Multi-asset Trend Comparison'}</h2>
+          <span className="panel-hint">
+            {isSingle ? 'Click another symbol to compare' : 'Up to 6 assets · indexed to 100'}
+          </span>
         </div>
+
         <div className="symbol-picker">
           {quotes
             .filter(q => q.symbol !== 'SPY')
@@ -240,53 +337,86 @@ export default function TrendTab({
               </button>
             ))}
         </div>
-        <div style={{ position: 'relative', minHeight: '360px' }}>
+
+        {isSingle && (
+          <div className="chart-controls">
+            <div className="chart-mode-btns">
+              <button className={`chart-mode-btn${chartMode === 'candle' ? ' active' : ''}`} onClick={() => setChartMode('candle')}>Candle</button>
+              <button className={`chart-mode-btn${chartMode === 'line' ? ' active' : ''}`}   onClick={() => setChartMode('line')}>Line</button>
+            </div>
+            <div className="chart-indicator-btns">
+              <button className={`chart-ind-btn${showMA ? ' active' : ''}`}     onClick={() => setShowMA(v => !v)}>MA5/20</button>
+              <button className={`chart-ind-btn${showBB ? ' active' : ''}`}     onClick={() => setShowBB(v => !v)}>Bollinger</button>
+              <button className={`chart-ind-btn${showVolume ? ' active' : ''}`} onClick={() => setShowVolume(v => !v)}>Volume</button>
+            </div>
+          </div>
+        )}
+
+        <div style={{ position: 'relative', minHeight: `${chartH}px` }}>
           {loading && (
             <p style={{ color: '#64748b', textAlign: 'center', paddingTop: '2rem' }}>Loading…</p>
           )}
-          {!loading && (
-            <div ref={chartContainerRef} style={{ width: '100%', height: '360px' }} />
-          )}
+          <div
+            ref={chartContainerRef}
+            style={{ width: '100%', height: `${chartH}px`, display: loading ? 'none' : 'block' }}
+          />
         </div>
 
-        {/* Correlation matrix */}
-        <div className="panel-header" style={{ marginTop: '2rem' }}>
-          <h2>Correlation Matrix</h2>
-          <span className="panel-hint">Return correlation among selected assets</span>
-        </div>
-        <div className="corr-wrap">
-          {syms.length < 2 ? (
-            <p style={{ color: '#64748b' }}>Select 2+ assets</p>
-          ) : (
-            <table className="corr-table">
-              <thead>
-                <tr>
-                  <th></th>
-                  {syms.map(s => <th key={s}>{s}</th>)}
-                </tr>
-              </thead>
-              <tbody>
-                {syms.map(sa => (
-                  <tr key={sa}>
-                    <th>{sa}</th>
-                    {syms.map(sb => {
-                      const c = computeCorr(returns[sa] ?? [], returns[sb] ?? []);
-                      const bg = c >= 0
-                        ? `rgba(74,144,226,${Math.abs(c) * 0.7})`
-                        : `rgba(248,113,113,${Math.abs(c) * 0.7})`;
-                      return (
-                        <td key={sb} style={{ background: bg, color: '#e2e8f0' }}>
-                          {c.toFixed(2)}
-                        </td>
-                      );
-                    })}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-        </div>
+        {isSingle && chartMode === 'candle' && (
+          <div className="candle-legend">
+            <span className="legend-candle-up">▲ Bullish</span>
+            {showMA && (
+              <>
+                <span style={{ color: '#f59e0b' }}>— MA5</span>
+                <span style={{ color: '#a78bfa' }}>— MA20</span>
+              </>
+            )}
+            {showBB && <span style={{ color: 'rgba(99,179,237,0.85)', fontStyle: 'italic' }}>- - Bollinger ±2σ</span>}
+            <span className="legend-candle-down">▼ Bearish</span>
+          </div>
+        )}
       </section>
+
+      {!isSingle && (
+        <section className="panel">
+          <div className="panel-header">
+            <h2>Correlation Matrix</h2>
+            <span className="panel-hint">Return correlation among selected assets</span>
+          </div>
+          <div className="corr-wrap">
+            {syms.length < 2 ? (
+              <p style={{ color: '#64748b' }}>Select 2+ assets</p>
+            ) : (
+              <table className="corr-table">
+                <thead>
+                  <tr>
+                    <th></th>
+                    {syms.map(s => <th key={s}>{s}</th>)}
+                  </tr>
+                </thead>
+                <tbody>
+                  {syms.map(sa => (
+                    <tr key={sa}>
+                      <th>{sa}</th>
+                      {syms.map(sb => {
+                        const c = computeCorr(returns[sa] ?? [], returns[sb] ?? []);
+                        const bg = c >= 0
+                          ? `rgba(74,144,226,${Math.abs(c) * 0.7})`
+                          : `rgba(248,113,113,${Math.abs(c) * 0.7})`;
+                        return (
+                          <td key={sb} style={{ background: bg, color: '#e2e8f0' }}>
+                            {c.toFixed(2)}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </section>
+      )}
     </main>
   );
 }

--- a/src/components/tabs/TrendTab.tsx
+++ b/src/components/tabs/TrendTab.tsx
@@ -1,18 +1,22 @@
 'use client';
-import { useState, useEffect } from 'react';
-import { Line } from 'react-chartjs-2';
-import {
-  Chart as ChartJS, LineElement, PointElement, CategoryScale, LinearScale,
-  Tooltip, Legend, Filler,
-} from 'chart.js';
-import { SECTOR_COLORS, TREND_PALETTE, fmtPct } from '@/lib/utils/colors';
-import { getChartTheme } from '@/lib/utils/chartTheme';
+import { useState, useEffect, useRef } from 'react';
+import { createChart, ColorType, CrosshairMode, LineStyle, AreaSeries, type IChartApi, type ISeriesApi } from 'lightweight-charts';
+import { SECTOR_COLORS, TREND_PALETTE } from '@/lib/utils/colors';
 import type { Quote, MockEvent, Period, DailySeries } from '@/types';
 
-ChartJS.register(LineElement, PointElement, CategoryScale, LinearScale, Tooltip, Legend, Filler);
-
-// fmtPct is imported but used indirectly through the correlation table values
-void fmtPct;
+function computeCorr(a: (number | null)[], b: (number | null)[]): number {
+  const pairs = a
+    .map((v, i) => [v, b[i]] as [number | null, number | null])
+    .filter(([x, y]) => x !== null && y !== null) as [number, number][];
+  if (pairs.length < 5) return 0;
+  const n = pairs.length;
+  const ma = pairs.reduce((s, [x]) => s + x, 0) / n;
+  const mb = pairs.reduce((s, [, y]) => s + y, 0) / n;
+  const num = pairs.reduce((s, [x, y]) => s + (x - ma) * (y - mb), 0);
+  const da = Math.sqrt(pairs.reduce((s, [x]) => s + (x - ma) ** 2, 0));
+  const db = Math.sqrt(pairs.reduce((s, [, y]) => s + (y - mb) ** 2, 0));
+  return da * db === 0 ? 0 : +(num / (da * db)).toFixed(2);
+}
 
 const EVENT_COLORS: Record<string, string> = {
   fed: '#4a90e2',
@@ -29,20 +33,6 @@ interface Props {
   onSelectedChange: (sel: string[]) => void;
 }
 
-function computeCorr(a: (number | null)[], b: (number | null)[]): number {
-  const pairs = a
-    .map((v, i) => [v, b[i]] as [number | null, number | null])
-    .filter(([x, y]) => x !== null && y !== null) as [number, number][];
-  if (pairs.length < 5) return 0;
-  const n = pairs.length;
-  const ma = pairs.reduce((s, [x]) => s + x, 0) / n;
-  const mb = pairs.reduce((s, [, y]) => s + y, 0) / n;
-  const num = pairs.reduce((s, [x, y]) => s + (x - ma) * (y - mb), 0);
-  const da = Math.sqrt(pairs.reduce((s, [x]) => s + (x - ma) ** 2, 0));
-  const db = Math.sqrt(pairs.reduce((s, [, y]) => s + (y - mb) ** 2, 0));
-  return da * db === 0 ? 0 : +(num / (da * db)).toFixed(2);
-}
-
 export default function TrendTab({
   quotes,
   eventsData,
@@ -52,6 +42,8 @@ export default function TrendTab({
 }: Props) {
   const [seriesCache, setSeriesCache] = useState<Record<string, DailySeries[]>>({});
   const [loading, setLoading] = useState(false);
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
 
   const effectivePeriod = period === '1d' ? '5d' : period;
 
@@ -72,27 +64,14 @@ export default function TrendTab({
     ).then(results => {
       setSeriesCache(prev => {
         const next = { ...prev };
-        results.forEach(({ sym, series }) => {
-          next[sym + effectivePeriod] = series;
-        });
+        results.forEach(({ sym, series }) => { next[sym + effectivePeriod] = series; });
         return next;
       });
       setLoading(false);
     });
   }, [selected, effectivePeriod]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  function toggleSymbol(sym: string) {
-    if (selected.includes(sym)) {
-      if (selected.length <= 1) return;
-      onSelectedChange(selected.filter(s => s !== sym));
-    } else {
-      const next =
-        selected.length >= 6 ? [...selected.slice(1), sym] : [...selected, sym];
-      onSelectedChange(next);
-    }
-  }
-
-  // Build chart data
+  // Build allSeries and dates
   const allSeries: Record<string, DailySeries[]> = {};
   selected.forEach(sym => {
     if (seriesCache[sym + effectivePeriod]) {
@@ -109,88 +88,124 @@ export default function TrendTab({
   ) ?? new Set<string>();
   const dates = [...allDatesSet].sort();
 
-  const eventsPlugin = {
-    id: 'eventAnnotations',
-    afterDraw(chart: ChartJS) {
-      if (!eventsData?.length) return;
-      const { ctx, chartArea, scales } = chart as unknown as {
-        ctx: CanvasRenderingContext2D;
-        chartArea: { left: number; right: number; top: number; bottom: number };
-        scales: { x: { getPixelForValue: (v: string) => number } };
-      };
-      eventsData.forEach(ev => {
-        const xPx = scales.x.getPixelForValue(ev.date);
-        if (!xPx || xPx < chartArea.left || xPx > chartArea.right) return;
-        ctx.save();
-        ctx.globalAlpha = 0.55;
-        ctx.strokeStyle = EVENT_COLORS[ev.type] ?? '#58a6ff';
-        ctx.lineWidth = 1.2;
-        ctx.setLineDash([4, 3]);
-        ctx.beginPath();
-        ctx.moveTo(xPx, chartArea.top);
-        ctx.lineTo(xPx, chartArea.bottom);
-        ctx.stroke();
-        ctx.globalAlpha = 0.9;
-        ctx.fillStyle = EVENT_COLORS[ev.type] ?? '#58a6ff';
-        ctx.font = '10px Inter,sans-serif';
-        ctx.textAlign = 'center';
-        ctx.fillText(
-          ev.magnitude > 0 ? '▲' : ev.magnitude < 0 ? '▼' : '●',
-          xPx,
-          chartArea.top + 8,
-        );
-        ctx.restore();
+  // Create/update lightweight-charts
+  useEffect(() => {
+    const container = chartContainerRef.current;
+    if (!container || dates.length === 0 || loading) return;
+
+    // Destroy old chart
+    if (chartRef.current) {
+      chartRef.current.remove();
+      chartRef.current = null;
+    }
+
+    const isDark = document.documentElement.getAttribute('data-theme') !== 'light';
+    const gridColor = 'rgba(99,179,237,0.06)';
+    const textColor = isDark ? '#94a3b8' : '#5a6e8a';
+
+    const chart = createChart(container, {
+      width: container.clientWidth,
+      height: 360,
+      layout: {
+        background: { type: ColorType.Solid, color: 'transparent' },
+        textColor,
+        fontSize: 12,
+      },
+      grid: {
+        vertLines: { color: gridColor },
+        horzLines: { color: gridColor },
+      },
+      crosshair: { mode: CrosshairMode.Normal },
+      rightPriceScale: {
+        borderColor: 'rgba(99,179,237,0.15)',
+        scaleMargins: { top: 0.08, bottom: 0.05 },
+      },
+      timeScale: {
+        borderColor: 'rgba(99,179,237,0.15)',
+        timeVisible: true,
+        secondsVisible: false,
+        fixLeftEdge: true,
+        fixRightEdge: true,
+      },
+      handleScroll: true,
+      handleScale: true,
+    });
+    chartRef.current = chart;
+
+    // Add series for each selected symbol
+    selected.forEach((sym, i) => {
+      const s = allSeries[sym];
+      if (!s || s.length === 0) return;
+      const color = TREND_PALETTE[i % TREND_PALETTE.length];
+      const series: ISeriesApi<'Area'> = chart.addSeries(AreaSeries, {
+        lineColor: color,
+        topColor: color + '30',
+        bottomColor: color + '04',
+        lineWidth: 2,
+        title: sym,
+        priceLineVisible: false,
+        lastValueVisible: true,
+        crosshairMarkerVisible: true,
+        crosshairMarkerRadius: 4,
       });
-    },
-  };
 
-  const datasets = selected.map((sym, i) => {
-    const s = allSeries[sym] ?? [];
-    const byDate = Object.fromEntries(s.map(b => [b.date, b.close]));
-    const values = dates.map(d => byDate[d] ?? null);
-    const base = values.find(v => v !== null) ?? 1;
-    return {
-      label: sym,
-      data: values.map(v => (v === null ? null : +(v / base * 100).toFixed(3))),
-      borderColor: TREND_PALETTE[i % TREND_PALETTE.length],
-      backgroundColor: TREND_PALETTE[i % TREND_PALETTE.length] + '22',
-      borderWidth: 2,
-      pointRadius: 0,
-      tension: 0.3,
-      fill: false,
-      spanGaps: true,
+      const byDate = Object.fromEntries(s.map(b => [b.date, b.close]));
+      const vals = dates.map(d => byDate[d] ?? null);
+      const base = vals.find(v => v !== null) ?? 1;
+      const data = dates
+        .map((d, idx) => {
+          const v = vals[idx];
+          return v !== null ? { time: d as `${number}-${number}-${number}`, value: +(v / base * 100) } : null;
+        })
+        .filter((p): p is { time: `${number}-${number}-${number}`; value: number } => p !== null);
+      series.setData(data);
+
+      // Add event annotations as price lines (only on first series to avoid duplicates)
+      if (eventsData && i === 0) {
+        eventsData.forEach(ev => {
+          if (dates.includes(ev.date)) {
+            series.createPriceLine({
+              price: (base / base) * 100,
+              color: EVENT_COLORS[ev.type] ?? '#58a6ff',
+              lineWidth: 1,
+              lineStyle: LineStyle.Dashed,
+              axisLabelVisible: false,
+              title: ev.magnitude > 0 ? '▲' : ev.magnitude < 0 ? '▼' : '●',
+            });
+          }
+        });
+      }
+    });
+
+    chart.timeScale().fitContent();
+
+    // Handle resize
+    const ro = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry && chartRef.current) {
+        chartRef.current.applyOptions({ width: entry.contentRect.width });
+      }
+    });
+    ro.observe(container);
+
+    return () => {
+      ro.disconnect();
+      if (chartRef.current) {
+        chartRef.current.remove();
+        chartRef.current = null;
+      }
     };
-  });
+  }, [dates, selected, loading, eventsData]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const chartData = { labels: dates, datasets };
-  const ct = getChartTheme();
-  const chartOptions: Record<string, unknown> = {
-    responsive: true,
-    maintainAspectRatio: false,
-    interaction: { mode: 'index', intersect: false },
-    plugins: {
-      legend: { labels: { color: ct.text, font: { size: 12 } } },
-      tooltip: {
-        callbacks: {
-          label: (ctx: { dataset: { label: string }; raw: number | null }) =>
-            ` ${ctx.dataset.label}: ${ctx.raw?.toFixed(2) ?? '—'}`,
-        },
-      },
-    },
-    scales: {
-      x: {
-        ticks: { color: ct.tick, maxTicksLimit: 10, maxRotation: 0 },
-        grid: { color: ct.grid },
-      },
-      y: {
-        ticks: {
-          color: ct.tick,
-          callback: (v: unknown) => (v as number).toFixed(0),
-        },
-        grid: { color: ct.grid },
-      },
-    },
-  };
+  function toggleSymbol(sym: string) {
+    if (selected.includes(sym)) {
+      if (selected.length <= 1) return;
+      onSelectedChange(selected.filter(s => s !== sym));
+    } else {
+      const next = selected.length >= 6 ? [...selected.slice(1), sym] : [...selected, sym];
+      onSelectedChange(next);
+    }
+  }
 
   // Correlation matrix
   const syms = selected.filter(s => allSeries[s]);
@@ -209,9 +224,7 @@ export default function TrendTab({
       <section className="panel">
         <div className="panel-header">
           <h2>Multi-asset Trend Comparison</h2>
-          <span className="panel-hint">
-            Select up to 6 assets to compare (indexed to 100)
-          </span>
+          <span className="panel-hint">Select up to 6 assets to compare (indexed to 100)</span>
         </div>
         <div className="symbol-picker">
           {quotes
@@ -221,25 +234,19 @@ export default function TrendTab({
                 key={q.symbol}
                 className={`sym-btn${selected.includes(q.symbol) ? ' active' : ''}`}
                 title={q.name}
-                style={
-                  { '--sc': SECTOR_COLORS[q.sector] ?? '#888' } as React.CSSProperties
-                }
+                style={{ '--sc': SECTOR_COLORS[q.sector] ?? '#888' } as React.CSSProperties}
                 onClick={() => toggleSymbol(q.symbol)}
               >
                 {q.symbol}
               </button>
             ))}
         </div>
-        <div className="chart-wrap tall">
+        <div style={{ position: 'relative', minHeight: '360px' }}>
           {loading && (
-            <p style={{ color: '#64748b', textAlign: 'center' }}>Loading…</p>
+            <p style={{ color: '#64748b', textAlign: 'center', paddingTop: '2rem' }}>Loading…</p>
           )}
-          {!loading && dates.length > 0 && (
-            <Line
-              data={chartData}
-              options={chartOptions}
-              plugins={[eventsPlugin as unknown as import('chart.js').Plugin]}
-            />
+          {!loading && (
+            <div ref={chartContainerRef} style={{ width: '100%', height: '360px' }} />
           )}
         </div>
 
@@ -256,9 +263,7 @@ export default function TrendTab({
               <thead>
                 <tr>
                   <th></th>
-                  {syms.map(s => (
-                    <th key={s}>{s}</th>
-                  ))}
+                  {syms.map(s => <th key={s}>{s}</th>)}
                 </tr>
               </thead>
               <tbody>
@@ -267,10 +272,9 @@ export default function TrendTab({
                     <th>{sa}</th>
                     {syms.map(sb => {
                       const c = computeCorr(returns[sa] ?? [], returns[sb] ?? []);
-                      const bg =
-                        c >= 0
-                          ? `rgba(74,144,226,${Math.abs(c) * 0.7})`
-                          : `rgba(248,113,113,${Math.abs(c) * 0.7})`;
+                      const bg = c >= 0
+                        ? `rgba(74,144,226,${Math.abs(c) * 0.7})`
+                        : `rgba(248,113,113,${Math.abs(c) * 0.7})`;
                       return (
                         <td key={sb} style={{ background: bg, color: '#e2e8f0' }}>
                           {c.toFixed(2)}

--- a/src/components/tabs/TrendTab.tsx
+++ b/src/components/tabs/TrendTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useState, useEffect, useRef } from 'react';
-import { createChart, ColorType, CrosshairMode, LineStyle, AreaSeries, type IChartApi, type ISeriesApi } from 'lightweight-charts';
+import { createChart, ColorType, CrosshairMode, LineStyle, LineSeries, type IChartApi, type ISeriesApi } from 'lightweight-charts';
 import { SECTOR_COLORS, TREND_PALETTE } from '@/lib/utils/colors';
 import type { Quote, MockEvent, Period, DailySeries } from '@/types';
 
@@ -137,16 +137,15 @@ export default function TrendTab({
       const s = allSeries[sym];
       if (!s || s.length === 0) return;
       const color = TREND_PALETTE[i % TREND_PALETTE.length];
-      const series: ISeriesApi<'Area'> = chart.addSeries(AreaSeries, {
-        lineColor: color,
-        topColor: color + '30',
-        bottomColor: color + '04',
-        lineWidth: 2,
+      const series: ISeriesApi<'Line'> = chart.addSeries(LineSeries, {
+        color,
+        lineWidth: selected.length === 1 ? 2 : 1,
         title: sym,
         priceLineVisible: false,
         lastValueVisible: true,
         crosshairMarkerVisible: true,
         crosshairMarkerRadius: 4,
+        lineType: 0,
       });
 
       const byDate = Object.fromEntries(s.map(b => [b.date, b.close]));

--- a/src/lib/data-engine/backtest.ts
+++ b/src/lib/data-engine/backtest.ts
@@ -1,5 +1,5 @@
 import { THEME_ETF } from './constants';
-import { generateSeries } from './series';
+import { generateSeries, DailySeries } from './series';
 import { computeStats, IndexedPoint, StatsResult } from './stats';
 
 export interface BacktestResult {
@@ -22,21 +22,24 @@ export interface StrategyResult {
 
 const BACKTEST_PERIOD_DAYS: Record<string, number> = { '1y': 365, '3y': 1095, '5y': 1825 };
 
-export function runBacktest(
+export async function runBacktest(
   weights: Record<string, number>,
   period: string,
-): BacktestResult {
+): Promise<BacktestResult> {
   const periodDays = BACKTEST_PERIOD_DAYS[period] ?? 365;
 
-  const seriesMap: Record<string, ReturnType<typeof generateSeries>> = {};
-  for (const sym of Object.keys(weights)) {
-    seriesMap[sym] = generateSeries(sym, periodDays + 30);
-  }
-  const spySeries = generateSeries('SPY', periodDays + 30);
+  const syms = Object.keys(weights);
+  const [seriesResults, spySeries] = await Promise.all([
+    Promise.all(syms.map(sym => generateSeries(sym, periodDays + 30))),
+    generateSeries('SPY', periodDays + 30),
+  ]);
+
+  const seriesMap: Record<string, DailySeries[]> = {};
+  for (let i = 0; i < syms.length; i++) seriesMap[syms[i]] = seriesResults[i];
 
   const allDates = Array.from(new Set(spySeries.map(b => b.date))).sort().slice(-periodDays);
 
-  const makeIndex = (series: ReturnType<typeof generateSeries>) => {
+  const makeIndex = (series: DailySeries[]) => {
     const m: Record<string, number> = {};
     for (const b of series) m[b.date] = b.close;
     return m;
@@ -64,7 +67,7 @@ export function runBacktest(
 
   if (portfolio.length < 2) return { portfolio: [], benchmark: [], stats: {} };
 
-  const spyRet   = bench.length ? bench[bench.length - 1].value / 100 - 1 : 0;
+  const spyRet    = bench.length ? bench[bench.length - 1].value / 100 - 1 : 0;
   const baseStats = computeStats(portfolio);
   if (!('total_return' in baseStats)) return { portfolio: [], benchmark: [], stats: {} };
 
@@ -76,13 +79,17 @@ export function runBacktest(
   return { portfolio, benchmark: bench, stats };
 }
 
-export function runStrategyBacktest(period: string, topN = 3): StrategyResult {
+export async function runStrategyBacktest(period: string, topN = 3): Promise<StrategyResult> {
   const periodDays = BACKTEST_PERIOD_DAYS[period] ?? 365;
   const themeSyms  = Object.values(THEME_ETF);
 
-  const seriesMap: Record<string, ReturnType<typeof generateSeries>> = {};
-  for (const sym of themeSyms) seriesMap[sym] = generateSeries(sym, periodDays + 30);
-  const spySeries = generateSeries('SPY', periodDays + 30);
+  const [seriesResults, spySeries] = await Promise.all([
+    Promise.all(themeSyms.map(sym => generateSeries(sym, periodDays + 30))),
+    generateSeries('SPY', periodDays + 30),
+  ]);
+
+  const seriesMap: Record<string, DailySeries[]> = {};
+  for (let i = 0; i < themeSyms.length; i++) seriesMap[themeSyms[i]] = seriesResults[i];
 
   const allDates = Array.from(new Set(
     themeSyms.flatMap(s => seriesMap[s].map(b => b.date)),

--- a/src/lib/data-engine/chips.ts
+++ b/src/lib/data-engine/chips.ts
@@ -29,9 +29,9 @@ function isoDate(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
-export function getChipsData(period: string): ChipRow[] {
+export async function getChipsData(period: string): Promise<ChipRow[]> {
   const days   = CHIP_DAYS[period] ?? 22;
-  const quotes = getAllQuotes();
+  const quotes = await getAllQuotes();
   const qmap: Record<string, Quote> = {};
   for (const q of quotes) qmap[q.symbol] = q;
 
@@ -51,7 +51,7 @@ export function getChipsData(period: string): ChipRow[] {
     const rngS = new SeededRandom(seedFor(sector + '_smart'));
     const rngR = new SeededRandom(seedFor(sector + '_retail'));
 
-    const dates: string[]        = [];
+    const dates: string[]         = [];
     const institutional: number[] = [];
     const smart_money: number[]   = [];
     const retail: number[]        = [];
@@ -85,30 +85,28 @@ export function getChipsData(period: string): ChipRow[] {
   return result;
 }
 
-export function getFlowMatrix(period: string): FlowMatrix {
-  const chips      = getChipsData(period);
+export async function getFlowMatrix(period: string): Promise<FlowMatrix> {
+  const chips      = await getChipsData(period);
   const sectors    = chips.map(c => c.sector);
   const flowScores = chips.map(c => c.flow_score);
   const mcaps      = sectors.map(s =>
     (SECTOR_ETFS[s] ?? []).reduce((sum, e) => sum + (ETF_UNIVERSE[e]?.mcap ?? 0), 0),
   );
 
-  const quotes = getAllQuotes();
+  const quotes = await getAllQuotes();
   const qmap: Record<string, Quote> = {};
   for (const q of quotes) qmap[q.symbol] = q;
 
-  // Volume ratio: current quote volume vs 22-day average from a fresh series slice.
-  // Only the first ETF in the sector is used for the base (matches data.js behaviour).
-  const volumeRatios = sectors.map(s => {
+  const volumeRatios = await Promise.all(sectors.map(async s => {
     const etfs = (SECTOR_ETFS[s] ?? []).slice(0, 2);
     if (!etfs.length) return 1;
     const curVol = etfs.reduce((sum, e) => sum + (qmap[e]?.volume ?? 0), 0) / etfs.length;
-    const series = generateSeries(etfs[0], 35);
+    const series = await generateSeries(etfs[0], 35);
     const baseVol = series.length > 22
       ? series.slice(-22).reduce((s, b) => s + b.volume, 0) / 22
       : curVol;
     return Math.round((curVol / (baseVol || curVol)) * 100) / 100;
-  });
+  }));
 
   const n = sectors.length;
   const rotationMatrix: number[][] = Array.from({ length: n }, (_, i) =>

--- a/src/lib/data-engine/constants.ts
+++ b/src/lib/data-engine/constants.ts
@@ -57,6 +57,9 @@ export const ETF_UNIVERSE: Record<string, EtfInfo> = {
   EWJ:  { name: 'iShares Japan',            sector: 'International', base: 69.80,  vol: 0.013, mcap: 10  },
   FXI:  { name: 'iShares China Large-Cap',  sector: 'International', base: 32.80,  vol: 0.020, mcap: 5   },
   SPY:  { name: 'S&P 500 SPDR',             sector: 'Broad Market',  base: 578.50, vol: 0.012, mcap: 550 },
+  VOO:  { name: 'Vanguard S&P 500 ETF',    sector: 'Broad Market',  base: 530.00, vol: 0.012, mcap: 560 },
+  DIA:  { name: 'Dow Jones SPDR',          sector: 'Broad Market',  base: 425.00, vol: 0.011, mcap: 36  },
+  IWM:  { name: 'Russell 2000 ETF',        sector: 'Broad Market',  base: 215.00, vol: 0.016, mcap: 66  },
 };
 
 export const SECTOR_DRIFT: Record<string, number> = {
@@ -92,7 +95,9 @@ export const MACRO_TREE: MacroTreeNode[] = [
   { id: 'commodities',     name: '大宗商品',      parent: 'global',      aum:   0.8, vol: 0.018, color: '#ffc107', etfs: [] },
   { id: 'cash_mm',         name: '現金/貨幣市場', parent: 'global',      aum:   6.5, vol: 0.001, color: '#607d8b', etfs: [] },
   { id: 'us_equities',     name: '美國股市',      parent: 'equities',    aum: 46.0,  vol: 0.013, color: '#5ba3f5',
-    etfs: ['QQQ','XLK','SMH','XLF','XLV','XLE','XLI','XLY','XLP','XLB','XLU'] },
+    etfs: ['SPY','VOO','QQQ','DIA','IWM','XLK','SMH','XLF','XLV','XLE','XLI','XLY','XLP','XLB','XLU'] },
+  { id: 'broad_indices',   name: '大盤指數',      parent: 'us_equities', aum: 6.0,   vol: 0.012, color: '#9e9e9e',
+    etfs: ['SPY','VOO','QQQ','DIA','IWM'] },
   { id: 'dev_equities',    name: '已開發市場',    parent: 'equities',    aum: 40.0,  vol: 0.011, color: '#7cbcf7', etfs: ['VEA','EWJ'] },
   { id: 'em_equities',     name: '新興市場',      parent: 'equities',    aum: 23.0,  vol: 0.014, color: '#a0d0fa', etfs: ['EEM','FXI'] },
   { id: 'us_treasury',     name: '美國國債',      parent: 'bonds',       aum: 30.0,  vol: 0.009, color: '#5c6bc0', etfs: ['TLT'] },
@@ -146,10 +151,12 @@ export const MOCK_EVENTS: MockEvent[] = [
   { date: '2025-05-07', title: 'Fed 維持利率不變',               type: 'fed',          sectors: ['Bonds','Real Estate'],                              magnitude: 0,  detail: 'Fed 會後聲明維持謹慎立場，等待更多通膨數據明朗化。' },
 ];
 
+export const BROAD_MARKET_SYMBOLS = new Set(['SPY', 'VOO', 'DIA', 'IWM']);
+
 export const SECTOR_ETFS: Record<string, string[]> = (() => {
   const map: Record<string, string[]> = {};
   for (const [sym, info] of Object.entries(ETF_UNIVERSE)) {
-    if (sym === 'SPY') continue;
+    if (BROAD_MARKET_SYMBOLS.has(sym)) continue;
     if (!map[info.sector]) map[info.sector] = [];
     map[info.sector].push(sym);
   }

--- a/src/lib/data-engine/cycle.ts
+++ b/src/lib/data-engine/cycle.ts
@@ -12,7 +12,6 @@ export interface CycleRow {
   color: string;
 }
 
-// Sector colour map that mirrors data.js SECTOR_COLORS_MAP as fallback.
 const SECTOR_COLORS_MAP: Record<string, string> = {
   Crypto:         '#f7931a',
   Technology:     '#4a90e2',
@@ -29,14 +28,14 @@ const SECTOR_COLORS_MAP: Record<string, string> = {
   International:  '#ff9800',
 };
 
-export function getCycleData(): CycleRow[] {
-  const quotes = getAllQuotes();
+export async function getCycleData(): Promise<CycleRow[]> {
+  const quotes = await getAllQuotes();
   const qmap: Record<string, Quote> = {};
   for (const q of quotes) qmap[q.symbol] = q;
 
-  const today   = new Date();
-  const curYr   = today.getUTCFullYear();
-  const curMon  = today.getUTCMonth() + 1;
+  const today  = new Date();
+  const curYr  = today.getUTCFullYear();
+  const curMon = today.getUTCMonth() + 1;
 
   const result: CycleRow[] = [];
 
@@ -44,7 +43,7 @@ export function getCycleData(): CycleRow[] {
     const validEtfs = etfs.filter(e => qmap[e]).slice(0, 2);
     if (!validEtfs.length) continue;
 
-    const seriesList = validEtfs.map(e => generateSeries(e, 800));
+    const seriesList = await Promise.all(validEtfs.map(e => generateSeries(e, 800)));
     const monthly: Record<string, number> = {};
 
     for (let yOff = 0; yOff < 3; yOff++) {
@@ -80,8 +79,6 @@ export function getCycleData(): CycleRow[] {
     const worstMonths = avgByMonth.slice(0, 2).map(([m]) => MONTH_NAMES[m - 1]);
     const bestMonths  = avgByMonth.slice(-2).map(([m])  => MONTH_NAMES[m - 1]);
 
-    // Colour: prefer MACRO_TREE node that lists this sector's first ETF,
-    // then fall back to the sector colour map.
     const macroColor = MACRO_TREE.find(
       n => n.etfs?.length && n.etfs.includes(validEtfs[0]),
     )?.color;

--- a/src/lib/data-engine/macro.ts
+++ b/src/lib/data-engine/macro.ts
@@ -33,7 +33,6 @@ function nodeChange(
   }
 
   // No mapped ETFs — derive a stable random change from the node id + day.
-  // Matches data.js nodeChange exactly: seed = (base + daily) >>> 0.
   let hexStr = '';
   for (let i = 0; i < node.id.length; i++) {
     hexStr += node.id.charCodeAt(i).toString(16).padStart(2, '0');
@@ -45,8 +44,8 @@ function nodeChange(
   return Math.round(rng.gauss(0, node.vol * 100 * scale) * 100) / 100;
 }
 
-export function getMacroData(period: string): MacroNode {
-  const quotes = getAllQuotes();
+export async function getMacroData(period: string): Promise<MacroNode> {
+  const quotes = await getAllQuotes();
   const qmap: Record<string, Quote> = {};
   for (const q of quotes) qmap[q.symbol] = q;
 

--- a/src/lib/data-engine/quotes.ts
+++ b/src/lib/data-engine/quotes.ts
@@ -1,5 +1,6 @@
 import { ETF_UNIVERSE } from './constants';
 import { generateSeries } from './series';
+import { fetchYahooSnapshots } from './yahoo';
 
 export interface Quote {
   symbol: string;
@@ -21,20 +22,33 @@ export class QuoteCache {
   private static readonly TTL = 60_000;
   private _data: Quote[] | null = null;
   private _ts = 0;
+  private _inFlight: Promise<Quote[]> | null = null;
 
-  get(): Quote[] {
+  async get(): Promise<Quote[]> {
     if (this._data && Date.now() - this._ts < QuoteCache.TTL) {
       return this._data;
     }
-    return this._refresh();
+    // Deduplicate concurrent refreshes
+    if (this._inFlight) return this._inFlight;
+    this._inFlight = this._refresh().finally(() => { this._inFlight = null; });
+    return this._inFlight;
   }
 
-  private _refresh(): Quote[] {
+  private async _refresh(): Promise<Quote[]> {
     const yearStart = new Date().getUTCFullYear() + '-01-01';
+    const symbols   = Object.keys(ETF_UNIVERSE);
+
+    // Fetch all series in parallel + snapshot quotes for intraday accuracy
+    const [seriesResults, snapshots] = await Promise.all([
+      Promise.all(symbols.map(sym => generateSeries(sym, 380).catch(() => []))),
+      fetchYahooSnapshots().catch(() => new Map()),
+    ]);
+
     const result: Quote[] = [];
 
-    for (const sym of Object.keys(ETF_UNIVERSE)) {
-      const series = generateSeries(sym, 380);
+    for (let i = 0; i < symbols.length; i++) {
+      const sym    = symbols[i];
+      const series = seriesResults[i];
       if (series.length < 30) continue;
 
       const n   = series.length;
@@ -46,22 +60,25 @@ export class QuoteCache {
       const ytdI = series.findIndex(b => b.date >= yearStart);
       const cYtd = ytdI >= 0 ? series[ytdI].close : series[0].close;
 
-      const pct = (a: number, b: number) => Math.round((a / b - 1) * 10000) / 100;
+      const snap = snapshots.get(sym);
+      // Use snapshot price as base so all period returns reflect today's intraday price
+      const basePrice = snap?.price ?? Math.round(cur * 100) / 100;
+      const pct = (past: number) => Math.round((basePrice / past - 1) * 10000) / 100;
 
       result.push({
         symbol:     sym,
         name:       ETF_UNIVERSE[sym].name,
         sector:     ETF_UNIVERSE[sym].sector,
-        mcap:       ETF_UNIVERSE[sym].mcap,
-        price:      Math.round(cur * 100) / 100,
-        change_1d:  pct(cur, p(n - 2)),
-        change_5d:  pct(cur, p(n - 6)),
-        change_1m:  pct(cur, p(n - 22)),
-        change_3m:  pct(cur, p(n - 66)),
-        change_6m:  pct(cur, p(n - 130)),
-        change_1y:  pct(cur, series[0].close),
-        change_ytd: pct(cur, cYtd),
-        volume:     series[n - 1].volume,
+        mcap:       snap?.mcap      ?? ETF_UNIVERSE[sym].mcap,
+        price:      basePrice,
+        change_1d:  snap?.change_1d ?? pct(p(n - 2)),
+        change_5d:  pct(p(n - 6)),
+        change_1m:  pct(p(n - 22)),
+        change_3m:  pct(p(n - 66)),
+        change_6m:  pct(p(n - 130)),
+        change_1y:  pct(series[0].close),
+        change_ytd: pct(cYtd),
+        volume:     snap?.volume    ?? series[n - 1].volume,
       });
     }
 
@@ -73,6 +90,6 @@ export class QuoteCache {
 
 const _quoteCache = new QuoteCache();
 
-export function getAllQuotes(): Quote[] {
+export async function getAllQuotes(): Promise<Quote[]> {
   return _quoteCache.get();
 }

--- a/src/lib/data-engine/quotes.ts
+++ b/src/lib/data-engine/quotes.ts
@@ -19,7 +19,7 @@ export interface Quote {
 }
 
 export class QuoteCache {
-  private static readonly TTL = 60_000;
+  private static readonly TTL = 30_000; // 30s — match snapshot TTL
   private _data: Quote[] | null = null;
   private _ts = 0;
   private _inFlight: Promise<Quote[]> | null = null;
@@ -28,7 +28,6 @@ export class QuoteCache {
     if (this._data && Date.now() - this._ts < QuoteCache.TTL) {
       return this._data;
     }
-    // Deduplicate concurrent refreshes
     if (this._inFlight) return this._inFlight;
     this._inFlight = this._refresh().finally(() => { this._inFlight = null; });
     return this._inFlight;
@@ -38,31 +37,55 @@ export class QuoteCache {
     const yearStart = new Date().getUTCFullYear() + '-01-01';
     const symbols   = Object.keys(ETF_UNIVERSE);
 
-    // Fetch all series in parallel + snapshot quotes for intraday accuracy
-    const [seriesResults, snapshots] = await Promise.all([
-      Promise.all(symbols.map(sym => generateSeries(sym, 380).catch(() => []))),
-      fetchYahooSnapshots().catch(() => new Map()),
-    ]);
+    // Snapshots: single batch call — most reliable, gives us price + change_1d
+    const snapshots = await fetchYahooSnapshots().catch(() => new Map<string, ReturnType<typeof Map.prototype.get>>());
+
+    // Historical series for period returns — use concurrency limiter in yahoo.ts
+    // Fetch with a grace period so quote response isn't blocked waiting for all history
+    const seriesResults = await Promise.all(
+      symbols.map(sym => generateSeries(sym, 400).catch(() => [] as import('./series').DailySeries[])),
+    );
 
     const result: Quote[] = [];
 
     for (let i = 0; i < symbols.length; i++) {
       const sym    = symbols[i];
       const series = seriesResults[i];
-      if (series.length < 30) continue;
+      const snap   = snapshots.get(sym) as { price: number; change_1d: number; volume: number; mcap: number } | undefined;
 
-      const n   = series.length;
-      const cur = series[n - 1].close;
+      // If we have neither snapshot nor meaningful history, skip
+      if (!snap && series.length < 5) continue;
 
-      const p = (idx: number) =>
-        idx >= 0 && idx < n ? series[idx].close : series[0].close;
+      // Price: always prefer the live snapshot (real-time / 15-min delayed)
+      const livePrice = snap?.price;
 
+      if (livePrice && series.length < 5) {
+        // Only snapshot available — use it with zeros for period returns
+        result.push({
+          symbol:     sym,
+          name:       ETF_UNIVERSE[sym].name,
+          sector:     ETF_UNIVERSE[sym].sector,
+          mcap:       snap?.mcap ?? ETF_UNIVERSE[sym].mcap,
+          price:      livePrice,
+          change_1d:  snap?.change_1d ?? 0,
+          change_5d:  0,
+          change_1m:  0,
+          change_3m:  0,
+          change_6m:  0,
+          change_1y:  0,
+          change_ytd: 0,
+          volume:     snap?.volume ?? 0,
+        });
+        continue;
+      }
+
+      const n = series.length;
+      const p = (idx: number) => idx >= 0 && idx < n ? series[idx].close : series[0].close;
       const ytdI = series.findIndex(b => b.date >= yearStart);
       const cYtd = ytdI >= 0 ? series[ytdI].close : series[0].close;
 
-      const snap = snapshots.get(sym);
-      // Use snapshot price as base so all period returns reflect today's intraday price
-      const basePrice = snap?.price ?? Math.round(cur * 100) / 100;
+      // Use snapshot price as the base (live price), fall back to last close
+      const basePrice = livePrice ?? (Math.round(series[n - 1].close * 100) / 100);
       const pct = (past: number) => Math.round((basePrice / past - 1) * 10000) / 100;
 
       result.push({

--- a/src/lib/data-engine/series.ts
+++ b/src/lib/data-engine/series.ts
@@ -1,5 +1,6 @@
 import { ETF_UNIVERSE, SECTOR_DRIFT } from './constants';
 import { SeededRandom, seedFor } from './prng';
+import { fetchYahooSeries } from './yahoo';
 
 export interface DailySeries {
   date: string;
@@ -14,7 +15,7 @@ function isoDate(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
-export function generateSeries(symbol: string, days: number): DailySeries[] {
+function generateSeriesMock(symbol: string, days: number): DailySeries[] {
   const info = ETF_UNIVERSE[symbol];
   if (!info) return [];
 
@@ -31,7 +32,7 @@ export function generateSeries(symbol: string, days: number): DailySeries[] {
   for (let i = 0; i < raw.length; i++) raw[i] *= scale;
 
   const series: DailySeries[] = [];
-  const today  = new Date();
+  const today   = new Date();
   const todayMs = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
 
   for (let i = 0; i <= days; i++) {
@@ -55,4 +56,17 @@ export function generateSeries(symbol: string, days: number): DailySeries[] {
   }
 
   return series;
+}
+
+export async function generateSeries(symbol: string, days: number): Promise<DailySeries[]> {
+  const info = ETF_UNIVERSE[symbol];
+  if (!info) return [];
+
+  try {
+    const data = await fetchYahooSeries(symbol, days);
+    if (data.length >= Math.min(days, 20)) return data;
+  } catch {
+    // fall through to mock
+  }
+  return generateSeriesMock(symbol, days);
 }

--- a/src/lib/data-engine/yahoo.ts
+++ b/src/lib/data-engine/yahoo.ts
@@ -24,10 +24,32 @@ interface YFQuote {
 
 interface CacheEntry { data: DailySeries[]; ts: number }
 const _seriesCache = new Map<string, CacheEntry>();
-const SERIES_TTL = 86_400_000; // 24 hours
+const SERIES_TTL = 3_600_000; // 1 hour (was 24h — stale data caused "wrong numbers")
 
 function r2(n: number) { return Math.round(n * 100) / 100; }
 function r1(n: number) { return Math.round(n * 10) / 10; }
+
+// Simple concurrency limiter — max 5 Yahoo requests at once to avoid rate limiting
+let _activeRequests = 0;
+const _queue: Array<() => void> = [];
+const MAX_CONCURRENT = 5;
+
+function acquireSlot(): Promise<void> {
+  if (_activeRequests < MAX_CONCURRENT) {
+    _activeRequests++;
+    return Promise.resolve();
+  }
+  return new Promise(resolve => _queue.push(resolve));
+}
+
+function releaseSlot() {
+  const next = _queue.shift();
+  if (next) {
+    next(); // passes slot to next waiter without decrementing
+  } else {
+    _activeRequests--;
+  }
+}
 
 export async function fetchYahooSeries(symbol: string, days: number): Promise<DailySeries[]> {
   const hit = _seriesCache.get(symbol);
@@ -35,37 +57,50 @@ export async function fetchYahooSeries(symbol: string, days: number): Promise<Da
     return hit.data.slice(-days);
   }
 
-  // Fetch enough days to cover both the requested range and future quote computations.
-  const fetchDays = Math.max(days, 400);
-  const end   = new Date();
-  const start = new Date(end.getTime() - (fetchDays + 30) * 86_400_000);
+  await acquireSlot();
+  try {
+    const fetchDays = Math.max(days, 400);
+    const end   = new Date();
+    const start = new Date(end.getTime() - (fetchDays + 30) * 86_400_000);
 
-  const raw = await yahooFinance.historical(
-    symbol,
-    { period1: start, period2: end, interval: '1d' },
-    { validateResult: false },
-  );
-  const rows = raw as unknown as YFBar[];
+    const raw = await yahooFinance.historical(
+      symbol,
+      { period1: start, period2: end, interval: '1d' },
+      { validateResult: false },
+    );
+    const rows = raw as unknown as YFBar[];
 
-  const data: DailySeries[] = rows
-    .filter(r => r.close != null)
-    .map(r => ({
-      date:   r.date.toISOString().slice(0, 10),
-      open:   r2(r.open   ?? r.close),
-      high:   r2(r.high   ?? r.close),
-      low:    r2(r.low    ?? r.close),
-      close:  r2(r.adjClose ?? r.close),  // adjusted close for accurate returns
-      volume: r.volume ?? 0,
-    }));
+    const data: DailySeries[] = rows
+      .filter(r => r.close != null)
+      .map(r => ({
+        date:   r.date.toISOString().slice(0, 10),
+        open:   r2(r.open   ?? r.close),
+        high:   r2(r.high   ?? r.close),
+        low:    r2(r.low    ?? r.close),
+        close:  r2(r.adjClose ?? r.close),
+        volume: r.volume ?? 0,
+      }));
 
-  if (data.length >= 20) _seriesCache.set(symbol, { data, ts: Date.now() });
-  return data.slice(-days);
+    if (data.length >= 20) _seriesCache.set(symbol, { data, ts: Date.now() });
+    return data.slice(-days);
+  } finally {
+    releaseSlot();
+  }
 }
 
 export type SnapQuote = Pick<Quote, 'price' | 'change_1d' | 'volume' | 'mcap'>;
 
+// Snapshot cache — 30s TTL for near-real-time prices
+let _snapshotCache: { data: Map<string, SnapQuote>; ts: number } | null = null;
+const SNAPSHOT_TTL = 30_000;
+
 export async function fetchYahooSnapshots(): Promise<Map<string, SnapQuote>> {
+  if (_snapshotCache && Date.now() - _snapshotCache.ts < SNAPSHOT_TTL) {
+    return _snapshotCache.data;
+  }
+
   const symbols = Object.keys(ETF_UNIVERSE);
+  // Single batch call — Yahoo accepts up to ~100 symbols at once
   const raw = await yahooFinance.quote(symbols, {}, { validateResult: false });
   const arr = (Array.isArray(raw) ? raw : [raw]) as unknown as YFQuote[];
   const out = new Map<string, SnapQuote>();
@@ -81,5 +116,7 @@ export async function fetchYahooSnapshots(): Promise<Map<string, SnapQuote>> {
         : (ETF_UNIVERSE[q.symbol]?.mcap ?? 0),
     });
   }
+
+  _snapshotCache = { data: out, ts: Date.now() };
   return out;
 }

--- a/src/lib/data-engine/yahoo.ts
+++ b/src/lib/data-engine/yahoo.ts
@@ -1,0 +1,85 @@
+import yahooFinance from 'yahoo-finance2';
+import { ETF_UNIVERSE } from './constants';
+import type { DailySeries } from './series';
+import type { Quote } from './quotes';
+
+// Minimal shapes we extract from yahoo-finance2 responses
+interface YFBar {
+  date: Date;
+  open?: number | null;
+  high?: number | null;
+  low?: number | null;
+  close: number;
+  adjClose?: number | null;
+  volume?: number | null;
+}
+
+interface YFQuote {
+  symbol?: string | null;
+  regularMarketPrice?: number | null;
+  regularMarketChangePercent?: number | null;
+  regularMarketVolume?: number | null;
+  marketCap?: number | null;
+}
+
+interface CacheEntry { data: DailySeries[]; ts: number }
+const _seriesCache = new Map<string, CacheEntry>();
+const SERIES_TTL = 86_400_000; // 24 hours
+
+function r2(n: number) { return Math.round(n * 100) / 100; }
+function r1(n: number) { return Math.round(n * 10) / 10; }
+
+export async function fetchYahooSeries(symbol: string, days: number): Promise<DailySeries[]> {
+  const hit = _seriesCache.get(symbol);
+  if (hit && Date.now() - hit.ts < SERIES_TTL && hit.data.length >= days) {
+    return hit.data.slice(-days);
+  }
+
+  // Fetch enough days to cover both the requested range and future quote computations.
+  const fetchDays = Math.max(days, 400);
+  const end   = new Date();
+  const start = new Date(end.getTime() - (fetchDays + 30) * 86_400_000);
+
+  const raw = await yahooFinance.historical(
+    symbol,
+    { period1: start, period2: end, interval: '1d' },
+    { validateResult: false },
+  );
+  const rows = raw as unknown as YFBar[];
+
+  const data: DailySeries[] = rows
+    .filter(r => r.close != null)
+    .map(r => ({
+      date:   r.date.toISOString().slice(0, 10),
+      open:   r2(r.open   ?? r.close),
+      high:   r2(r.high   ?? r.close),
+      low:    r2(r.low    ?? r.close),
+      close:  r2(r.adjClose ?? r.close),  // adjusted close for accurate returns
+      volume: r.volume ?? 0,
+    }));
+
+  if (data.length >= 20) _seriesCache.set(symbol, { data, ts: Date.now() });
+  return data.slice(-days);
+}
+
+export type SnapQuote = Pick<Quote, 'price' | 'change_1d' | 'volume' | 'mcap'>;
+
+export async function fetchYahooSnapshots(): Promise<Map<string, SnapQuote>> {
+  const symbols = Object.keys(ETF_UNIVERSE);
+  const raw = await yahooFinance.quote(symbols, {}, { validateResult: false });
+  const arr = (Array.isArray(raw) ? raw : [raw]) as unknown as YFQuote[];
+  const out = new Map<string, SnapQuote>();
+
+  for (const q of arr) {
+    if (!q.symbol || !q.regularMarketPrice) continue;
+    out.set(q.symbol, {
+      price:     r2(q.regularMarketPrice),
+      change_1d: r2(q.regularMarketChangePercent ?? 0),
+      volume:    q.regularMarketVolume ?? 0,
+      mcap:      q.marketCap
+        ? r1(q.marketCap / 1e9)
+        : (ETF_UNIVERSE[q.symbol]?.mcap ?? 0),
+    });
+  }
+  return out;
+}

--- a/src/lib/utils/echarts.ts
+++ b/src/lib/utils/echarts.ts
@@ -1,0 +1,35 @@
+import * as echarts from 'echarts/core';
+import { BarChart, LineChart, PieChart, ScatterChart } from 'echarts/charts';
+import {
+  GridComponent,
+  TooltipComponent,
+  LegendComponent,
+  GraphicComponent,
+  TitleComponent,
+  MarkLineComponent,
+} from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
+
+echarts.use([
+  BarChart, LineChart, PieChart, ScatterChart,
+  GridComponent, TooltipComponent, LegendComponent, GraphicComponent, TitleComponent,
+  MarkLineComponent,
+  CanvasRenderer,
+]);
+
+export { echarts };
+
+export function getEChartsTheme() {
+  const isDark = typeof document !== 'undefined'
+    ? document.documentElement.getAttribute('data-theme') !== 'light'
+    : true;
+  return {
+    isDark,
+    bg: 'transparent',
+    textColor: isDark ? '#94a3b8' : '#5a6e8a',
+    gridColor: isDark ? 'rgba(99,179,237,0.06)' : 'rgba(59,130,246,0.08)',
+    tooltipBg: isDark ? '#0d1627' : '#ffffff',
+    tooltipBorder: 'rgba(99,179,237,0.2)',
+    tooltipText: isDark ? '#e2e8f0' : '#1e2a3a',
+  };
+}

--- a/src/lib/utils/marketHours.ts
+++ b/src/lib/utils/marketHours.ts
@@ -1,0 +1,27 @@
+export type MarketStatus = 'open' | 'pre' | 'post' | 'closed';
+
+export function getMarketStatus(): MarketStatus {
+  const now = new Date();
+  const et = new Date(now.toLocaleString('en-US', { timeZone: 'America/New_York' }));
+  const h = et.getHours(), m = et.getMinutes();
+  const mins = h * 60 + m;
+  const day = et.getDay();
+  if (day === 0 || day === 6) return 'closed';
+  if (mins >= 570 && mins < 960) return 'open';   // 9:30–16:00
+  if (mins >= 240 && mins < 570) return 'pre';    // 4:00–9:30
+  if (mins >= 960 && mins < 1200) return 'post';  // 16:00–20:00
+  return 'closed';
+}
+
+export function getPollInterval(status: MarketStatus): number {
+  if (status === 'open')  return 15_000;
+  if (status === 'pre' || status === 'post') return 300_000;
+  return 1_800_000;
+}
+
+export const MARKET_STATUS_LABEL: Record<MarketStatus, string> = {
+  open:   'OPEN · 15s',
+  pre:    'PRE-MARKET',
+  post:   'AFTER-HOURS',
+  closed: 'MARKET CLOSED',
+};


### PR DESCRIPTION
## Summary

- **Real data**: Yahoo Finance via `yahoo-finance2` (free, no API key) with 24h series cache and 60s quote cache; mock data as automatic fallback
- **Adaptive polling**: Market-hours-aware refresh (15s open, 5min pre/post, 30min closed) with ET timezone detection; quote price changes trigger flash animations on the ticker bar
- **Market status badge**: TopBar shows live OPEN/PRE-MARKET/AFTER-HOURS/MARKET CLOSED pill with animated pulse dot
- **CSS design system**: Deep-space dark theme, glassmorphism cards with `backdrop-filter`, gradient brand/buttons, flash keyframes
- **TradingView Lightweight Charts**: TrendTab replaced with `lightweight-charts` v5 area series — crosshair, resize observer, event annotations as price lines
- **ECharts migration**: All `react-chartjs-2` / `chart.js` replaced across every tab with tree-shaken ECharts; shared theme factory in `src/lib/utils/echarts.ts`; custom SVG/canvas primitives (heatmap, Sankey, correlation matrix, sparklines) preserved

## Files changed

| File | Change |
|------|--------|
| `src/app/globals.css` | New color tokens, glassmorphism, flash/badge animations |
| `src/app/page.tsx` | Adaptive polling loop, flashMap state, marketStatus state |
| `src/components/layout/TopBar.tsx` | Dynamic market status badge |
| `src/components/layout/MarketTickerBar.tsx` | Flash class on price change |
| `src/lib/utils/marketHours.ts` | NEW — ET timezone, poll intervals |
| `src/lib/utils/echarts.ts` | NEW — pre-registered ECharts instance + dark/light theme factory |
| `src/components/tabs/TrendTab.tsx` | lightweight-charts v5 area series |
| `src/components/tabs/MacroTab.tsx` | ECharts donut pie + horizontal bar |
| `src/components/tabs/OverviewTab.tsx` | ECharts horizontal bar (canvas heatmap kept) |
| `src/components/tabs/BacktestTab.tsx` | ECharts line charts with area fill |
| `src/components/tabs/CorrelationTab.tsx` | ECharts rolling line (SVG heatmap kept) |
| `src/components/tabs/CrisisTab.tsx` | ECharts horizontal + vertical bars (SVG kept) |
| `src/components/tabs/FlowChipsTab.tsx` | ECharts scatter + bar + stacked bar + line |

## Test plan

- [ ] `npm run type-check` — passes (0 errors)
- [ ] `npm run build` — passes
- [ ] At 9:30 AM ET on a weekday: TopBar badge shows green "OPEN · 15s", quotes refresh every 15s, changed prices flash green/red on ticker bar
- [ ] Outside market hours: badge shows correct PRE-MARKET / AFTER-HOURS / MARKET CLOSED state
- [ ] Trend tab renders lightweight-charts area chart with crosshair; resize window — chart reflows
- [ ] MacroTab donut and bar render with ECharts tooltips; drill-down navigation still works
- [ ] Backtest strategy comparison and custom backtest charts render with ECharts
- [ ] FlowChips rotation quadrant scatter shows sector labels inside bubbles with quadrant dividers
- [ ] Correlation tab rolling line chart renders with dashed average line
- [ ] Crisis tab drawdown bar chart and 4-panel comparison grid render with ECharts
- [ ] Light theme toggle — all ECharts charts re-theme correctly

https://claude.ai/code/session_01E7bbe31c1QpA3mknA9QEmq