### PR TITLE
Frontend UX overhaul: command palette, directional tabs, skeleton states

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "echarts": "^6.0.0",
         "echarts-for-react": "^3.0.6",
         "lightweight-charts": "^5.2.0",
+        "lucide-react": "^1.16.0",
         "next": "15.5.18",
         "react": "^19.0.0",
         "react-chartjs-2": "^5.2.0",
@@ -4381,6 +4382,15 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
+      "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "echarts": "^6.0.0",
     "echarts-for-react": "^3.0.6",
     "lightweight-charts": "^5.2.0",
+    "lucide-react": "^1.16.0",
     "next": "15.5.18",
     "react": "^19.0.0",
     "react-chartjs-2": "^5.2.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,29 +6,32 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  --bg:           #060c18;
-  --surface:      #0e1c31;
-  --surface2:     #152540;
-  --surface-glass:rgba(14,28,49,0.75);
-  --border:       rgba(99,179,237,0.14);
-  --border-hover: rgba(99,179,237,0.36);
-  --glow:         rgba(59,130,246,0.18);
-  --text:         #e2e8f0;
-  --text-muted:   #94a3b8;
-  --accent:       #3b82f6;
-  --accent2:      #2563eb;
-  --accent-end:   #8b5cf6;
-  --pos:          #22c55e;
-  --neg:          #ef4444;
-  --radius:       14px;
-  --radius-sm:    8px;
-  --shadow:       0 8px 32px rgba(0,0,0,0.65), 0 1px 0 rgba(99,179,237,0.07) inset;
-  --shadow-card:  0 4px 20px rgba(0,0,0,0.45), 0 1px 0 rgba(99,179,237,0.07) inset;
-  --chart-grid:   rgba(99,179,237,0.06);
+  --bg:           #050a16;
+  --surface:      #0d1729;
+  --surface2:     #142036;
+  --surface-glass:rgba(13,23,41,0.75);
+  --border:       rgba(255,255,255,0.06);
+  --border-hover: rgba(255,255,255,0.18);
+  --glow:         rgba(79,140,255,0.16);
+  --text:         #eef2f9;
+  --text-muted:   #8895ab;
+  --text-faint:   #5b6878;
+  --accent:       #4f8cff;
+  --accent2:      #2f6fe6;
+  --accent-end:   #a78bfa;
+  --gold:         #f4c25e;
+  --pos:          #34d399;
+  --neg:          #f87171;
+  --radius:       16px;
+  --radius-sm:    10px;
+  --shadow:       0 16px 48px rgba(0,0,0,0.65), 0 1px 0 rgba(255,255,255,0.04) inset;
+  --shadow-card:  0 8px 28px rgba(0,0,0,0.45), 0 1px 0 rgba(255,255,255,0.04) inset;
+  --chart-grid:   rgba(255,255,255,0.04);
   --chart-tick:   #4d6080;
-  --flash-pos:    rgba(34,197,94,0.22);
-  --flash-neg:    rgba(239,68,68,0.22);
-  --topbar-start: #07111f;
+  --flash-pos:    rgba(52,211,153,0.20);
+  --flash-neg:    rgba(248,113,113,0.20);
+  --topbar-start: #060b18;
+  --font-display: 'Instrument Serif', 'New York', Georgia, 'Times New Roman', serif;
   /* Motion tokens (Dieter Rams / Jony Ive principles) */
   --ease-out:    cubic-bezier(0, 0, 0.2, 1);
   --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -39,27 +42,29 @@
 }
 
 [data-theme="light"] {
-  --bg:           #eef3fc;
+  --bg:           #f5f7fc;
   --surface:      #ffffff;
-  --surface2:     #f4f7ff;
+  --surface2:     #f1f4fa;
   --surface-glass:rgba(255,255,255,0.90);
-  --border:       rgba(59,130,246,0.15);
-  --border-hover: rgba(59,130,246,0.40);
-  --glow:         rgba(59,130,246,0.06);
-  --text:         #111827;
-  --text-muted:   #6b7f9a;
-  --accent:       #2563eb;
+  --border:       rgba(15,23,42,0.07);
+  --border-hover: rgba(15,23,42,0.18);
+  --glow:         rgba(47,111,230,0.10);
+  --text:         #0f172a;
+  --text-muted:   #475569;
+  --text-faint:   #94a3b8;
+  --accent:       #2f6fe6;
   --accent2:      #1d4ed8;
   --accent-end:   #7c3aed;
-  --pos:          #16a34a;
+  --gold:         #c69134;
+  --pos:          #059669;
   --neg:          #dc2626;
-  --shadow:       none;
-  --shadow-card:  none;
-  --chart-grid:   rgba(59,130,246,0.07);
+  --shadow:       0 1px 3px rgba(15,23,42,0.06), 0 8px 24px rgba(15,23,42,0.05);
+  --shadow-card:  0 1px 2px rgba(15,23,42,0.04), 0 4px 16px rgba(15,23,42,0.04);
+  --chart-grid:   rgba(15,23,42,0.06);
   --chart-tick:   #7a8fa8;
-  --flash-pos:    rgba(22,163,74,0.18);
-  --flash-neg:    rgba(220,38,38,0.15);
-  --topbar-start: #dce8fb;
+  --flash-pos:    rgba(5,150,105,0.16);
+  --flash-neg:    rgba(220,38,38,0.14);
+  --topbar-start: #ffffff;
 }
 
 [data-theme="light"] .topbar {
@@ -73,14 +78,18 @@ html { scroll-behavior: smooth; }
 body {
   font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   background:
-    radial-gradient(ellipse 75% 45% at 8% 0%,   rgba(59,130,246,0.11) 0%, transparent 55%),
-    radial-gradient(ellipse 55% 40% at 92% 100%, rgba(139,92,246,0.09) 0%, transparent 55%),
+    radial-gradient(ellipse 80% 55% at 12% 0%,   rgba(79,140,255,0.10) 0%, transparent 60%),
+    radial-gradient(ellipse 60% 45% at 88% 100%, rgba(167,139,250,0.08) 0%, transparent 60%),
+    radial-gradient(ellipse 45% 30% at 50% 50%,  rgba(244,194,94,0.025) 0%, transparent 65%),
     var(--bg);
   background-attachment: fixed;
   color: var(--text);
   font-size: 14px;
-  line-height: 1.5;
+  line-height: 1.55;
   min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 [data-theme="light"] body {
   background:
@@ -93,41 +102,52 @@ body {
 .topbar {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 0.65rem 1.25rem;
-  padding-top: max(0.65rem, env(safe-area-inset-top));
-  background: linear-gradient(180deg, var(--topbar-start) 0%, var(--bg) 100%);
+  gap: 1.25rem;
+  padding: 0.9rem 1.5rem;
+  padding-top: max(0.9rem, env(safe-area-inset-top));
+  background: rgba(5,10,22,0.7);
   border-bottom: 1px solid var(--border);
   position: sticky;
   top: 0;
   z-index: 100;
   flex-wrap: wrap;
-  -webkit-backdrop-filter: blur(12px);
-  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  backdrop-filter: blur(20px) saturate(180%);
 }
+[data-theme="light"] .topbar { background: rgba(255,255,255,0.7); }
 
 .topbar-brand {
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  align-items: baseline;
+  gap: 0.7rem;
   margin-right: auto;
 }
-.brand-icon { font-size: 1.25rem; line-height: 1; }
+.brand-icon {
+  font-size: 1.1rem;
+  line-height: 1;
+  color: var(--gold);
+  align-self: center;
+  filter: drop-shadow(0 0 8px rgba(244,194,94,0.4));
+}
 .brand-name {
-  font-weight: 800;
-  font-size: 1.05rem;
-  letter-spacing: -0.01em;
-  background: linear-gradient(90deg, var(--accent), var(--accent-end));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 1.85rem;
+  line-height: 1;
+  letter-spacing: -0.025em;
+  color: var(--text);
   white-space: nowrap;
 }
 .brand-sub {
-  font-size: 0.68rem;
-  color: var(--text-muted);
+  font-size: 0.62rem;
+  color: var(--text-faint);
   white-space: nowrap;
-  font-weight: 400;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  padding-left: 0.65rem;
+  border-left: 1px solid var(--border);
 }
 
 .topbar-period {
@@ -159,9 +179,13 @@ body {
 .period-btn:active { transform: scale(0.97); transition-duration: 80ms; }
 [data-theme="light"] .period-btn:hover { background: var(--border); color: var(--text); transform: translateY(-1px); }
 .period-btn.active {
-  background: linear-gradient(135deg, var(--accent), var(--accent-end));
+  background: var(--text);
+  color: var(--bg);
+  box-shadow: 0 2px 12px rgba(255,255,255,0.18);
+}
+[data-theme="light"] .period-btn.active {
+  background: var(--text);
   color: #fff;
-  box-shadow: 0 1px 8px rgba(59,130,246,0.40);
 }
 
 .topbar-meta {
@@ -187,25 +211,26 @@ body {
 .tab-btn {
   background: transparent;
   border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--text-muted);
-  font-size: 0.82rem;
+  border-bottom: 1px solid transparent;
+  color: var(--text-faint);
+  font-size: 0.78rem;
   font-weight: 500;
-  padding: 0.7rem 1rem;
+  padding: 0.85rem 1.1rem;
   cursor: pointer;
   transition: color 150ms cubic-bezier(0,0,0.2,1), border-color 150ms cubic-bezier(0,0,0.2,1), background 150ms cubic-bezier(0,0,0.2,1), transform 80ms cubic-bezier(0,0,0.2,1);
   white-space: nowrap;
   font-family: inherit;
   display: flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: 0.35rem;
   border-radius: 0;
+  letter-spacing: 0.02em;
 }
-.tab-btn:hover { color: var(--text); background: rgba(99,179,237,0.04); }
+.tab-btn:hover { color: var(--text); background: rgba(255,255,255,0.025); }
 .tab-btn:active { transform: scale(0.97); }
 .tab-btn.active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
+  color: var(--text);
+  border-bottom-color: var(--gold);
   font-weight: 600;
 }
 [data-theme="light"] .tab-btn:hover { background: rgba(59,130,246,0.05); }
@@ -286,10 +311,12 @@ body {
 .stat-card {
   position: relative;
   overflow: hidden;
-  background: var(--surface);
+  background:
+    radial-gradient(ellipse 120% 80% at 0% 0%, rgba(79,140,255,0.04) 0%, transparent 60%),
+    var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 1.1rem 1.2rem;
+  padding: 1.5rem 1.5rem 1.35rem;
   box-shadow: var(--shadow-card);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -298,55 +325,60 @@ body {
 .stat-card::before {
   content: '';
   position: absolute;
-  top: 0; left: 0; right: 0;
-  height: 3px;
-  background: linear-gradient(90deg, var(--accent), var(--accent-end), transparent 80%);
-  border-radius: var(--radius) var(--radius) 0 0;
+  top: 0; left: 1.5rem; right: 1.5rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(79,140,255,0.5), transparent);
 }
 .stat-card:hover {
   border-color: var(--border-hover);
-  box-shadow: 0 0 0 3px var(--glow), 0 16px 48px rgba(0,0,0,0.65), 0 1px 0 rgba(99,179,237,0.07) inset;
+  box-shadow: 0 0 0 1px var(--glow), 0 24px 60px rgba(0,0,0,0.7), 0 1px 0 rgba(255,255,255,0.06) inset;
   transform: translateY(-4px);
 }
 
 .stat-label {
-  font-size: 0.68rem;
-  color: var(--text-muted);
+  font-size: 0.62rem;
+  color: var(--text-faint);
   text-transform: uppercase;
-  letter-spacing: 0.07em;
-  font-weight: 600;
-  margin-bottom: 0.45rem;
+  letter-spacing: 0.18em;
+  font-weight: 500;
+  margin-bottom: 0.85rem;
 }
 .stat-symbol {
-  font-size: 1.6rem;
-  font-weight: 800;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 2.85rem;
   color: var(--text);
-  letter-spacing: -0.02em;
-  margin-bottom: 0.2rem;
-  line-height: 1.1;
+  letter-spacing: -0.035em;
+  margin-bottom: 0.4rem;
+  line-height: 0.95;
 }
 .stat-change {
-  font-size: 1.1rem;
-  font-weight: 700;
-  margin-bottom: 0.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
   font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
   letter-spacing: -0.01em;
 }
 .stat-sector {
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   color: var(--text-muted);
   font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 /* ── Panels ─────────────────────────────────────────────────────── */
 .panel {
   position: relative;
   overflow: hidden;
-  background: var(--surface);
+  background:
+    radial-gradient(ellipse 100% 60% at 0% 0%, rgba(79,140,255,0.025) 0%, transparent 70%),
+    var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 1.35rem 1.4rem;
-  margin-bottom: 1.25rem;
+  padding: 1.75rem 1.85rem;
+  margin-bottom: 1.5rem;
   box-shadow: var(--shadow-card);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
@@ -355,39 +387,43 @@ body {
 .panel::before {
   content: '';
   position: absolute;
-  top: 0; left: 0; right: 0;
-  height: 3px;
-  background: linear-gradient(90deg, var(--accent), var(--accent-end), transparent 65%);
-  border-radius: var(--radius) var(--radius) 0 0;
+  top: 0; left: 1.85rem; right: 1.85rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(79,140,255,0.35), transparent);
 }
 .panel:hover {
   border-color: var(--border-hover);
-  box-shadow: 0 0 0 3px var(--glow), var(--shadow-card);
+  box-shadow: 0 0 0 1px var(--glow), 0 16px 48px rgba(0,0,0,0.5);
   transform: translateY(-2px);
 }
 
 .panel-header {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 1.1rem;
-  padding-bottom: 0.85rem;
+  align-items: baseline;
+  gap: 0.85rem;
+  margin-bottom: 1.4rem;
+  padding-bottom: 1rem;
   border-bottom: 1px solid var(--border);
   flex-wrap: wrap;
 }
 .panel-header h2 {
-  font-size: 0.92rem;
-  font-weight: 700;
-  letter-spacing: 0.01em;
-  text-transform: uppercase;
-  color: var(--text-muted);
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 1.45rem;
+  letter-spacing: -0.015em;
+  text-transform: none;
+  color: var(--text);
+  line-height: 1;
 }
 .panel-hint {
-  font-size: 0.7rem;
-  color: var(--text-muted);
+  font-size: 0.66rem;
+  color: var(--text-faint);
   margin-left: auto;
-  font-weight: 400;
-  opacity: 0.8;
+  font-weight: 500;
+  opacity: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
 }
 
 /* ── Heatmap ────────────────────────────────────────────────────── */
@@ -665,14 +701,21 @@ body {
   text-align: center;
 }
 .bt-stat-label {
-  font-size: 0.7rem;
-  color: var(--text-muted);
-  margin-bottom: 0.3rem;
+  font-size: 0.6rem;
+  color: var(--text-faint);
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-weight: 500;
 }
 .bt-stat-value {
-  font-size: 1.1rem;
-  font-weight: 700;
-  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.7rem;
+  font-weight: 400;
+  color: var(--text);
+  letter-spacing: -0.025em;
+  line-height: 1;
 }
 
 .bt-composition { margin-top: 1.5rem; }
@@ -743,8 +786,8 @@ body {
   flex-wrap: wrap;
 }
 .macro-sum-item { display: flex; flex-direction: column; gap: 2px; }
-.macro-sum-label { font-size: 0.7rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
-.macro-sum-val   { font-size: 1.1rem; font-weight: 700; color: var(--text); }
+.macro-sum-label { font-size: 0.62rem; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.16em; font-weight: 500; }
+.macro-sum-val   { font-family: var(--font-display); font-style: italic; font-size: 1.85rem; font-weight: 400; color: var(--text); letter-spacing: -0.025em; line-height: 1; }
 
 .macro-charts {
   display: grid;
@@ -765,8 +808,8 @@ body {
   text-align: center;
   pointer-events: none;
 }
-.donut-label { font-size: 0.68rem; color: var(--text-muted); text-transform: uppercase; }
-.donut-value { font-size: 1.05rem; font-weight: 700; color: var(--text); }
+.donut-label { font-size: 0.62rem; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.16em; margin-bottom: 4px; }
+.donut-value { font-family: var(--font-display); font-style: italic; font-weight: 400; font-size: 1.7rem; color: var(--text); letter-spacing: -0.02em; line-height: 1; }
 .macro-bar-wrap { flex: 1; }
 
 .macro-cards {
@@ -785,14 +828,14 @@ body {
 .macro-card-drillable:hover { border-color: var(--accent2); transform: translateY(-3px); box-shadow: 0 8px 24px rgba(0,0,0,0.4); }
 .macro-card-drillable:active { transform: scale(0.97); transition-duration: 80ms; }
 
-.macro-card-color { height: 3px; }
-.macro-card-body  { padding: 0.7rem; position: relative; }
-.macro-card-name  { font-size: 0.82rem; font-weight: 600; color: var(--text); margin-bottom: 0.3rem; }
-.macro-card-aum   { font-size: 1rem; font-weight: 700; color: var(--text); font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace; }
-.macro-card-pct   { font-size: 0.68rem; color: var(--text-muted); margin-bottom: 0.25rem; }
-.macro-card-change{ font-size: 0.88rem; font-weight: 600; font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace; }
-.macro-card-arrow { position: absolute; top: 0.6rem; right: 0.7rem; color: var(--accent); font-size: 1rem; }
-.macro-card-bar   { height: 4px; background: var(--bg); margin: 0 0.5rem 0.5rem; border-radius: 2px; }
+.macro-card-color { height: 2px; opacity: 0.7; }
+.macro-card-body  { padding: 0.95rem 1rem; position: relative; }
+.macro-card-name  { font-size: 0.7rem; font-weight: 500; color: var(--text-muted); margin-bottom: 0.4rem; text-transform: uppercase; letter-spacing: 0.1em; }
+.macro-card-aum   { font-family: var(--font-display); font-style: italic; font-size: 1.6rem; font-weight: 400; color: var(--text); letter-spacing: -0.02em; line-height: 1; margin-bottom: 0.2rem; }
+.macro-card-pct   { font-size: 0.62rem; color: var(--text-faint); margin-bottom: 0.35rem; letter-spacing: 0.05em; }
+.macro-card-change{ font-size: 0.86rem; font-weight: 600; font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace; }
+.macro-card-arrow { position: absolute; top: 0.85rem; right: 0.85rem; color: var(--accent); font-size: 0.85rem; opacity: 0.6; }
+.macro-card-bar   { height: 3px; background: var(--bg); margin: 0 0.5rem 0.5rem; border-radius: 2px; }
 
 /* ── Strategy Comparison ─────────────────────────────────────────── */
 .strat-controls {
@@ -1355,12 +1398,20 @@ body {
 }
 
 @media (max-width: 600px) {
-  .topbar       { padding: 0.5rem 0.75rem; gap: 0.5rem; }
+  .topbar       { padding: 0.7rem 1rem; gap: 0.6rem; }
+  .brand-name   { font-size: 1.4rem; }
   .brand-sub    { display: none; }
-  .tab-panel    { padding: 0.75rem; }
-  .stat-row     { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .tab-panel    { padding: 0.875rem; }
+  .stat-row     { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
   .stats-row    { grid-template-columns: repeat(2, 1fr); }
-  .panel        { padding: 0.875rem; }
+  .panel        { padding: 1.1rem 1rem; }
+  .panel-header h2 { font-size: 1.2rem; }
+  .stat-card    { padding: 1.15rem 1.1rem; }
+  .stat-symbol  { font-size: 2.1rem; }
+  .macro-card-aum { font-size: 1.3rem; }
+  .macro-sum-val { font-size: 1.45rem; }
+  .donut-value  { font-size: 1.35rem; }
+  .bt-stat-value { font-size: 1.3rem; }
   .chart-wrap.tall   { height: 280px; }
   .chart-wrap.medium { height: 200px; }
   .name-cell    { display: none; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,6 +29,13 @@
   --flash-pos:    rgba(34,197,94,0.22);
   --flash-neg:    rgba(239,68,68,0.22);
   --topbar-start: #07111f;
+  /* Motion tokens (Dieter Rams / Jony Ive principles) */
+  --ease-out:    cubic-bezier(0, 0, 0.2, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --dur-micro:   80ms;
+  --dur-fast:    150ms;
+  --dur-base:    250ms;
+  --dur-slow:    350ms;
 }
 
 [data-theme="light"] {
@@ -144,12 +151,13 @@ body {
   padding: 4px 10px;
   border-radius: 6px;
   cursor: pointer;
-  transition: background 0.12s, color 0.12s;
+  transition: background 150ms cubic-bezier(0,0,0.2,1), color 150ms cubic-bezier(0,0,0.2,1), transform 150ms cubic-bezier(0,0,0.2,1);
   font-family: inherit;
   letter-spacing: 0.01em;
 }
-.period-btn:hover { background: rgba(255,255,255,0.08); color: var(--text); }
-[data-theme="light"] .period-btn:hover { background: var(--border); color: var(--text); }
+.period-btn:hover { background: rgba(255,255,255,0.08); color: var(--text); transform: translateY(-1px); }
+.period-btn:active { transform: scale(0.97); transition-duration: 80ms; }
+[data-theme="light"] .period-btn:hover { background: var(--border); color: var(--text); transform: translateY(-1px); }
 .period-btn.active {
   background: linear-gradient(135deg, var(--accent), var(--accent-end));
   color: #fff;
@@ -185,7 +193,7 @@ body {
   font-weight: 500;
   padding: 0.7rem 1rem;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s, background 0.15s;
+  transition: color 150ms cubic-bezier(0,0,0.2,1), border-color 150ms cubic-bezier(0,0,0.2,1), background 150ms cubic-bezier(0,0,0.2,1), transform 80ms cubic-bezier(0,0,0.2,1);
   white-space: nowrap;
   font-family: inherit;
   display: flex;
@@ -194,6 +202,7 @@ body {
   border-radius: 0;
 }
 .tab-btn:hover { color: var(--text); background: rgba(99,179,237,0.04); }
+.tab-btn:active { transform: scale(0.97); }
 .tab-btn.active {
   color: var(--accent);
   border-bottom-color: var(--accent);
@@ -230,7 +239,11 @@ body {
 
 /* ── Tab Panels ─────────────────────────────────────────────────── */
 @keyframes fadeInUp {
-  from { opacity: 0; transform: translateY(10px); }
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes staggerIn {
+  from { opacity: 0; transform: translateY(18px); }
   to   { opacity: 1; transform: translateY(0); }
 }
 
@@ -242,8 +255,25 @@ body {
 }
 .tab-panel.active {
   display: block;
-  animation: fadeInUp 0.22s ease;
+  animation: fadeInUp 0.3s cubic-bezier(0, 0, 0.2, 1);
 }
+
+/* Stagger — stat cards (60 ms apart) */
+.tab-panel.active .stat-row .stat-card:nth-child(1) { animation: staggerIn 0.35s cubic-bezier(0,0,0.2,1) both; }
+.tab-panel.active .stat-row .stat-card:nth-child(2) { animation: staggerIn 0.35s cubic-bezier(0,0,0.2,1) 60ms both; }
+.tab-panel.active .stat-row .stat-card:nth-child(3) { animation: staggerIn 0.35s cubic-bezier(0,0,0.2,1) 120ms both; }
+.tab-panel.active .stat-row .stat-card:nth-child(4) { animation: staggerIn 0.35s cubic-bezier(0,0,0.2,1) 180ms both; }
+
+/* Stagger — macro cards (35 ms apart) */
+.tab-panel.active .macro-cards .macro-card:nth-child(1) { animation: staggerIn 0.3s cubic-bezier(0,0,0.2,1) both; }
+.tab-panel.active .macro-cards .macro-card:nth-child(2) { animation: staggerIn 0.3s cubic-bezier(0,0,0.2,1) 35ms both; }
+.tab-panel.active .macro-cards .macro-card:nth-child(3) { animation: staggerIn 0.3s cubic-bezier(0,0,0.2,1) 70ms both; }
+.tab-panel.active .macro-cards .macro-card:nth-child(4) { animation: staggerIn 0.3s cubic-bezier(0,0,0.2,1) 105ms both; }
+.tab-panel.active .macro-cards .macro-card:nth-child(5) { animation: staggerIn 0.3s cubic-bezier(0,0,0.2,1) 140ms both; }
+.tab-panel.active .macro-cards .macro-card:nth-child(6) { animation: staggerIn 0.3s cubic-bezier(0,0,0.2,1) 175ms both; }
+.tab-panel.active .macro-cards .macro-card:nth-child(7) { animation: staggerIn 0.3s cubic-bezier(0,0,0.2,1) 210ms both; }
+.tab-panel.active .macro-cards .macro-card:nth-child(8) { animation: staggerIn 0.3s cubic-bezier(0,0,0.2,1) 245ms both; }
+.tab-panel.active .macro-cards .macro-card:nth-child(n+9) { animation: staggerIn 0.3s cubic-bezier(0,0,0.2,1) 280ms both; }
 
 /* ── Stat Cards Row ─────────────────────────────────────────────── */
 .stat-row {
@@ -263,7 +293,7 @@ body {
   box-shadow: var(--shadow-card);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  transition: border-color 0.18s, box-shadow 0.18s, transform 0.15s;
+  transition: border-color 150ms cubic-bezier(0,0,0.2,1), box-shadow 220ms cubic-bezier(0,0,0.2,1), transform 220ms cubic-bezier(0,0,0.2,1);
 }
 .stat-card::before {
   content: '';
@@ -275,8 +305,8 @@ body {
 }
 .stat-card:hover {
   border-color: var(--border-hover);
-  box-shadow: 0 0 0 3px var(--glow), var(--shadow-card);
-  transform: translateY(-2px);
+  box-shadow: 0 0 0 3px var(--glow), 0 16px 48px rgba(0,0,0,0.65), 0 1px 0 rgba(99,179,237,0.07) inset;
+  transform: translateY(-4px);
 }
 
 .stat-label {
@@ -320,7 +350,7 @@ body {
   box-shadow: var(--shadow-card);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
-  transition: border-color 0.18s, box-shadow 0.18s;
+  transition: border-color 150ms cubic-bezier(0,0,0.2,1), box-shadow 220ms cubic-bezier(0,0,0.2,1), transform 220ms cubic-bezier(0,0,0.2,1);
 }
 .panel::before {
   content: '';
@@ -333,6 +363,7 @@ body {
 .panel:hover {
   border-color: var(--border-hover);
   box-shadow: 0 0 0 3px var(--glow), var(--shadow-card);
+  transform: translateY(-2px);
 }
 
 .panel-header {
@@ -436,9 +467,10 @@ body {
   border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: 0.85rem;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color 150ms cubic-bezier(0,0,0.2,1), border-color 150ms cubic-bezier(0,0,0.2,1), transform 150ms cubic-bezier(0,0,0.2,1);
 }
-.icon-btn:hover { color: var(--text); border-color: var(--accent2); }
+.icon-btn:hover { color: var(--text); border-color: var(--accent2); transform: translateY(-1px); }
+.icon-btn:active { transform: scale(0.97); transition-duration: 80ms; }
 
 /* ── Symbol Picker ──────────────────────────────────────────────── */
 .symbol-picker {
@@ -610,11 +642,12 @@ body {
   padding: 8px 20px;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 150ms cubic-bezier(0,0,0.2,1), transform 150ms cubic-bezier(0,0,0.2,1), box-shadow 150ms cubic-bezier(0,0,0.2,1);
   font-family: inherit;
   margin-left: auto;
 }
-.run-btn:hover:not(:disabled) { background: #1f6feb; }
+.run-btn:hover:not(:disabled) { background: #1f6feb; transform: translateY(-1px); box-shadow: 0 6px 20px rgba(59,130,246,0.45); }
+.run-btn:active:not(:disabled) { transform: scale(0.97); transition-duration: 80ms; }
 .run-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
 /* ── Backtest Results ───────────────────────────────────────────── */
@@ -746,10 +779,11 @@ body {
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   overflow: hidden;
-  transition: border-color 0.2s, transform 0.15s;
+  transition: border-color 150ms cubic-bezier(0,0,0.2,1), transform 200ms cubic-bezier(0,0,0.2,1), box-shadow 200ms cubic-bezier(0,0,0.2,1);
 }
 .macro-card-drillable { cursor: pointer; }
-.macro-card-drillable:hover { border-color: var(--accent2); transform: translateY(-1px); }
+.macro-card-drillable:hover { border-color: var(--accent2); transform: translateY(-3px); box-shadow: 0 8px 24px rgba(0,0,0,0.4); }
+.macro-card-drillable:active { transform: scale(0.97); transition-duration: 80ms; }
 
 .macro-card-color { height: 3px; }
 .macro-card-body  { padding: 0.7rem; position: relative; }
@@ -2209,3 +2243,32 @@ body {
   0%,100% { opacity: 1; }
   50%      { opacity: 0.45; }
 }
+
+/* ── Micro-interactions (Jony Ive / Dieter Rams principles) ─────── */
+/* Hover lift + physical press for buttons with transition: all */
+.sym-btn:hover        { transform: translateY(-1px); }
+.sym-btn:active       { transform: scale(0.97); transition-duration: 80ms !important; }
+.bt-period-btn:hover  { transform: translateY(-1px); }
+.bt-period-btn:active { transform: scale(0.97); transition-duration: 80ms !important; }
+.template-btn:hover   { transform: translateY(-1px); }
+.template-btn:active  { transform: scale(0.97); transition-duration: 80ms !important; }
+.cp-btn:hover         { transform: translateY(-1px); }
+.cp-btn:active        { transform: scale(0.97); transition-duration: 80ms !important; }
+.cm-btn:hover         { transform: translateY(-1px); }
+.cm-btn:active        { transform: scale(0.97); transition-duration: 80ms !important; }
+.ef-btn:hover         { transform: translateY(-1px); }
+.ef-btn:active        { transform: scale(0.97); transition-duration: 80ms !important; }
+.chart-mode-btn:hover { transform: translateY(-1px); }
+.chart-mode-btn:active{ transform: scale(0.97); transition-duration: 80ms !important; }
+.chart-ind-btn:hover  { transform: translateY(-1px); }
+.chart-ind-btn:active { transform: scale(0.97); transition-duration: 80ms !important; }
+.nsb:hover            { transform: translateY(-1px); }
+.nsb:active           { transform: scale(0.97); transition-duration: 80ms !important; }
+
+/* ── Focus-visible (WCAG accessibility ring) ────────────────────── */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+button:focus-visible { border-radius: var(--radius-sm); }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,33 +6,31 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  --bg:           #050a16;
-  --surface:      #0d1729;
-  --surface2:     #142036;
-  --surface-glass:rgba(13,23,41,0.75);
-  --border:       rgba(255,255,255,0.06);
-  --border-hover: rgba(255,255,255,0.18);
-  --glow:         rgba(79,140,255,0.16);
-  --text:         #eef2f9;
-  --text-muted:   #8895ab;
+  --bg:           #060c18;
+  --surface:      #0e1c31;
+  --surface2:     #152540;
+  --surface-glass:rgba(14,28,49,0.75);
+  --border:       rgba(99,179,237,0.14);
+  --border-hover: rgba(99,179,237,0.36);
+  --glow:         rgba(59,130,246,0.18);
+  --text:         #e2e8f0;
+  --text-muted:   #94a3b8;
   --text-faint:   #5b6878;
-  --accent:       #4f8cff;
-  --accent2:      #2f6fe6;
-  --accent-end:   #a78bfa;
-  --gold:         #f4c25e;
-  --pos:          #34d399;
-  --neg:          #f87171;
-  --radius:       16px;
-  --radius-sm:    10px;
-  --shadow:       0 16px 48px rgba(0,0,0,0.65), 0 1px 0 rgba(255,255,255,0.04) inset;
-  --shadow-card:  0 8px 28px rgba(0,0,0,0.45), 0 1px 0 rgba(255,255,255,0.04) inset;
-  --chart-grid:   rgba(255,255,255,0.04);
+  --accent:       #3b82f6;
+  --accent2:      #2563eb;
+  --accent-end:   #8b5cf6;
+  --pos:          #22c55e;
+  --neg:          #ef4444;
+  --radius:       14px;
+  --radius-sm:    8px;
+  --shadow:       0 8px 32px rgba(0,0,0,0.65), 0 1px 0 rgba(99,179,237,0.07) inset;
+  --shadow-card:  0 4px 20px rgba(0,0,0,0.45), 0 1px 0 rgba(99,179,237,0.07) inset;
+  --chart-grid:   rgba(99,179,237,0.06);
   --chart-tick:   #4d6080;
-  --flash-pos:    rgba(52,211,153,0.20);
-  --flash-neg:    rgba(248,113,113,0.20);
-  --topbar-start: #060b18;
-  --font-display: 'Instrument Serif', 'New York', Georgia, 'Times New Roman', serif;
-  /* Motion tokens (Dieter Rams / Jony Ive principles) */
+  --flash-pos:    rgba(34,197,94,0.22);
+  --flash-neg:    rgba(239,68,68,0.22);
+  --topbar-start: #07111f;
+  /* Motion tokens */
   --ease-out:    cubic-bezier(0, 0, 0.2, 1);
   --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
   --dur-micro:   80ms;
@@ -42,29 +40,28 @@
 }
 
 [data-theme="light"] {
-  --bg:           #f5f7fc;
+  --bg:           #eef3fc;
   --surface:      #ffffff;
-  --surface2:     #f1f4fa;
+  --surface2:     #f4f7ff;
   --surface-glass:rgba(255,255,255,0.90);
-  --border:       rgba(15,23,42,0.07);
-  --border-hover: rgba(15,23,42,0.18);
-  --glow:         rgba(47,111,230,0.10);
-  --text:         #0f172a;
-  --text-muted:   #475569;
+  --border:       rgba(59,130,246,0.15);
+  --border-hover: rgba(59,130,246,0.40);
+  --glow:         rgba(59,130,246,0.06);
+  --text:         #111827;
+  --text-muted:   #6b7f9a;
   --text-faint:   #94a3b8;
-  --accent:       #2f6fe6;
+  --accent:       #2563eb;
   --accent2:      #1d4ed8;
   --accent-end:   #7c3aed;
-  --gold:         #c69134;
-  --pos:          #059669;
+  --pos:          #16a34a;
   --neg:          #dc2626;
-  --shadow:       0 1px 3px rgba(15,23,42,0.06), 0 8px 24px rgba(15,23,42,0.05);
-  --shadow-card:  0 1px 2px rgba(15,23,42,0.04), 0 4px 16px rgba(15,23,42,0.04);
-  --chart-grid:   rgba(15,23,42,0.06);
+  --shadow:       none;
+  --shadow-card:  none;
+  --chart-grid:   rgba(59,130,246,0.07);
   --chart-tick:   #7a8fa8;
-  --flash-pos:    rgba(5,150,105,0.16);
-  --flash-neg:    rgba(220,38,38,0.14);
-  --topbar-start: #ffffff;
+  --flash-pos:    rgba(22,163,74,0.18);
+  --flash-neg:    rgba(220,38,38,0.15);
+  --topbar-start: #dce8fb;
 }
 
 [data-theme="light"] .topbar {
@@ -78,14 +75,13 @@ html { scroll-behavior: smooth; }
 body {
   font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   background:
-    radial-gradient(ellipse 80% 55% at 12% 0%,   rgba(79,140,255,0.10) 0%, transparent 60%),
-    radial-gradient(ellipse 60% 45% at 88% 100%, rgba(167,139,250,0.08) 0%, transparent 60%),
-    radial-gradient(ellipse 45% 30% at 50% 50%,  rgba(244,194,94,0.025) 0%, transparent 65%),
+    radial-gradient(ellipse 75% 45% at 8% 0%,   rgba(59,130,246,0.11) 0%, transparent 55%),
+    radial-gradient(ellipse 55% 40% at 92% 100%, rgba(139,92,246,0.09) 0%, transparent 55%),
     var(--bg);
   background-attachment: fixed;
   color: var(--text);
   font-size: 14px;
-  line-height: 1.55;
+  line-height: 1.5;
   min-height: 100vh;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -102,10 +98,10 @@ body {
 .topbar {
   display: flex;
   align-items: center;
-  gap: 1.25rem;
-  padding: 0.9rem 1.5rem;
-  padding-top: max(0.9rem, env(safe-area-inset-top));
-  background: rgba(5,10,22,0.7);
+  gap: 1rem;
+  padding: 0.65rem 1.25rem;
+  padding-top: max(0.65rem, env(safe-area-inset-top));
+  background: linear-gradient(180deg, var(--topbar-start) 0%, var(--bg) 100%);
   border-bottom: 1px solid var(--border);
   position: sticky;
   top: 0;
@@ -114,7 +110,6 @@ body {
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   backdrop-filter: blur(20px) saturate(180%);
 }
-[data-theme="light"] .topbar { background: rgba(255,255,255,0.7); }
 
 .topbar-brand {
   display: flex;
@@ -122,32 +117,22 @@ body {
   gap: 0.7rem;
   margin-right: auto;
 }
-.brand-icon {
-  font-size: 1.1rem;
-  line-height: 1;
-  color: var(--gold);
-  align-self: center;
-  filter: drop-shadow(0 0 8px rgba(244,194,94,0.4));
-}
+.brand-icon { font-size: 1.25rem; line-height: 1; }
 .brand-name {
-  font-family: var(--font-display);
-  font-style: italic;
-  font-weight: 400;
-  font-size: 1.85rem;
-  line-height: 1;
-  letter-spacing: -0.025em;
-  color: var(--text);
+  font-weight: 800;
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+  background: linear-gradient(90deg, var(--accent), var(--accent-end));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
   white-space: nowrap;
 }
 .brand-sub {
-  font-size: 0.62rem;
-  color: var(--text-faint);
+  font-size: 0.68rem;
+  color: var(--text-muted);
   white-space: nowrap;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  padding-left: 0.65rem;
-  border-left: 1px solid var(--border);
+  font-weight: 400;
 }
 
 .topbar-period {
@@ -179,13 +164,9 @@ body {
 .period-btn:active { transform: scale(0.97); transition-duration: 80ms; }
 [data-theme="light"] .period-btn:hover { background: var(--border); color: var(--text); transform: translateY(-1px); }
 .period-btn.active {
-  background: var(--text);
-  color: var(--bg);
-  box-shadow: 0 2px 12px rgba(255,255,255,0.18);
-}
-[data-theme="light"] .period-btn.active {
-  background: var(--text);
+  background: linear-gradient(135deg, var(--accent), var(--accent-end));
   color: #fff;
+  box-shadow: 0 1px 8px rgba(59,130,246,0.40);
 }
 
 .topbar-meta {
@@ -211,26 +192,25 @@ body {
 .tab-btn {
   background: transparent;
   border: none;
-  border-bottom: 1px solid transparent;
-  color: var(--text-faint);
-  font-size: 0.78rem;
+  border-bottom: 2px solid transparent;
+  color: var(--text-muted);
+  font-size: 0.82rem;
   font-weight: 500;
-  padding: 0.85rem 1.1rem;
+  padding: 0.7rem 1rem;
   cursor: pointer;
   transition: color 150ms cubic-bezier(0,0,0.2,1), border-color 150ms cubic-bezier(0,0,0.2,1), background 150ms cubic-bezier(0,0,0.2,1), transform 80ms cubic-bezier(0,0,0.2,1);
   white-space: nowrap;
   font-family: inherit;
   display: flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.3rem;
   border-radius: 0;
-  letter-spacing: 0.02em;
 }
-.tab-btn:hover { color: var(--text); background: rgba(255,255,255,0.025); }
+.tab-btn:hover { color: var(--text); background: rgba(99,179,237,0.04); }
 .tab-btn:active { transform: scale(0.97); }
 .tab-btn.active {
-  color: var(--text);
-  border-bottom-color: var(--gold);
+  color: var(--accent);
+  border-bottom-color: var(--accent);
   font-weight: 600;
 }
 [data-theme="light"] .tab-btn:hover { background: rgba(59,130,246,0.05); }
@@ -311,12 +291,10 @@ body {
 .stat-card {
   position: relative;
   overflow: hidden;
-  background:
-    radial-gradient(ellipse 120% 80% at 0% 0%, rgba(79,140,255,0.04) 0%, transparent 60%),
-    var(--surface);
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 1.5rem 1.5rem 1.35rem;
+  padding: 1.1rem 1.2rem;
   box-shadow: var(--shadow-card);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -325,60 +303,55 @@ body {
 .stat-card::before {
   content: '';
   position: absolute;
-  top: 0; left: 1.5rem; right: 1.5rem;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(79,140,255,0.5), transparent);
+  top: 0; left: 0; right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-end), transparent 80%);
+  border-radius: var(--radius) var(--radius) 0 0;
 }
 .stat-card:hover {
   border-color: var(--border-hover);
-  box-shadow: 0 0 0 1px var(--glow), 0 24px 60px rgba(0,0,0,0.7), 0 1px 0 rgba(255,255,255,0.06) inset;
-  transform: translateY(-4px);
+  box-shadow: 0 0 0 3px var(--glow), var(--shadow-card);
+  transform: translateY(-2px);
 }
 
 .stat-label {
-  font-size: 0.62rem;
-  color: var(--text-faint);
+  font-size: 0.68rem;
+  color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-weight: 500;
-  margin-bottom: 0.85rem;
+  letter-spacing: 0.07em;
+  font-weight: 600;
+  margin-bottom: 0.45rem;
 }
 .stat-symbol {
-  font-family: var(--font-display);
-  font-style: italic;
-  font-weight: 400;
-  font-size: 2.85rem;
+  font-size: 1.6rem;
+  font-weight: 800;
   color: var(--text);
-  letter-spacing: -0.035em;
-  margin-bottom: 0.4rem;
-  line-height: 0.95;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.2rem;
+  line-height: 1.1;
 }
 .stat-change {
-  font-size: 1rem;
-  font-weight: 600;
-  margin-bottom: 0.4rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
   font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
   letter-spacing: -0.01em;
 }
 .stat-sector {
-  font-size: 0.7rem;
+  font-size: 0.72rem;
   color: var(--text-muted);
   font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 
 /* ── Panels ─────────────────────────────────────────────────────── */
 .panel {
   position: relative;
   overflow: hidden;
-  background:
-    radial-gradient(ellipse 100% 60% at 0% 0%, rgba(79,140,255,0.025) 0%, transparent 70%),
-    var(--surface);
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 1.75rem 1.85rem;
-  margin-bottom: 1.5rem;
+  padding: 1.35rem 1.4rem;
+  margin-bottom: 1.25rem;
   box-shadow: var(--shadow-card);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
@@ -387,43 +360,39 @@ body {
 .panel::before {
   content: '';
   position: absolute;
-  top: 0; left: 1.85rem; right: 1.85rem;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(79,140,255,0.35), transparent);
+  top: 0; left: 0; right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-end), transparent 65%);
+  border-radius: var(--radius) var(--radius) 0 0;
 }
 .panel:hover {
   border-color: var(--border-hover);
-  box-shadow: 0 0 0 1px var(--glow), 0 16px 48px rgba(0,0,0,0.5);
+  box-shadow: 0 0 0 3px var(--glow), var(--shadow-card);
   transform: translateY(-2px);
 }
 
 .panel-header {
   display: flex;
-  align-items: baseline;
-  gap: 0.85rem;
-  margin-bottom: 1.4rem;
-  padding-bottom: 1rem;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.1rem;
+  padding-bottom: 0.85rem;
   border-bottom: 1px solid var(--border);
   flex-wrap: wrap;
 }
 .panel-header h2 {
-  font-family: var(--font-display);
-  font-style: italic;
-  font-weight: 400;
-  font-size: 1.45rem;
-  letter-spacing: -0.015em;
-  text-transform: none;
-  color: var(--text);
-  line-height: 1;
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
 .panel-hint {
-  font-size: 0.66rem;
-  color: var(--text-faint);
+  font-size: 0.7rem;
+  color: var(--text-muted);
   margin-left: auto;
-  font-weight: 500;
-  opacity: 1;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
+  font-weight: 400;
+  opacity: 0.8;
 }
 
 /* ── Heatmap ────────────────────────────────────────────────────── */
@@ -701,21 +670,14 @@ body {
   text-align: center;
 }
 .bt-stat-label {
-  font-size: 0.6rem;
-  color: var(--text-faint);
-  margin-bottom: 0.5rem;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  font-weight: 500;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  margin-bottom: 0.3rem;
 }
 .bt-stat-value {
-  font-family: var(--font-display);
-  font-style: italic;
-  font-size: 1.7rem;
-  font-weight: 400;
-  color: var(--text);
-  letter-spacing: -0.025em;
-  line-height: 1;
+  font-size: 1.1rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace;
 }
 
 .bt-composition { margin-top: 1.5rem; }
@@ -786,8 +748,8 @@ body {
   flex-wrap: wrap;
 }
 .macro-sum-item { display: flex; flex-direction: column; gap: 2px; }
-.macro-sum-label { font-size: 0.62rem; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.16em; font-weight: 500; }
-.macro-sum-val   { font-family: var(--font-display); font-style: italic; font-size: 1.85rem; font-weight: 400; color: var(--text); letter-spacing: -0.025em; line-height: 1; }
+.macro-sum-label { font-size: 0.7rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.macro-sum-val   { font-size: 1.1rem; font-weight: 700; color: var(--text); }
 
 .macro-charts {
   display: grid;
@@ -808,8 +770,8 @@ body {
   text-align: center;
   pointer-events: none;
 }
-.donut-label { font-size: 0.62rem; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.16em; margin-bottom: 4px; }
-.donut-value { font-family: var(--font-display); font-style: italic; font-weight: 400; font-size: 1.7rem; color: var(--text); letter-spacing: -0.02em; line-height: 1; }
+.donut-label { font-size: 0.68rem; color: var(--text-muted); text-transform: uppercase; }
+.donut-value { font-size: 1.05rem; font-weight: 700; color: var(--text); }
 .macro-bar-wrap { flex: 1; }
 
 .macro-cards {
@@ -825,17 +787,17 @@ body {
   transition: border-color 150ms cubic-bezier(0,0,0.2,1), transform 200ms cubic-bezier(0,0,0.2,1), box-shadow 200ms cubic-bezier(0,0,0.2,1);
 }
 .macro-card-drillable { cursor: pointer; }
-.macro-card-drillable:hover { border-color: var(--accent2); transform: translateY(-3px); box-shadow: 0 8px 24px rgba(0,0,0,0.4); }
+.macro-card-drillable:hover { border-color: var(--accent2); transform: translateY(-2px); box-shadow: 0 8px 24px rgba(0,0,0,0.4); }
 .macro-card-drillable:active { transform: scale(0.97); transition-duration: 80ms; }
 
-.macro-card-color { height: 2px; opacity: 0.7; }
-.macro-card-body  { padding: 0.95rem 1rem; position: relative; }
-.macro-card-name  { font-size: 0.7rem; font-weight: 500; color: var(--text-muted); margin-bottom: 0.4rem; text-transform: uppercase; letter-spacing: 0.1em; }
-.macro-card-aum   { font-family: var(--font-display); font-style: italic; font-size: 1.6rem; font-weight: 400; color: var(--text); letter-spacing: -0.02em; line-height: 1; margin-bottom: 0.2rem; }
-.macro-card-pct   { font-size: 0.62rem; color: var(--text-faint); margin-bottom: 0.35rem; letter-spacing: 0.05em; }
-.macro-card-change{ font-size: 0.86rem; font-weight: 600; font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace; }
-.macro-card-arrow { position: absolute; top: 0.85rem; right: 0.85rem; color: var(--accent); font-size: 0.85rem; opacity: 0.6; }
-.macro-card-bar   { height: 3px; background: var(--bg); margin: 0 0.5rem 0.5rem; border-radius: 2px; }
+.macro-card-color { height: 3px; }
+.macro-card-body  { padding: 0.7rem; position: relative; }
+.macro-card-name  { font-size: 0.82rem; font-weight: 600; color: var(--text); margin-bottom: 0.3rem; }
+.macro-card-aum   { font-size: 1rem; font-weight: 700; color: var(--text); font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace; }
+.macro-card-pct   { font-size: 0.68rem; color: var(--text-muted); margin-bottom: 0.25rem; }
+.macro-card-change{ font-size: 0.88rem; font-weight: 600; font-family: 'JetBrains Mono', 'Courier New', Consolas, monospace; }
+.macro-card-arrow { position: absolute; top: 0.6rem; right: 0.7rem; color: var(--accent); font-size: 1rem; }
+.macro-card-bar   { height: 4px; background: var(--bg); margin: 0 0.5rem 0.5rem; border-radius: 2px; }
 
 /* ── Strategy Comparison ─────────────────────────────────────────── */
 .strat-controls {
@@ -1399,19 +1361,11 @@ body {
 
 @media (max-width: 600px) {
   .topbar       { padding: 0.7rem 1rem; gap: 0.6rem; }
-  .brand-name   { font-size: 1.4rem; }
   .brand-sub    { display: none; }
   .tab-panel    { padding: 0.875rem; }
   .stat-row     { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
   .stats-row    { grid-template-columns: repeat(2, 1fr); }
   .panel        { padding: 1.1rem 1rem; }
-  .panel-header h2 { font-size: 1.2rem; }
-  .stat-card    { padding: 1.15rem 1.1rem; }
-  .stat-symbol  { font-size: 2.1rem; }
-  .macro-card-aum { font-size: 1.3rem; }
-  .macro-sum-val { font-size: 1.45rem; }
-  .donut-value  { font-size: 1.35rem; }
-  .bt-stat-value { font-size: 1.3rem; }
   .chart-wrap.tall   { height: 280px; }
   .chart-wrap.medium { height: 200px; }
   .name-cell    { display: none; }
@@ -2315,6 +2269,68 @@ body {
 .chart-ind-btn:active { transform: scale(0.97); transition-duration: 80ms !important; }
 .nsb:hover            { transform: translateY(-1px); }
 .nsb:active           { transform: scale(0.97); transition-duration: 80ms !important; }
+
+/* ── Directional tab transitions ────────────────────────────────── */
+@keyframes slideInRight {
+  from { opacity: 0; transform: translate(20px, 6px); }
+  to   { opacity: 1; transform: translate(0, 0); }
+}
+@keyframes slideInLeft {
+  from { opacity: 0; transform: translate(-20px, 6px); }
+  to   { opacity: 1; transform: translate(0, 0); }
+}
+.tab-dir-right .tab-panel.active {
+  animation: slideInRight 0.24s cubic-bezier(0, 0, 0.2, 1) both;
+}
+.tab-dir-left .tab-panel.active {
+  animation: slideInLeft 0.24s cubic-bezier(0, 0, 0.2, 1) both;
+}
+
+/* Stagger still runs on top of directional slide — stat cards */
+.tab-dir-right .tab-panel.active .stat-row .stat-card:nth-child(1),
+.tab-dir-left  .tab-panel.active .stat-row .stat-card:nth-child(1) { animation: staggerIn 0.35s cubic-bezier(0,0,0.2,1) both; }
+.tab-dir-right .tab-panel.active .stat-row .stat-card:nth-child(2),
+.tab-dir-left  .tab-panel.active .stat-row .stat-card:nth-child(2) { animation: staggerIn 0.35s cubic-bezier(0,0,0.2,1) 60ms both; }
+.tab-dir-right .tab-panel.active .stat-row .stat-card:nth-child(3),
+.tab-dir-left  .tab-panel.active .stat-row .stat-card:nth-child(3) { animation: staggerIn 0.35s cubic-bezier(0,0,0.2,1) 120ms both; }
+.tab-dir-right .tab-panel.active .stat-row .stat-card:nth-child(4),
+.tab-dir-left  .tab-panel.active .stat-row .stat-card:nth-child(4) { animation: staggerIn 0.35s cubic-bezier(0,0,0.2,1) 180ms both; }
+
+/* ── Command Palette (enhanced QS) ─────────────────────────────── */
+.qs-result-item.active,
+.qs-result-item:focus {
+  background: rgba(59,130,246,0.12);
+  outline: none;
+}
+.qs-section-header {
+  padding: 0.35rem 1rem 0.2rem;
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-faint);
+}
+.qs-result-icon {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  width: 20px;
+  text-align: center;
+}
+.qs-result-action {
+  font-size: 0.72rem;
+  color: var(--text-faint);
+  white-space: nowrap;
+}
+
+/* ── Number count-up animation ──────────────────────────────────── */
+@keyframes countUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.count-up-enter {
+  animation: countUp 0.4s cubic-bezier(0, 0, 0.2, 1) both;
+}
 
 /* ── Focus-visible (WCAG accessibility ring) ────────────────────── */
 :focus-visible {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -99,70 +99,82 @@ body {
   display: flex;
   align-items: center;
   gap: 1rem;
-  padding: 0.65rem 1.25rem;
-  padding-top: max(0.65rem, env(safe-area-inset-top));
+  padding: 0.6rem 1.25rem;
+  padding-top: max(0.6rem, env(safe-area-inset-top));
   background: linear-gradient(180deg, var(--topbar-start) 0%, var(--bg) 100%);
   border-bottom: 1px solid var(--border);
   position: sticky;
   top: 0;
   z-index: 100;
-  flex-wrap: wrap;
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   backdrop-filter: blur(20px) saturate(180%);
 }
 
 .topbar-brand {
   display: flex;
-  align-items: baseline;
-  gap: 0.7rem;
+  align-items: center;
+  gap: 0.65rem;
   margin-right: auto;
 }
-.brand-icon { font-size: 1.25rem; line-height: 1; }
+.brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
 .brand-name {
   font-weight: 800;
-  font-size: 1.05rem;
+  font-size: 0.95rem;
   letter-spacing: -0.01em;
   background: linear-gradient(90deg, var(--accent), var(--accent-end));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
   white-space: nowrap;
+  line-height: 1;
 }
 .brand-sub {
-  font-size: 0.68rem;
-  color: var(--text-muted);
+  font-size: 0.6rem;
+  color: var(--text-faint);
   white-space: nowrap;
-  font-weight: 400;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  line-height: 1;
 }
 
-.topbar-period {
+.theme-toggle-btn {
   display: flex;
-  gap: 2px;
-  background: rgba(0,0,0,0.18);
-  border-radius: 9px;
-  padding: 3px;
-  border: 1px solid var(--border);
-}
-[data-theme="light"] .topbar-period {
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
   background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color var(--dur-fast) var(--ease-out), border-color var(--dur-fast) var(--ease-out), transform var(--dur-micro) var(--ease-out);
 }
+.theme-toggle-btn:hover { color: var(--text); border-color: var(--border-hover); transform: translateY(-1px); }
+.theme-toggle-btn:active { transform: scale(0.93); }
 
+/* Period pills now live inside .tab-nav-period — see Tab Navigation */
 .period-btn {
   background: transparent;
   border: none;
   color: var(--text-muted);
-  font-size: 0.77rem;
+  font-size: 0.73rem;
   font-weight: 600;
-  padding: 4px 10px;
+  padding: 3px 9px;
   border-radius: 6px;
   cursor: pointer;
-  transition: background 150ms cubic-bezier(0,0,0.2,1), color 150ms cubic-bezier(0,0,0.2,1), transform 150ms cubic-bezier(0,0,0.2,1);
+  transition: background var(--dur-fast) var(--ease-out), color var(--dur-fast) var(--ease-out), transform var(--dur-micro) var(--ease-out);
   font-family: inherit;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.04em;
 }
 .period-btn:hover { background: rgba(255,255,255,0.08); color: var(--text); transform: translateY(-1px); }
-.period-btn:active { transform: scale(0.97); transition-duration: 80ms; }
-[data-theme="light"] .period-btn:hover { background: var(--border); color: var(--text); transform: translateY(-1px); }
+.period-btn:active { transform: scale(0.97); }
+[data-theme="light"] .period-btn:hover { background: var(--border); color: var(--text); }
 .period-btn.active {
   background: linear-gradient(135deg, var(--accent), var(--accent-end));
   color: #fff;
@@ -172,19 +184,11 @@ body {
 .topbar-meta {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-}
-.data-badge {
-  font-size: 0.7rem;
-  background: var(--surface2);
-  color: #ffc107;
-  padding: 3px 8px;
-  border-radius: 20px;
-  border: 1px solid var(--border);
+  gap: 0.6rem;
 }
 .update-time {
-  font-size: 0.7rem;
-  color: var(--text-muted);
+  font-size: 0.68rem;
+  color: var(--text-faint);
   white-space: nowrap;
 }
 
@@ -194,20 +198,20 @@ body {
   border: none;
   border-bottom: 2px solid transparent;
   color: var(--text-muted);
-  font-size: 0.82rem;
+  font-size: 0.8rem;
   font-weight: 500;
-  padding: 0.7rem 1rem;
+  padding: 0.65rem 0.85rem;
   cursor: pointer;
-  transition: color 150ms cubic-bezier(0,0,0.2,1), border-color 150ms cubic-bezier(0,0,0.2,1), background 150ms cubic-bezier(0,0,0.2,1), transform 80ms cubic-bezier(0,0,0.2,1);
+  transition: color var(--dur-fast) var(--ease-out), border-color var(--dur-fast) var(--ease-out), background var(--dur-fast) var(--ease-out);
   white-space: nowrap;
   font-family: inherit;
   display: flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: 0.45rem;
   border-radius: 0;
 }
-.tab-btn:hover { color: var(--text); background: rgba(99,179,237,0.04); }
-.tab-btn:active { transform: scale(0.97); }
+.tab-btn:hover { color: var(--text); background: rgba(99,179,237,0.05); }
+.tab-btn:active { opacity: 0.75; }
 .tab-btn.active {
   color: var(--accent);
   border-bottom-color: var(--accent);
@@ -1359,8 +1363,14 @@ body {
   .strat-stat-row  { grid-template-columns: 80px repeat(3, 1fr); }
 }
 
+@media (max-width: 720px) {
+  .tab-nav-period { padding: 0 0.5rem; }
+  .period-btn     { padding: 3px 6px; font-size: 0.68rem; }
+  .tab-group-label { display: none; }
+}
+
 @media (max-width: 600px) {
-  .topbar       { padding: 0.7rem 1rem; gap: 0.6rem; }
+  .topbar       { padding: 0.55rem 0.85rem; gap: 0.5rem; }
   .brand-sub    { display: none; }
   .tab-panel    { padding: 0.875rem; }
   .stat-row     { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
@@ -1986,16 +1996,32 @@ body {
 .tab-nav {
   display: flex;
   align-items: stretch;
-  gap: 0;
   background: var(--surface);
   border-bottom: 1px solid var(--border);
   position: sticky;
-  top: 92px; /* below TopBar + TickerBar */
+  top: 88px; /* below TopBar + TickerBar */
   z-index: 89;
+}
+
+.tab-nav-tabs {
+  display: flex;
+  align-items: stretch;
   overflow-x: auto;
   scrollbar-width: none;
+  flex: 1;
+  min-width: 0;
 }
-.tab-nav::-webkit-scrollbar { display: none; }
+.tab-nav-tabs::-webkit-scrollbar { display: none; }
+
+.tab-nav-period {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 0 1rem;
+  border-left: 1px solid var(--border);
+  background: var(--surface);
+  flex-shrink: 0;
+}
 
 .tab-group {
   display: flex;
@@ -2006,15 +2032,15 @@ body {
 .tab-group-label {
   display: flex;
   align-items: center;
-  padding: 0 0.6rem 0 0.9rem;
-  font-size: 0.62rem;
+  padding: 0 0.5rem 0 0.85rem;
+  font-size: 0.58rem;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.09em;
-  color: var(--text-muted);
+  letter-spacing: 0.1em;
+  color: var(--text-faint);
   white-space: nowrap;
   border-right: 1px solid var(--border);
-  opacity: 0.7;
+  opacity: 0.8;
 }
 
 .tab-sep {
@@ -2022,23 +2048,6 @@ body {
   background: var(--border);
   margin: 6px 0;
 }
-
-/* Keyboard shortcut badge — hidden until hover */
-.tab-kbd {
-  display: none;
-  font-size: 0.6rem;
-  padding: 1px 4px;
-  border: 1px solid var(--border);
-  border-radius: 3px;
-  background: var(--surface2);
-  color: var(--text-muted);
-  font-family: inherit;
-  margin-left: 4px;
-  vertical-align: middle;
-  line-height: 1.4;
-  pointer-events: none;
-}
-.tab-btn:hover .tab-kbd { display: inline; }
 
 /* ── Quick Search (Cmd+K) ──────────────────────────────────────── */
 .qs-overlay {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -202,14 +202,48 @@ body {
 [data-theme="light"] .tab-btn:hover { background: rgba(59,130,246,0.05); }
 [data-theme="light"] .tab-btn.active { color: var(--accent2); border-bottom-color: var(--accent2); }
 
+/* ── Skeleton shimmer ───────────────────────────────────────────── */
+@keyframes shimmer {
+  0%   { background-position: -200% center; }
+  100% { background-position:  200% center; }
+}
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--surface2) 25%,
+    rgba(255,255,255,0.045) 50%,
+    var(--surface2) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease infinite;
+  border-radius: var(--radius-sm);
+}
+[data-theme="light"] .skeleton {
+  background: linear-gradient(
+    90deg,
+    #dde8f8 25%,
+    #eef3fc 50%,
+    #dde8f8 75%
+  );
+  background-size: 200% 100%;
+}
+
 /* ── Tab Panels ─────────────────────────────────────────────────── */
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 .tab-panel {
   display: none;
   padding: 1.25rem;
   max-width: 1400px;
   margin: 0 auto;
 }
-.tab-panel.active { display: block; }
+.tab-panel.active {
+  display: block;
+  animation: fadeInUp 0.22s ease;
+}
 
 /* ── Stat Cards Row ─────────────────────────────────────────────── */
 .stat-row {
@@ -1144,27 +1178,131 @@ body {
   display: none;
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.55);
-  backdrop-filter: blur(4px);
+  background: rgba(6, 12, 24, 0.82);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   z-index: 999;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
 }
 .loader-overlay.active { display: flex; }
+[data-theme="light"] .loader-overlay { background: rgba(238,243,252,0.88); }
 
-.loader-spinner {
-  width: 40px;
-  height: 40px;
-  border: 3px solid var(--border);
+.loader-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.35rem;
+  background: var(--surface);
+  border: 1px solid var(--border-hover);
+  border-radius: 20px;
+  padding: 2.5rem 3.25rem;
+  box-shadow: 0 32px 80px rgba(0,0,0,0.65), 0 0 0 1px rgba(99,179,237,0.07) inset;
+  min-width: 290px;
+  position: relative;
+  overflow: hidden;
+}
+.loader-card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-end));
+}
+[data-theme="light"] .loader-card {
+  background: #fff;
+  box-shadow: 0 24px 64px rgba(0,0,0,0.12);
+}
+
+.loader-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+.loader-brand-icon {
+  font-size: 1.3rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent-end));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.loader-brand-name {
+  font-size: 1.05rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  background: linear-gradient(90deg, var(--accent), var(--accent-end));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.loader-spinner-wrap {
+  position: relative;
+  width: 54px;
+  height: 54px;
+}
+.loader-ring {
+  position: absolute;
+  inset: 0;
+  width: 54px;
+  height: 54px;
+  border: 2.5px solid var(--border);
   border-top-color: var(--accent);
+  border-right-color: var(--accent-end);
   border-radius: 50%;
-  animation: spin 0.8s linear infinite;
+  animation: spin 0.85s linear infinite;
+}
+.loader-ring-inner {
+  position: absolute;
+  inset: 11px;
+  width: 32px;
+  height: 32px;
+  border: 2px solid var(--border);
+  border-bottom-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite reverse;
 }
 @keyframes spin { to { transform: rotate(360deg); } }
 
-.loader-text { color: var(--text-muted); font-size: 0.85rem; }
+.loader-step-label {
+  font-size: 0.81rem;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 1.25em;
+  transition: opacity 0.3s;
+}
+.loader-step-icon { font-size: 0.95rem; }
+
+.loader-progress {
+  width: 180px;
+  height: 3px;
+  background: var(--border);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.loader-progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-end));
+  border-radius: 2px;
+  transition: width 0.55s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* period-change shimmer on tab btn */
+.period-btn.refreshing {
+  position: relative;
+  overflow: hidden;
+}
+.period-btn.refreshing::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent 25%, rgba(255,255,255,0.15) 50%, transparent 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1s linear infinite;
+  border-radius: 6px;
+}
 
 /* ── Scrollbar ──────────────────────────────────────────────────── */
 ::-webkit-scrollbar { width: 6px; height: 6px; }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" crossOrigin="anonymous" />
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" media="print" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500&display=swap"
+        />
       </head>
       <body>
         <script dangerouslySetInnerHTML={{__html: `

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
           rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"
         />
       </head>
       <body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -159,8 +159,6 @@ export default function DashboardPage() {
   return (
     <>
       <TopBar
-        period={period}
-        onPeriodChange={setPeriod}
         updateTime={updateTime}
         marketStatus={marketStatus}
       />
@@ -170,7 +168,12 @@ export default function DashboardPage() {
         onSelectSymbol={handleViewChart}
         flashMap={flashMap}
       />
-      <TabNav activeTab={activeTab} onTabChange={changeTab} />
+      <TabNav
+        activeTab={activeTab}
+        onTabChange={changeTab}
+        period={period}
+        onPeriodChange={setPeriod}
+      />
       <QuickSearch
         quotes={quotes}
         onSelect={handleSelectSymbolForTrend}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,8 @@ import Loader from '@/components/layout/Loader';
 import MarketTickerBar from '@/components/layout/MarketTickerBar';
 import QuickSearch from '@/components/layout/QuickSearch';
 import type { Quote, MacroNode, MockEvent, CycleRow, CrisisEvent, CorrelationMatrix, Period } from '@/types';
+
+const TAB_ORDER = ['macro', 'overview', 'trends', 'backtest', 'flow', 'cycle', 'crisis', 'correlation'];
 import { getMarketStatus, getPollInterval, type MarketStatus } from '@/lib/utils/marketHours';
 
 // Dynamic imports to avoid SSR for canvas/chart components
@@ -38,6 +40,7 @@ const CorrelationTab = dynamic(() => import('@/components/tabs/CorrelationTab'),
 export default function DashboardPage() {
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState('macro');
+  const [tabDir, setTabDir] = useState<'left' | 'right'>('right');
   const [period, setPeriod] = useState<Period>('1d');
   const [quotes, setQuotes] = useState<Quote[]>([]);
   const [macroData, setMacroData] = useState<MacroNode | null>(null);
@@ -131,19 +134,26 @@ export default function DashboardPage() {
     return () => clearTimeout(timerId);
   }, []);
 
+  function changeTab(newTab: string) {
+    const oldIdx = TAB_ORDER.indexOf(activeTab);
+    const newIdx = TAB_ORDER.indexOf(newTab);
+    setTabDir(newIdx >= oldIdx ? 'right' : 'left');
+    setActiveTab(newTab);
+  }
+
   // Add to multi-symbol comparison in Trends tab
   function handleSelectSymbolForTrend(sym: string) {
     setSelected(prev => {
       if (prev.includes(sym)) return prev;
       return prev.length >= 6 ? [...prev.slice(1), sym] : [...prev, sym];
     });
-    setActiveTab('trends');
+    changeTab('trends');
   }
 
   // Navigate to Trends tab with only this single symbol (solo chart view)
   function handleViewChart(sym: string) {
     setSelected([sym]);
-    setActiveTab('trends');
+    changeTab('trends');
   }
 
   return (
@@ -160,9 +170,17 @@ export default function DashboardPage() {
         onSelectSymbol={handleViewChart}
         flashMap={flashMap}
       />
-      <TabNav activeTab={activeTab} onTabChange={setActiveTab} />
-      <QuickSearch quotes={quotes} onSelect={handleSelectSymbolForTrend} />
+      <TabNav activeTab={activeTab} onTabChange={changeTab} />
+      <QuickSearch
+        quotes={quotes}
+        onSelect={handleSelectSymbolForTrend}
+        onTabChange={changeTab}
+        onPeriodChange={setPeriod}
+        activeTab={activeTab}
+        period={period}
+      />
       <Loader show={loading} />
+      <div className={`tab-dir-${tabDir}`}>
       {activeTab === 'macro' && (
         <MacroTab macroData={macroData} period={period} />
       )}
@@ -195,6 +213,7 @@ export default function DashboardPage() {
       {activeTab === 'correlation' && (
         <CorrelationTab correlationData={correlationData} />
       )}
+      </div>
     </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -93,6 +93,7 @@ export default function DashboardPage() {
   // Refresh macro when period changes (skip if quotes not loaded yet)
   useEffect(() => {
     if (!quotes.length) return;
+    setMacroData(null); // show skeleton while refetching
     fetchMacro(period).then(setMacroData);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [period]);

--- a/src/components/layout/Loader.tsx
+++ b/src/components/layout/Loader.tsx
@@ -1,9 +1,48 @@
+'use client';
+import { useState, useEffect } from 'react';
+
 interface Props { show: boolean }
+
+const STEPS = [
+  { icon: '📡', label: 'Fetching market quotes' },
+  { icon: '🌐', label: 'Computing macro flows' },
+  { icon: '📊', label: 'Loading sector data' },
+  { icon: '⚡', label: 'Initialising charts' },
+];
+
 export default function Loader({ show }: Props) {
-  return show ? (
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    if (!show) { setStep(0); return; }
+    const t = setInterval(() => setStep(s => Math.min(s + 1, STEPS.length - 1)), 650);
+    return () => clearInterval(t);
+  }, [show]);
+
+  if (!show) return null;
+
+  return (
     <div className="loader-overlay active">
-      <div className="loader-spinner" />
-      <div className="loader-text">載入市場數據中…</div>
+      <div className="loader-card">
+        <div className="loader-brand">
+          <span className="loader-brand-icon">◈</span>
+          <span className="loader-brand-name">Fund Flow</span>
+        </div>
+        <div className="loader-spinner-wrap">
+          <div className="loader-ring" />
+          <div className="loader-ring-inner" />
+        </div>
+        <div className="loader-step-label">
+          <span className="loader-step-icon">{STEPS[step].icon}</span>
+          {STEPS[step].label}
+        </div>
+        <div className="loader-progress">
+          <div
+            className="loader-progress-bar"
+            style={{ width: `${((step + 1) / STEPS.length) * 100}%` }}
+          />
+        </div>
+      </div>
     </div>
-  ) : null;
+  );
 }

--- a/src/components/layout/QuickSearch.tsx
+++ b/src/components/layout/QuickSearch.tsx
@@ -1,17 +1,47 @@
 'use client';
-import { useState, useEffect, useRef, useMemo } from 'react';
-import type { Quote } from '@/types';
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import type { Quote, Period } from '@/types';
 import { SECTOR_COLORS, changeTextColor, fmtPct } from '@/lib/utils/colors';
+
+const TABS = [
+  { id: 'macro',       label: 'Macro Flow',      icon: '🌐' },
+  { id: 'overview',   label: 'Overview',         icon: '📊' },
+  { id: 'trends',     label: 'Trend Analysis',   icon: '📈' },
+  { id: 'backtest',   label: 'Backtest',          icon: '🔬' },
+  { id: 'flow',       label: 'Flow & Chips',      icon: '📡' },
+  { id: 'cycle',      label: 'Events & Cycles',   icon: '📅' },
+  { id: 'crisis',     label: 'Crisis Atlas',      icon: '🚨' },
+  { id: 'correlation',label: 'Correlation',       icon: '🔗' },
+];
+
+const PERIODS: Period[] = ['1d', '5d', '1m', '3m', '6m', '1y', 'ytd'];
+
+interface QSItem {
+  type: 'etf' | 'tab' | 'period';
+  id: string;
+  label: string;
+  subLabel?: string;
+  icon?: string;
+  color?: string;
+  pct?: number;
+  action?: string;
+}
 
 interface Props {
   quotes: Quote[];
   onSelect: (sym: string) => void;
+  onTabChange?: (tab: string) => void;
+  onPeriodChange?: (p: Period) => void;
+  activeTab?: string;
+  period?: Period;
 }
 
-export default function QuickSearch({ quotes, onSelect }: Props) {
-  const [open, setOpen]   = useState(false);
-  const [query, setQuery] = useState('');
-  const inputRef          = useRef<HTMLInputElement>(null);
+export default function QuickSearch({ quotes, onSelect, onTabChange, onPeriodChange, activeTab, period }: Props) {
+  const [open, setOpen]         = useState(false);
+  const [query, setQuery]       = useState('');
+  const [activeIdx, setActiveIdx] = useState(0);
+  const inputRef                = useRef<HTMLInputElement>(null);
+  const listRef                 = useRef<HTMLDivElement>(null);
 
   // Cmd+K / Ctrl+K to open
   useEffect(() => {
@@ -29,64 +59,218 @@ export default function QuickSearch({ quotes, onSelect }: Props) {
   useEffect(() => {
     if (open) {
       setQuery('');
+      setActiveIdx(0);
       setTimeout(() => inputRef.current?.focus(), 30);
     }
   }, [open]);
 
-  const results = useMemo(() => {
-    if (!query.trim()) return quotes.slice(0, 12);
-    const q = query.toLowerCase();
-    return quotes.filter(
-      r => r.symbol.toLowerCase().includes(q) || r.name.toLowerCase().includes(q),
-    ).slice(0, 12);
-  }, [quotes, query]);
+  const items = useMemo<QSItem[]>(() => {
+    const q = query.toLowerCase().trim();
 
-  function pick(sym: string) {
-    onSelect(sym);
+    if (!q) {
+      // Default: show tabs + top ETFs
+      const tabItems: QSItem[] = TABS.map(t => ({
+        type: 'tab',
+        id: t.id,
+        label: t.label,
+        icon: t.icon,
+        subLabel: activeTab === t.id ? 'Current tab' : 'Go to tab',
+        action: 'tab',
+      }));
+      const etfItems: QSItem[] = quotes.slice(0, 8).map(r => ({
+        type: 'etf',
+        id: r.symbol,
+        label: r.symbol,
+        subLabel: r.name,
+        color: SECTOR_COLORS[r.sector],
+        pct: r.change_1d,
+        action: 'chart',
+      }));
+      return [...tabItems, ...etfItems];
+    }
+
+    const results: QSItem[] = [];
+
+    // Tabs
+    TABS.filter(t =>
+      t.label.toLowerCase().includes(q) || t.id.includes(q)
+    ).forEach(t => results.push({
+      type: 'tab', id: t.id, label: t.label, icon: t.icon,
+      subLabel: 'Go to tab', action: 'tab',
+    }));
+
+    // Periods
+    PERIODS.filter(p => p.includes(q) || (q === '1' && p.startsWith('1'))).forEach(p => results.push({
+      type: 'period', id: p, label: `Set period: ${p.toUpperCase()}`,
+      icon: '⏱', subLabel: period === p ? 'Current period' : 'Change period',
+      action: 'period',
+    }));
+
+    // ETFs
+    quotes.filter(r =>
+      r.symbol.toLowerCase().includes(q) || r.name.toLowerCase().includes(q)
+    ).slice(0, 8).forEach(r => results.push({
+      type: 'etf', id: r.symbol, label: r.symbol,
+      subLabel: r.name, color: SECTOR_COLORS[r.sector],
+      pct: r.change_1d, action: 'chart',
+    }));
+
+    return results;
+  }, [quotes, query, activeTab, period]);
+
+  const execute = useCallback((item: QSItem) => {
+    if (item.type === 'etf') {
+      onSelect(item.id);
+    } else if (item.type === 'tab' && onTabChange) {
+      onTabChange(item.id);
+    } else if (item.type === 'period' && onPeriodChange) {
+      onPeriodChange(item.id as Period);
+    }
     setOpen(false);
+  }, [onSelect, onTabChange, onPeriodChange]);
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIdx(i => Math.min(i + 1, items.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIdx(i => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (items[activeIdx]) execute(items[activeIdx]);
+    }
   }
+
+  // Scroll active item into view
+  useEffect(() => {
+    const el = listRef.current?.querySelector<HTMLElement>('.qs-result-item.active');
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [activeIdx]);
+
+  // Reset active index when query changes
+  useEffect(() => { setActiveIdx(0); }, [query]);
 
   if (!open) return null;
 
+  const hasTabResults  = items.some(i => i.type === 'tab');
+  const hasEtfResults  = items.some(i => i.type === 'etf');
+  const hasPeriodResults = items.some(i => i.type === 'period');
+
   return (
     <div className="qs-overlay" onClick={() => setOpen(false)}>
-      <div className="qs-modal" onClick={e => e.stopPropagation()} role="dialog" aria-modal aria-label="Symbol search">
+      <div
+        className="qs-modal"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal
+        aria-label="Command palette"
+      >
         <div className="qs-header">
           <span className="qs-icon">⌕</span>
           <input
             ref={inputRef}
             className="qs-input"
-            placeholder="Search symbols or names…"
+            placeholder="Search ETFs, navigate tabs, change period…"
             value={query}
             onChange={e => setQuery(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === 'Enter' && results[0]) pick(results[0].symbol);
-            }}
+            onKeyDown={onKeyDown}
           />
           <kbd className="qs-esc">Esc</kbd>
         </div>
-        <div className="qs-results">
-          {results.map(r => (
-            <button key={r.symbol} className="qs-result-item" onClick={() => pick(r.symbol)}>
-              <span
-                className="qs-sym"
-                style={{ color: SECTOR_COLORS[r.sector] ?? '#cdd9e5' }}
-              >{r.symbol}</span>
-              <span className="qs-name">{r.name}</span>
-              <span className="qs-sector">{r.sector}</span>
-              <span className="qs-pct" style={{ color: changeTextColor(r.change_1d) }}>
-                {fmtPct(r.change_1d)}
-              </span>
-            </button>
-          ))}
-          {!results.length && (
-            <div className="qs-empty">No symbols match "{query}"</div>
+        <div className="qs-results" ref={listRef}>
+          {!items.length && (
+            <div className="qs-empty">No results for "{query}"</div>
           )}
+
+          {/* Tabs section */}
+          {hasTabResults && !query && (
+            <div className="qs-section-header">Navigate</div>
+          )}
+          {items.map((item, idx) => {
+            if (item.type === 'tab') {
+              const isActive = activeTab === item.id;
+              return (
+                <button
+                  key={`tab-${item.id}`}
+                  className={`qs-result-item${activeIdx === idx ? ' active' : ''}`}
+                  onClick={() => execute(item)}
+                  onMouseEnter={() => setActiveIdx(idx)}
+                >
+                  <span className="qs-result-icon">{item.icon}</span>
+                  <span className="qs-name" style={{ color: isActive ? 'var(--accent)' : 'var(--text)' }}>
+                    {item.label}
+                    {isActive && <span style={{ marginLeft: 6, fontSize: '0.65rem', color: 'var(--accent)', opacity: 0.7 }}>●</span>}
+                  </span>
+                  <span className="qs-sector">{item.subLabel}</span>
+                  <span className="qs-result-action">→</span>
+                </button>
+              );
+            }
+            return null;
+          })}
+
+          {/* Period section */}
+          {hasPeriodResults && (
+            <div className="qs-section-header">Period</div>
+          )}
+          {items.map((item, idx) => {
+            if (item.type === 'period') {
+              const isCurrent = period === item.id;
+              return (
+                <button
+                  key={`period-${item.id}`}
+                  className={`qs-result-item${activeIdx === idx ? ' active' : ''}`}
+                  onClick={() => execute(item)}
+                  onMouseEnter={() => setActiveIdx(idx)}
+                >
+                  <span className="qs-result-icon">{item.icon}</span>
+                  <span className="qs-name" style={{ color: isCurrent ? 'var(--accent)' : 'var(--text)' }}>
+                    {item.label}
+                  </span>
+                  <span className="qs-sector">{isCurrent ? 'Active' : ''}</span>
+                  <span className="qs-result-action">→</span>
+                </button>
+              );
+            }
+            return null;
+          })}
+
+          {/* ETF section */}
+          {hasEtfResults && !query && (
+            <div className="qs-section-header">ETFs</div>
+          )}
+          {hasEtfResults && query && (
+            <div className="qs-section-header">Symbols</div>
+          )}
+          {items.map((item, idx) => {
+            if (item.type === 'etf') {
+              return (
+                <button
+                  key={`etf-${item.id}`}
+                  className={`qs-result-item${activeIdx === idx ? ' active' : ''}`}
+                  onClick={() => execute(item)}
+                  onMouseEnter={() => setActiveIdx(idx)}
+                >
+                  <span className="qs-sym" style={{ color: item.color ?? 'var(--accent)' }}>{item.label}</span>
+                  <span className="qs-name">{item.subLabel}</span>
+                  <span className="qs-sector"></span>
+                  {item.pct !== undefined && (
+                    <span className="qs-pct" style={{ color: changeTextColor(item.pct) }}>
+                      {fmtPct(item.pct)}
+                    </span>
+                  )}
+                </button>
+              );
+            }
+            return null;
+          })}
         </div>
         <div className="qs-footer">
-          <span><kbd>↵</kbd> to chart first result</span>
-          <span><kbd>Esc</kbd> to close</span>
-          <span><kbd>⌘K</kbd> to toggle</span>
+          <span><kbd>↑↓</kbd> navigate</span>
+          <span><kbd>↵</kbd> select</span>
+          <span><kbd>Esc</kbd> close</span>
+          <span><kbd>⌘K</kbd> toggle</span>
         </div>
       </div>
     </div>

--- a/src/components/layout/TabNav.tsx
+++ b/src/components/layout/TabNav.tsx
@@ -1,42 +1,49 @@
 'use client';
 import { useEffect } from 'react';
+import {
+  Globe, BarChart2, TrendingUp, FlaskConical,
+  Activity, CalendarDays, AlertTriangle, Network,
+} from 'lucide-react';
+import type { Period } from '@/types';
 
-interface Props {
-  activeTab: string;
-  onTabChange: (tab: string) => void;
-}
+const PERIODS: Period[] = ['1d', '5d', '1m', '3m', '6m', '1y', 'ytd'];
 
 const TAB_GROUPS = [
   {
     label: 'Markets',
     tabs: [
-      { id: 'macro',    label: '🌐 Macro Flow',      key: '1' },
-      { id: 'overview', label: '📊 Overview',         key: '2' },
-      { id: 'trends',   label: '📈 Trend Analysis',   key: '3' },
+      { id: 'macro',    label: 'Macro Flow',     key: '1', Icon: Globe },
+      { id: 'overview', label: 'Overview',        key: '2', Icon: BarChart2 },
+      { id: 'trends',   label: 'Trend Analysis',  key: '3', Icon: TrendingUp },
     ],
   },
   {
     label: 'Portfolio',
     tabs: [
-      { id: 'backtest', label: '🔬 Backtest',          key: '4' },
-      { id: 'flow',     label: '📡 Flow & Chips',      key: '5' },
+      { id: 'backtest', label: 'Backtest',        key: '4', Icon: FlaskConical },
+      { id: 'flow',     label: 'Flow & Chips',    key: '5', Icon: Activity },
     ],
   },
   {
     label: 'Research',
     tabs: [
-      { id: 'cycle',       label: '📅 Events & Cycles', key: '6' },
-      { id: 'crisis',      label: '🚨 Crisis Atlas',    key: '7' },
-      { id: 'correlation', label: '🔗 Correlation',     key: '8' },
+      { id: 'cycle',        label: 'Events & Cycles', key: '6', Icon: CalendarDays },
+      { id: 'crisis',       label: 'Crisis Atlas',    key: '7', Icon: AlertTriangle },
+      { id: 'correlation',  label: 'Correlation',     key: '8', Icon: Network },
     ],
   },
 ];
 
-// Flat list used for keyboard shortcut lookup
 const ALL_TABS = TAB_GROUPS.flatMap(g => g.tabs);
 
-export default function TabNav({ activeTab, onTabChange }: Props) {
-  // Alt+1–8 keyboard shortcuts
+interface Props {
+  activeTab: string;
+  onTabChange: (tab: string) => void;
+  period: Period;
+  onPeriodChange: (p: Period) => void;
+}
+
+export default function TabNav({ activeTab, onTabChange, period, onPeriodChange }: Props) {
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (!e.altKey) return;
@@ -49,24 +56,37 @@ export default function TabNav({ activeTab, onTabChange }: Props) {
 
   return (
     <nav className="tab-nav" aria-label="Main navigation">
-      {TAB_GROUPS.map((group, gi) => (
-        <div key={group.label} className="tab-group">
-          <span className="tab-group-label">{group.label}</span>
-          {group.tabs.map(t => (
-            <button
-              key={t.id}
-              className={`tab-btn${activeTab === t.id ? ' active' : ''}`}
-              onClick={() => onTabChange(t.id)}
-              title={`Alt+${t.key}`}
-              aria-current={activeTab === t.id ? 'page' : undefined}
-            >
-              {t.label}
-              <kbd className="tab-kbd">Alt+{t.key}</kbd>
-            </button>
-          ))}
-          {gi < TAB_GROUPS.length - 1 && <div className="tab-sep" aria-hidden />}
-        </div>
-      ))}
+      <div className="tab-nav-tabs">
+        {TAB_GROUPS.map((group, gi) => (
+          <div key={group.label} className="tab-group">
+            <span className="tab-group-label">{group.label}</span>
+            {group.tabs.map(t => (
+              <button
+                key={t.id}
+                className={`tab-btn${activeTab === t.id ? ' active' : ''}`}
+                onClick={() => onTabChange(t.id)}
+                aria-current={activeTab === t.id ? 'page' : undefined}
+              >
+                <t.Icon size={14} strokeWidth={1.75} aria-hidden />
+                {t.label}
+              </button>
+            ))}
+            {gi < TAB_GROUPS.length - 1 && <div className="tab-sep" aria-hidden />}
+          </div>
+        ))}
+      </div>
+
+      <div className="tab-nav-period" aria-label="Time period">
+        {PERIODS.map(p => (
+          <button
+            key={p}
+            className={`period-btn${period === p ? ' active' : ''}`}
+            onClick={() => onPeriodChange(p)}
+          >
+            {p.toUpperCase()}
+          </button>
+        ))}
+      </div>
     </nav>
   );
 }

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,19 +1,31 @@
 'use client';
 import { useState, useEffect } from 'react';
-import type { Period } from '@/types';
 import type { MarketStatus } from '@/lib/utils/marketHours';
 import { MARKET_STATUS_LABEL } from '@/lib/utils/marketHours';
-
-const PERIODS: Period[] = ['1d', '5d', '1m', '3m', '6m', '1y', 'ytd'];
+import { Sun, Moon } from 'lucide-react';
 
 interface Props {
-  period: Period;
-  onPeriodChange: (p: Period) => void;
   updateTime: string;
   marketStatus: MarketStatus;
 }
 
-export default function TopBar({ period, onPeriodChange, updateTime, marketStatus }: Props) {
+function LogoMark() {
+  return (
+    <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
+      <rect width="28" height="28" rx="7" fill="url(#logo-g)" />
+      <polyline points="5,21 10,14 16,17 23,8" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      <circle cx="23" cy="8" r="2" fill="white" />
+      <defs>
+        <linearGradient id="logo-g" x1="0" y1="0" x2="28" y2="28" gradientUnits="userSpaceOnUse">
+          <stop offset="0%" stopColor="#3b82f6" />
+          <stop offset="100%" stopColor="#8b5cf6" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}
+
+export default function TopBar({ updateTime, marketStatus }: Props) {
   const [theme, setTheme] = useState<'dark' | 'light'>('dark');
 
   useEffect(() => {
@@ -31,40 +43,29 @@ export default function TopBar({ period, onPeriodChange, updateTime, marketStatu
   return (
     <header className="topbar">
       <div className="topbar-brand">
-        <span className="brand-icon">⚡</span>
-        <span className="brand-name">Fund Flow</span>
-        <span className="brand-sub">Global Capital Flow Analytics</span>
+        <LogoMark />
+        <div className="brand-text">
+          <span className="brand-name">Fund Flow</span>
+          <span className="brand-sub">Global Capital Analytics</span>
+        </div>
       </div>
-      <div className="topbar-period" id="periodBar">
-        {PERIODS.map(p => (
-          <button key={p} className={`period-btn${period === p ? ' active' : ''}`}
-            onClick={() => onPeriodChange(p)}>
-            {p.toUpperCase()}
-          </button>
-        ))}
-      </div>
+
       <div className="topbar-meta">
-        <button
-          onClick={toggleTheme}
-          title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
-          style={{
-            background: 'var(--surface2)',
-            border: '1px solid var(--border)',
-            color: 'var(--text)',
-            padding: '4px 8px',
-            borderRadius: 'var(--radius-sm)',
-            cursor: 'pointer',
-            fontSize: '1rem',
-            lineHeight: 1,
-          }}
-        >
-          {theme === 'dark' ? '☀️' : '🌙'}
-        </button>
         <span className={`market-status-badge market-${marketStatus}`}>
           <span className="market-dot" />
           {MARKET_STATUS_LABEL[marketStatus]}
         </span>
         <span className="update-time">{updateTime}</span>
+        <button
+          onClick={toggleTheme}
+          title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+          className="theme-toggle-btn"
+          aria-label="Toggle theme"
+        >
+          {theme === 'dark'
+            ? <Sun size={15} strokeWidth={1.75} />
+            : <Moon size={15} strokeWidth={1.75} />}
+        </button>
       </div>
     </header>
   );

--- a/src/components/tabs/CorrelationTab.tsx
+++ b/src/components/tabs/CorrelationTab.tsx
@@ -342,7 +342,13 @@ export default function CorrelationTab({ correlationData }: Props) {
     return (
       <main className="tab-panel active">
         <div className="panel">
-          <p style={{ color: 'var(--text-muted)' }}>Loading…</p>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 220px', gap: '1.25rem' }}>
+            <div className="skeleton" style={{ height: 380 }} />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <div className="skeleton" style={{ height: 180 }} />
+              <div className="skeleton" style={{ height: 180 }} />
+            </div>
+          </div>
         </div>
       </main>
     );

--- a/src/components/tabs/CrisisTab.tsx
+++ b/src/components/tabs/CrisisTab.tsx
@@ -432,7 +432,14 @@ export default function CrisisTab({ crisisData, allEvents }: Props) {
   if (!crisisData || !allEvents) {
     return (
       <main className="tab-panel active">
-        <div className="panel"><p style={{ color: 'var(--text-muted)' }}>Loading…</p></div>
+        <div className="crisis-wrap">
+          <div className="skeleton" style={{ height: 60, borderRadius: 'var(--radius)' }} />
+          <div className="crisis-cards-grid">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="skeleton" style={{ height: 140, borderRadius: 'var(--radius)' }} />
+            ))}
+          </div>
+        </div>
       </main>
     );
   }

--- a/src/components/tabs/CycleTab.tsx
+++ b/src/components/tabs/CycleTab.tsx
@@ -163,7 +163,12 @@ export default function CycleTab({ eventsData, cycleData }: Props) {
             </div>
           </div>
         ) : (
-          <p style={{ color: '#64748b' }}>Loading…</p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <div className="skeleton" style={{ height: 320 }} />
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 8 }}>
+              {[1,2,3,4].map(i => <div key={i} className="skeleton" style={{ height: 80 }} />)}
+            </div>
+          </div>
         )}
       </section>
 

--- a/src/components/tabs/FlowChipsTab.tsx
+++ b/src/components/tabs/FlowChipsTab.tsx
@@ -44,7 +44,13 @@ export default function FlowChipsTab({ quotes, period }: Props) {
     return (
       <main className="tab-panel active">
         <div className="panel">
-          <p style={{ color: '#64748b' }}>Loading…</p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <div className="skeleton" style={{ height: 260 }} />
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+              <div className="skeleton" style={{ height: 200 }} />
+              <div className="skeleton" style={{ height: 200 }} />
+            </div>
+          </div>
         </div>
       </main>
     );

--- a/src/components/tabs/MacroTab.tsx
+++ b/src/components/tabs/MacroTab.tsx
@@ -25,7 +25,29 @@ export default function MacroTab({ macroData, period }: Props) {
   // Reset path when period changes
   useEffect(() => { setMacroPath(['global']); }, [period]);
 
-  if (!macroData) return <div className="panel"><p style={{color:'var(--text-muted)'}}>Loading…</p></div>;
+  if (!macroData) return (
+    <div className="tab-panel active">
+      <div className="panel">
+        <div style={{ display: 'flex', gap: '1.5rem', marginBottom: '1.5rem' }}>
+          {[80, 110, 95].map((w, i) => (
+            <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <div className="skeleton" style={{ width: w * 0.7, height: 11 }} />
+              <div className="skeleton" style={{ width: w, height: 20 }} />
+            </div>
+          ))}
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '260px 1fr', gap: '1.5rem', marginBottom: '1.5rem' }}>
+          <div className="skeleton" style={{ height: 200 }} />
+          <div className="skeleton" style={{ height: 200 }} />
+        </div>
+        <div className="macro-cards">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="skeleton" style={{ height: 88 }} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
 
   const currentId = macroPath[macroPath.length - 1];
   const current = findNode(macroData, currentId) ?? macroData;

--- a/src/components/tabs/OverviewTab.tsx
+++ b/src/components/tabs/OverviewTab.tsx
@@ -199,7 +199,22 @@ export default function OverviewTab({ quotes, period, onSelectSymbolForTrend }: 
 
   if (!quotes.length) return (
     <main className="tab-panel active">
-      <div className="panel"><p style={{color:'#64748b'}}>Loading…</p></div>
+      <div className="stat-row" style={{ marginBottom: '1.25rem' }}>
+        {[1, 2, 3, 4].map(i => (
+          <div key={i} className="stat-card">
+            <div className="skeleton" style={{ width: 80, height: 11, marginBottom: 10 }} />
+            <div className="skeleton" style={{ width: 56, height: 28, marginBottom: 8 }} />
+            <div className="skeleton" style={{ width: 110, height: 18, marginBottom: 6 }} />
+            <div className="skeleton" style={{ width: 70, height: 13 }} />
+          </div>
+        ))}
+      </div>
+      <div className="panel">
+        <div className="skeleton" style={{ height: 340 }} />
+      </div>
+      <div className="panel">
+        <div className="skeleton" style={{ height: 240 }} />
+      </div>
     </main>
   );
 

--- a/src/components/tabs/TrendTab.tsx
+++ b/src/components/tabs/TrendTab.tsx
@@ -354,7 +354,10 @@ export default function TrendTab({ quotes, eventsData, period, selected, onSelec
 
         <div style={{ position: 'relative', minHeight: `${chartH}px` }}>
           {loading && (
-            <p style={{ color: '#64748b', textAlign: 'center', paddingTop: '2rem' }}>Loading…</p>
+            <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', gap: 8, padding: '0.5rem' }}>
+              <div className="skeleton" style={{ height: '65%', borderRadius: 'var(--radius-sm)' }} />
+              <div className="skeleton" style={{ height: '30%', borderRadius: 'var(--radius-sm)' }} />
+            </div>
           )}
           <div
             ref={chartContainerRef}


### PR DESCRIPTION
## Summary

- **Reverted visual overhaul** — restored the original blue-tinted design system (borders, accent colors, card top-stripes, gradient brand name); removed Instrument Serif display font and gold accents that were added in error
- **Command palette (⌘K)** — upgraded QuickSearch into a full command palette with three sections: tab navigation (switch to any of the 8 tabs directly), period switching (change time window from palette), and ETF search; ↑↓ arrow-key navigation with active highlight, section headers, current-tab indicator
- **Directional tab transitions** — tabs now slide in from the left or right depending on navigation direction (going forward slides from right; going backward slides from left), giving the UI a spatial orientation that feels native
- **All previous good UX work retained** — skeleton loading states on all 8 tabs, stagger animations on stat/macro cards, redesigned loader, period-change skeleton feedback, flash animations, micro-interactions

## Test plan

- [ ] Verify the design matches the original blue-tinted palette (no gold, no oversized serif fonts)
- [ ] Press ⌘K (Mac) or Ctrl+K (Win/Linux) to open the command palette
- [ ] Type a tab name (e.g. "backtest") and press Enter to navigate
- [ ] Type a period (e.g. "1y") and select to change the time window
- [ ] Type an ETF symbol (e.g. "QQQ") and select to view chart in Trend Analysis
- [ ] Use ↑↓ arrows to navigate results, Enter to confirm, Esc to close
- [ ] Navigate between tabs and notice the directional slide animation
- [ ] Confirm all skeleton/loading states still work correctly

https://claude.ai/code/session_01VayEBLZwpLnoUwDw9XJiQX