### PR TITLE
Add hero landing section with trend-first philosophy and mobile UX fixes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1530,7 +1530,7 @@ body::before {
 
 @media (max-width: 720px) {
   .tab-nav-period { padding: 0 8px; }
-  .period-btn     { padding: 6px 10px; font-size: 11px; min-height: 32px; }
+  .period-btn     { padding: 8px 10px; font-size: 11px; min-height: 40px; }
   .tab-group-label { display: none; }
 }
 
@@ -1555,10 +1555,19 @@ body::before {
   .macro-sum-val { font-size: 22px; }
 }
 
+/* ── 480px gap fill (between 380 and 600) ────────────────────────── */
+@media (max-width: 480px) {
+  .tab-nav-strip { gap: 2px; }
+  .tab-btn       { padding: 0 10px; font-size: 11px; min-height: 44px; }
+  .period-btn    { min-height: 44px; padding: 10px 10px; }
+  .macro-donut-wrap { width: 200px; }
+}
+
 @media (max-width: 380px) {
   .stat-row     { grid-template-columns: 1fr; }
   .stats-row    { grid-template-columns: 1fr; }
   .macro-cards  { grid-template-columns: 1fr 1fr; }
+  .macro-donut-wrap { width: 180px; }
 }
 
 /* ── Sankey Chart ────────────────────────────────────────────────── */
@@ -2569,4 +2578,250 @@ button:focus-visible { border-radius: var(--radius-sm); }
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
+}
+
+/* ── Hero / Landing Section ──────────────────────────────────────── */
+.hero-section {
+  position: relative;
+  min-height: 100svh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: var(--bg-0);
+  opacity: 0;
+  transition: opacity 500ms var(--ease-out);
+}
+.hero-section.hero-visible { opacity: 1; }
+
+.hero-glow-orb {
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+  filter: blur(90px);
+}
+.hero-orb-1 {
+  width: 600px; height: 600px;
+  top: -180px; left: -120px;
+  background: radial-gradient(circle, rgba(191,160,106,0.08) 0%, transparent 70%);
+}
+.hero-orb-2 {
+  width: 500px; height: 500px;
+  bottom: -120px; right: -80px;
+  background: radial-gradient(circle, rgba(74,144,217,0.06) 0%, transparent 70%);
+}
+
+.hero-inner {
+  position: relative;
+  z-index: 1;
+  max-width: 780px;
+  width: 100%;
+  padding: 80px 32px 100px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.hero-eyebrow {
+  display: flex;
+}
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 99px;
+  border: 1px solid var(--gold-line);
+  background: var(--gold-dim);
+  color: var(--gold-soft);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-headline {
+  font-family: var(--font-serif);
+  font-size: clamp(2.6rem, 7vw, 4.4rem);
+  font-weight: 400;
+  line-height: 1.12;
+  color: var(--ink-0);
+  letter-spacing: -0.02em;
+}
+.hero-headline em {
+  font-style: italic;
+  color: var(--gold-soft);
+}
+
+.hero-lead {
+  font-size: clamp(0.95rem, 2.2vw, 1.08rem);
+  line-height: 1.7;
+  color: var(--ink-1);
+  max-width: 600px;
+}
+.hero-lead strong { color: var(--ink-0); font-weight: 500; }
+.hero-lead em { font-style: italic; color: var(--gold-soft); }
+.hero-lead-2 { margin-top: -12px; }
+
+.hero-pillars {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 4px;
+}
+.hero-pillar {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  padding: 18px 20px;
+  border-radius: var(--radius);
+  background: var(--bg-2);
+  border: 1px solid var(--line-1);
+  transition: border-color var(--dur-base) var(--ease-out),
+              background var(--dur-base) var(--ease-out);
+}
+.hero-pillar:hover {
+  border-color: var(--gold-line);
+  background: var(--bg-3);
+}
+.hero-pillar-icon {
+  flex-shrink: 0;
+  width: 36px; height: 36px;
+  border-radius: var(--radius-sm);
+  background: var(--gold-dim);
+  border: 1px solid var(--gold-line);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--gold-soft);
+  margin-top: 1px;
+}
+.hero-pillar-body { display: flex; flex-direction: column; gap: 4px; }
+.hero-pillar-title {
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--ink-0);
+  letter-spacing: 0.01em;
+}
+.hero-pillar-desc {
+  font-size: 0.85rem;
+  line-height: 1.65;
+  color: var(--ink-1);
+}
+
+.hero-vs {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 0;
+  border-radius: var(--radius);
+  overflow: hidden;
+  border: 1px solid var(--line-1);
+  margin-top: 4px;
+}
+.hero-vs-col {
+  padding: 20px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.hero-vs-old { background: var(--bg-2); }
+.hero-vs-new { background: color-mix(in srgb, var(--gold-dim) 60%, var(--bg-2)); }
+.hero-vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  background: var(--bg-2);
+  border-left: 1px solid var(--line-1);
+  border-right: 1px solid var(--line-1);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+.hero-vs-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+}
+.hero-vs-new .hero-vs-label { color: var(--gold); }
+.hero-vs-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.hero-vs-list li {
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--ink-1);
+  padding-left: 14px;
+  position: relative;
+}
+.hero-vs-list li::before {
+  content: '–';
+  position: absolute;
+  left: 0;
+  color: var(--ink-2);
+}
+.hero-vs-new .hero-vs-list li { color: var(--ink-0); }
+.hero-vs-new .hero-vs-list li::before { color: var(--gold); content: '→'; }
+
+.hero-cta {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 13px 28px;
+  border-radius: var(--radius);
+  background: var(--gold);
+  color: #0A0E18;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border: none;
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out),
+              transform var(--dur-fast) var(--ease-out),
+              box-shadow var(--dur-fast) var(--ease-out);
+  box-shadow: 0 0 0 0 var(--gold-glow);
+  margin-top: 4px;
+}
+.hero-cta:hover {
+  background: var(--gold-soft);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 24px var(--gold-glow);
+}
+.hero-cta:active { transform: translateY(0); }
+.hero-cta-icon {
+  transition: transform var(--dur-fast) var(--ease-spring);
+}
+.hero-cta:hover .hero-cta-icon { transform: translateY(3px); }
+
+/* ── Hero mobile ─────────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  .hero-inner {
+    padding: 60px 20px 80px;
+    gap: 22px;
+  }
+  .hero-vs {
+    grid-template-columns: 1fr;
+  }
+  .hero-vs-divider {
+    width: 100%;
+    height: 32px;
+    border-left: none;
+    border-right: none;
+    border-top: 1px solid var(--line-1);
+    border-bottom: 1px solid var(--line-1);
+  }
+  .hero-vs-col { padding: 16px 18px; }
+  .hero-pillar { flex-direction: column; gap: 12px; }
+  .hero-cta { align-self: stretch; justify-content: center; }
+}
+@media (max-width: 380px) {
+  .hero-headline { font-size: 2.2rem; }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import TabNav from '@/components/layout/TabNav';
 import Loader from '@/components/layout/Loader';
 import MarketTickerBar from '@/components/layout/MarketTickerBar';
 import QuickSearch from '@/components/layout/QuickSearch';
+import HeroSection from '@/components/layout/HeroSection';
 import type { Quote, MacroNode, MockEvent, CycleRow, CrisisEvent, CorrelationMatrix, Period } from '@/types';
 
 const TAB_ORDER = ['macro', 'overview', 'trends', 'backtest', 'flow', 'cycle', 'crisis', 'correlation'];
@@ -39,6 +40,7 @@ const CorrelationTab = dynamic(() => import('@/components/tabs/CorrelationTab'),
 });
 
 export default function DashboardPage() {
+  const [heroShown, setHeroShown] = useState(true);
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState('macro');
   const [tabDir, setTabDir] = useState<'left' | 'right'>('right');
@@ -155,6 +157,15 @@ export default function DashboardPage() {
   function handleViewChart(sym: string) {
     setSelected([sym]);
     changeTab('trends');
+  }
+
+  function handleEnterDashboard() {
+    setHeroShown(false);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  if (heroShown) {
+    return <HeroSection onEnter={handleEnterDashboard} />;
   }
 
   return (

--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -1,0 +1,108 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { ChevronDown, TrendingUp, ArrowRightLeft, Clock } from 'lucide-react';
+
+interface Props {
+  onEnter: () => void;
+}
+
+const PILLARS = [
+  {
+    icon: TrendingUp,
+    title: 'Trend Over Price',
+    desc: 'Forget whether a stock is "cheap" or "expensive." When capital rotates into a sector, it flows regardless of valuation. We track the direction of money — not its destination price.',
+  },
+  {
+    icon: ArrowRightLeft,
+    title: 'No Such Thing as Too Late',
+    desc: "Traditional analysis asks: has this stock run too far? We ask: is the trend still intact? A trend-based view removes the anxiety of timing — what matters is the current phase of rotation, not when you arrived.",
+  },
+  {
+    icon: Clock,
+    title: 'Time-Agnostic Signals',
+    desc: 'Momentum, sector rotation, and institutional flow cycles repeat across every market era. We surface these structural rhythms so you can position alongside capital — not against it.',
+  },
+];
+
+export default function HeroSection({ onEnter }: Props) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), 60);
+    return () => clearTimeout(t);
+  }, []);
+
+  return (
+    <section className={`hero-section${visible ? ' hero-visible' : ''}`} aria-label="Platform introduction">
+      <div className="hero-glow-orb hero-orb-1" aria-hidden />
+      <div className="hero-glow-orb hero-orb-2" aria-hidden />
+
+      <div className="hero-inner">
+        <div className="hero-eyebrow">
+          <span className="hero-badge">Market Observation Platform</span>
+        </div>
+
+        <h1 className="hero-headline">
+          Stop asking<br />
+          <em>if it&apos;s too late.</em>
+        </h1>
+
+        <p className="hero-lead">
+          Most analysis tools obsess over price levels and valuations — but when a stock has
+          already run 300%, asking "is it cheap?" is the wrong question.
+        </p>
+        <p className="hero-lead hero-lead-2">
+          This platform was built around a single insight:{' '}
+          <strong>capital flows and trend rotations are time-agnostic.</strong>{' '}
+          When institutional money moves into a sector, it doesn&apos;t care whether you bought at the
+          bottom. What matters is where the trend is <em>now</em> — and where it&apos;s heading.
+        </p>
+
+        <div className="hero-pillars" role="list">
+          {PILLARS.map(({ icon: Icon, title, desc }) => (
+            <div key={title} className="hero-pillar" role="listitem">
+              <div className="hero-pillar-icon" aria-hidden>
+                <Icon size={18} strokeWidth={1.6} />
+              </div>
+              <div className="hero-pillar-body">
+                <h3 className="hero-pillar-title">{title}</h3>
+                <p className="hero-pillar-desc">{desc}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="hero-vs">
+          <div className="hero-vs-col hero-vs-old">
+            <span className="hero-vs-label">Traditional Tools Ask</span>
+            <ul className="hero-vs-list">
+              <li>Is this stock overvalued?</li>
+              <li>Have I missed the run?</li>
+              <li>What&apos;s the fair-value target?</li>
+              <li>When should I have bought?</li>
+            </ul>
+          </div>
+          <div className="hero-vs-divider" aria-hidden>vs</div>
+          <div className="hero-vs-col hero-vs-new">
+            <span className="hero-vs-label">We Ask Instead</span>
+            <ul className="hero-vs-list">
+              <li>Where is capital flowing today?</li>
+              <li>Which sectors are in trend acceleration?</li>
+              <li>Is this rotation early, mid, or late cycle?</li>
+              <li>What does institutional flow say?</li>
+            </ul>
+          </div>
+        </div>
+
+        <button
+          className="hero-cta"
+          onClick={onEnter}
+          aria-label="Open the dashboard"
+        >
+          Open Dashboard
+          <ChevronDown size={16} strokeWidth={2} className="hero-cta-icon" aria-hidden />
+        </button>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- **New `HeroSection` component** — a full-viewport landing screen shown before the dashboard. Explains the platform's core philosophy: focus on trend rotation and capital flow, not absolute price levels. Includes headline, 3 feature pillars, and a "traditional tools vs this platform" comparison table.
- **page.tsx integration** — hero renders first; clicking "Open Dashboard" transitions to the existing tab interface.
- **Mobile UX fixes** (from agent audit):
  - Period button tap targets raised to 40 px at 720 px, 44 px at 480 px (was 32 px — below WCAG safe zone)
  - Added missing 480 px breakpoint gap between existing 380 px and 600 px rules
  - Macro donut chart width reduced at 480 px / 380 px to prevent canvas overflow on small phones

## Philosophy copy (hero section)

> "Stop asking if it's too late."
>
> Most market tools focus on whether a stock is cheap or expensive. But when a stock has already run 300%, asking "is it cheap?" is the wrong question. Capital flows and trend rotations are time-agnostic — this platform tracks WHERE money moves, not whether price levels justify entry.

**Three pillars:**
1. Trend Over Price
2. No Such Thing as Too Late
3. Time-Agnostic Signals

## Test plan

- [ ] Visit `/` — hero section renders full-viewport with gold headline and CTA button
- [ ] Click "Open Dashboard" — hero dismisses, full tab interface appears
- [ ] Resize to 375 px width — hero layout goes single-column, CTA is full-width
- [ ] Resize to 320 px width — donut chart does not overflow, tap targets are finger-friendly
- [ ] Check period buttons on mobile — min-height ≥ 44 px

https://claude.ai/code/session_01HhLtkPaqWqtpkb72wGRsgp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhLtkPaqWqtpkb72wGRsgp)_